### PR TITLE
feat: dev menu toggles + environment switcher redesign

### DIFF
--- a/src/app/store/config/FeaturesModel.tsx
+++ b/src/app/store/config/FeaturesModel.tsx
@@ -1,6 +1,7 @@
 import { GlobalStoreModel } from "app/store/GlobalStoreModel"
-import { Action, action, Computed, computed } from "easy-peasy"
-import { DevToggleName, devToggles, FeatureName, features } from "./features"
+import { EchoModel } from "app/store/config/EchoModel"
+import { Action, action, Computed, computed, FilterActionTypes, StateMapper } from "easy-peasy"
+import { DevToggleName, devToggles, FeatureDescriptor, FeatureName, features } from "./features"
 
 export type FeatureMap = { [k in FeatureName]: boolean }
 export type DevToggleMap = { [k in DevToggleName]: boolean }
@@ -15,6 +16,9 @@ export interface FeaturesModel {
 
   // user features
   flags: Computed<FeaturesModel, FeatureMap, GlobalStoreModel>
+
+  // the value a feature would have if no local override were set
+  defaultFlags: Computed<FeaturesModel, FeatureMap, GlobalStoreModel>
 
   // only for devs
   devToggles: Computed<FeaturesModel, DevToggleMap, GlobalStoreModel>
@@ -39,18 +43,17 @@ export const getFeaturesModel = (): FeaturesModel => ({
       if (state.localOverrides[key as FeatureName] != null) {
         // If there's a local override, it takes precedence
         result[key] = state.localOverrides[key as FeatureName]
-      } else if (feature.readyForRelease) {
-        // If the feature is ready for release, the echo flag takes precedence
-        const echoFlag = echo.state.features.find((f) => f.name === feature.echoFlagKey)
-
-        if (feature.echoFlagKey && !echoFlag && __DEV__) {
-          console.error("No echo flag found for feature", key)
-        }
-        result[key] = echoFlag?.value ?? true
       } else {
-        // If the feature is not ready for release, uh, don't show it
-        result[key] = false
+        result[key] = getDefaultFlagValue(feature, key, echo)
       }
+    }
+    return result
+  }),
+
+  defaultFlags: computed([(_, store) => store.artsyPrefs.echo], (echo) => {
+    const result = {} as any
+    for (const [key, feature] of Object.entries(features)) {
+      result[key] = getDefaultFlagValue(feature, key, echo)
     }
     return result
   }),
@@ -63,3 +66,22 @@ export const getFeaturesModel = (): FeaturesModel => ({
     return result
   }),
 })
+
+const getDefaultFlagValue = (
+  feature: FeatureDescriptor,
+  key: string,
+  echo: StateMapper<FilterActionTypes<EchoModel>>
+) => {
+  if (!feature.readyForRelease) {
+    // If the feature is not ready for release, uh, don't show it
+    return false
+  }
+
+  // If the feature is ready for release, the echo flag takes precedence
+  const echoFlag = echo.state.features.find((f) => f.name === feature.echoFlagKey)
+
+  if (feature.echoFlagKey && !echoFlag && __DEV__) {
+    console.error("No echo flag found for feature", key)
+  }
+  return echoFlag?.value ?? true
+}

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -46,7 +46,6 @@ export type FeatureName = keyof typeof features
 export const features = {
   ARDarkModeSupport: {
     readyForRelease: true,
-    showInDevMenu: true,
     description: "Support dark mode",
     echoFlagKey: "ARDarkModeSupport",
   },
@@ -95,38 +94,32 @@ export const features = {
   AREnableExpiredPartnerOffers: {
     description: "Enable expired partner offers handling",
     readyForRelease: true,
-    showInDevMenu: true,
     echoFlagKey: "AREnableExpiredPartnerOffers",
   },
   AREnableProgressiveOnboardingAlerts: {
     description: "Enable progressive onboarding alerts",
     readyForRelease: true,
-    showInDevMenu: true,
     echoFlagKey: "AREnableProgressiveOnboardingAlerts",
   },
   AREnableArtworkListOfferability: {
     description: "Enable Parnter Offer v1.5, edit sharing artwork list with partners for offers",
     readyForRelease: true,
-    showInDevMenu: true,
     echoFlagKey: "AREnableArtworkListOfferability",
   },
 
   AREnableAlertBottomSheet: {
     description: "Enable tapping on alerts to show bottom sheet",
     readyForRelease: true,
-    showInDevMenu: true,
     echoFlagKey: "AREnableAlertBottomSheet",
   },
   AREnableCollectionsWithoutHeaderImage: {
     description: "Remove the header image from collections",
     readyForRelease: true,
-    showInDevMenu: true,
     echoFlagKey: "AREnableCollectionsWithoutHeaderImage",
   },
   AREnablePaymentFailureBanner: {
     description: "Enable payment failure banner",
     readyForRelease: true,
-    showInDevMenu: true,
     echoFlagKey: "AREnablePaymentFailureBanner",
   },
   AREnableViewPortPrefetching: {
@@ -138,30 +131,25 @@ export const features = {
   AREnableHidingDislikedArtworks: {
     description: "Enable hiding disliked artworks",
     readyForRelease: true,
-    showInDevMenu: true,
     echoFlagKey: "AREnableHidingDislikedArtworks",
   },
   ARShowOnboardingPriceRangeScreen: {
     readyForRelease: true,
-    showInDevMenu: true,
     description: "Show onboarding price range screen",
     echoFlagKey: "ARShowOnboardingPriceRangeScreen",
   },
   AREnableRedirectForVideoFeatureType: {
     readyForRelease: true,
-    showInDevMenu: true,
     description: "Enable Redirecting feature pages with video to webviews",
     echoFlagKey: "AREnableRedirectForVideoFeatureType",
   },
   AREnableFeatureVideoPhase2Type: {
     readyForRelease: true,
-    showInDevMenu: true,
     description: "Enable feature videos phase 2, falls back to webview if disabled",
     echoFlagKey: "AREnableFeatureVideoPhase2Type",
   },
   AREnableExpandedCityGuide: {
     readyForRelease: true,
-    showInDevMenu: true,
     description: "Enable expanded city list in City Guide",
     echoFlagKey: "AREnableExpandedCityGuide",
   },

--- a/src/app/system/devTools/DevMenu/Components/DevToggleItem.tsx
+++ b/src/app/system/devTools/DevMenu/Components/DevToggleItem.tsx
@@ -1,55 +1,32 @@
-import { Text } from "@artsy/palette-mobile"
+import { Flex, Switch, Text } from "@artsy/palette-mobile"
 import { useToast } from "app/Components/Toast/toastHook"
 import { GlobalStore } from "app/store/GlobalStore"
 import { DevToggleName, devToggles } from "app/store/config/features"
-import { DevMenuButtonItem } from "app/system/devTools/DevMenu/Components/DevMenuButtonItem"
-import { Alert } from "react-native"
 
 export const DevToggleItem: React.FC<{ toggleKey: DevToggleName }> = ({ toggleKey }) => {
   const config = GlobalStore.useAppState((s) => s.artsyPrefs)
   const currentValue = config.features.devToggles[toggleKey]
-  const valText = currentValue ? "Yes" : "No"
   const description = devToggles[toggleKey].description
   const toast = useToast()
 
   return (
-    <DevMenuButtonItem
-      title={description}
-      onPress={() => {
-        Alert.alert(description, undefined, [
-          {
-            text: currentValue ? "Keep turned ON" : "Turn ON",
-            onPress() {
-              GlobalStore.actions.artsyPrefs.features.setLocalOverride({
-                key: toggleKey,
-                value: true,
-              })
-              devToggles[toggleKey].onChange?.(true, { toast })
-            },
-          },
-          {
-            text: currentValue ? "Turn OFF" : "Keep turned OFF",
-            onPress() {
-              GlobalStore.actions.artsyPrefs.features.setLocalOverride({
-                key: toggleKey,
-                value: false,
-              })
-              devToggles[toggleKey].onChange?.(false, { toast })
-            },
-          },
-        ])
-      }}
-      value={
-        currentValue ? (
-          <Text variant="sm-display" color="mono100" fontWeight="bold">
-            {valText}
-          </Text>
-        ) : (
-          <Text variant="sm-display" color="mono60">
-            {valText}
-          </Text>
-        )
-      }
-    />
+    <Flex flexDirection="row" alignItems="center" justifyContent="space-between" py="7.5px" px={2}>
+      <Flex flex={1} mr={2}>
+        <Text variant="sm-display" color="mono100">
+          {description}
+        </Text>
+      </Flex>
+
+      <Switch
+        value={currentValue}
+        onValueChange={(value) => {
+          GlobalStore.actions.artsyPrefs.features.setLocalOverride({
+            key: toggleKey,
+            value,
+          })
+          devToggles[toggleKey].onChange?.(value, { toast })
+        }}
+      />
+    </Flex>
   )
 }

--- a/src/app/system/devTools/DevMenu/Components/EnvironmentOptions.tsx
+++ b/src/app/system/devTools/DevMenu/Components/EnvironmentOptions.tsx
@@ -1,23 +1,49 @@
-import { ChevronSmallRightIcon } from "@artsy/icons/native"
-import { Flex, Separator, Spacer, Text, useColor } from "@artsy/palette-mobile"
+import { ChevronSmallDownIcon, ChevronSmallRightIcon } from "@artsy/icons/native"
+import { Flex, Pill, Separator, Spacer, Text, Touchable, useColor } from "@artsy/palette-mobile"
 import { ArtsyNativeModule } from "app/NativeModules/ArtsyNativeModule"
 import { GlobalStore, globalStoreInstance } from "app/store/GlobalStore"
 import { EnvironmentKey, environment } from "app/store/config/EnvironmentModel"
-import { DevMenuButtonItem } from "app/system/devTools/DevMenu/Components/DevMenuButtonItem"
 import { _globalCacheRef } from "app/system/relay/defaultEnvironment"
-import { capitalize, compact } from "lodash"
+import { capitalize } from "lodash"
 import { useState } from "react"
-import { Alert, AlertButton, Platform, TouchableHighlight } from "react-native"
+import { Alert, Platform, TouchableHighlight } from "react-native"
+
+type Environment = "staging" | "production"
+
+const ENVIRONMENTS: Environment[] = ["staging", "production"]
 
 export const EnvironmentOptions: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const color = useColor()
   const { env, localOverrides, strings } = GlobalStore.useAppState(
     (store) => store.devicePrefs.environment
   )
-  // show custom url options if there are already local overrides in effect, or if the user has tapped the option
-  // to set custom overrides during the lifetime of this component
-  const [showCustomURLOptions, setShowCustomURLOptions] = useState(false)
-  Object.keys(localOverrides).length > 0
+  const hasLocalOverrides = Object.entries(localOverrides).some(
+    ([key, value]) => value !== environment[key as EnvironmentKey].presets[env]
+  )
+  // show custom url options if there are already local overrides in effect, or if the user has tapped
+  // the option to set custom overrides during the lifetime of this component
+  const [showCustomURLOptions, setShowCustomURLOptions] = useState(hasLocalOverrides)
+
+  const switchEnvironment = (newEnv: Environment) => {
+    Alert.alert(`Log out and switch to '${capitalize(newEnv)}'?`, undefined, [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Log Out & Switch",
+        style: "destructive",
+        onPress: () => {
+          GlobalStore.actions.devicePrefs.environment.clearLocalOverrides()
+          GlobalStore.actions.devicePrefs.environment.setEnv(newEnv)
+          setShowCustomURLOptions(false)
+          onClose()
+          // No need to sign out if the user is already logged out
+          if (!!globalStoreInstance().getState().auth.userID) {
+            GlobalStore.actions.auth.signOut()
+          }
+          _globalCacheRef?.clear()
+        },
+      },
+    ])
+  }
 
   return (
     <>
@@ -26,32 +52,70 @@ export const EnvironmentOptions: React.FC<{ onClose: () => void }> = ({ onClose 
       </Flex>
       <Spacer y={0.5} />
 
-      <DevMenuButtonItem
-        title="Environment"
-        value={showCustomURLOptions ? `Custom (${capitalize(env)})` : capitalize(env)}
-        direction="down"
-        onPress={() => {
-          Alert.alert(
-            "Environment",
-            undefined,
-            compact([
-              envMenuOption("staging", env, showCustomURLOptions, setShowCustomURLOptions, onClose),
-              envMenuOption(
-                "production",
-                env,
-                showCustomURLOptions,
-                setShowCustomURLOptions,
-                onClose
-              ),
-              {
-                text: "Cancel",
-                style: "destructive",
-              },
-            ]),
-            { cancelable: true }
-          )
-        }}
-      />
+      <Flex mx={2} flexDirection="row" alignItems="center" justifyContent="space-between">
+        <Text variant="sm-display" color="mono100">
+          Environment
+        </Text>
+
+        <Flex flexDirection="row">
+          {ENVIRONMENTS.map((option) => (
+            <Pill
+              key={option}
+              variant="default"
+              ml={0.5}
+              selected={env === option}
+              onPress={() => {
+                if (option !== env) {
+                  switchEnvironment(option)
+                }
+              }}
+            >
+              {capitalize(option)}
+            </Pill>
+          ))}
+        </Flex>
+      </Flex>
+
+      {!!ArtsyNativeModule.isBetaOrDev && (
+        <>
+          <Spacer y={0.5} />
+
+          <Flex mx={2} flexDirection="row" alignItems="center" justifyContent="space-between">
+            <Touchable
+              accessibilityRole="button"
+              onPress={() => setShowCustomURLOptions(!showCustomURLOptions)}
+            >
+              <Flex flexDirection="row" alignItems="center">
+                <Text
+                  variant="xs"
+                  color={showCustomURLOptions ? "blue100" : "mono60"}
+                  underline={showCustomURLOptions}
+                >
+                  {showCustomURLOptions ? "Hide Custom URLs" : "Tap to Customize URLs"}
+                </Text>
+
+                {showCustomURLOptions ? (
+                  <ChevronSmallDownIcon fill="blue100" ml="2px" />
+                ) : (
+                  <ChevronSmallRightIcon fill="mono60" ml="2px" />
+                )}
+              </Flex>
+            </Touchable>
+
+            {!!hasLocalOverrides && (
+              <Pill
+                variant="default"
+                onPress={() => {
+                  GlobalStore.actions.devicePrefs.environment.clearLocalOverrides()
+                }}
+              >
+                Reset to default
+              </Pill>
+            )}
+          </Flex>
+        </>
+      )}
+
       {Platform.OS === "android" && !!showCustomURLOptions && (
         <Flex px={2}>
           <Text color="red100" variant="xs">
@@ -69,6 +133,10 @@ export const EnvironmentOptions: React.FC<{ onClose: () => void }> = ({ onClose 
       )}
       {!!showCustomURLOptions &&
         Object.entries(environment).map(([key, { description, presets }]) => {
+          const defaultValue = presets[env]
+          const currentValue = strings[key as EnvironmentKey]
+          const isOverriddenFromDefault = currentValue !== defaultValue
+
           return (
             <TouchableHighlight
               accessibilityRole="button"
@@ -77,7 +145,7 @@ export const EnvironmentOptions: React.FC<{ onClose: () => void }> = ({ onClose 
               onPress={() => {
                 Alert.alert(
                   description,
-                  undefined,
+                  `Default: ${defaultValue}`,
                   Object.entries(presets).map(([name, value]) => ({
                     text: name,
                     onPress: () => {
@@ -103,7 +171,13 @@ export const EnvironmentOptions: React.FC<{ onClose: () => void }> = ({ onClose 
                     {description}
                   </Text>
                   <Flex key={key} flexDirection="row" justifyContent="space-between">
-                    <Text variant="sm-display">{strings[key as EnvironmentKey]}</Text>
+                    <Text
+                      variant="sm-display"
+                      color={isOverriddenFromDefault ? "blue100" : "mono100"}
+                      fontWeight={isOverriddenFromDefault ? "bold" : "normal"}
+                    >
+                      {currentValue}
+                    </Text>
                   </Flex>
                 </Flex>
                 <ChevronSmallRightIcon fill="mono60" />
@@ -113,41 +187,4 @@ export const EnvironmentOptions: React.FC<{ onClose: () => void }> = ({ onClose 
         })}
     </>
   )
-}
-
-function envMenuOption(
-  env: "staging" | "production",
-  currentEnv: "staging" | "production",
-  showCustomURLOptions: boolean,
-  setShowCustomURLOptions: (newValue: boolean) => void,
-  onClose: () => void
-): AlertButton | null {
-  let text = `Log out and switch to '${capitalize(env)}'`
-  if (currentEnv === env) {
-    if (!ArtsyNativeModule.isBetaOrDev) {
-      return null
-    }
-    if (showCustomURLOptions) {
-      text = `Reset all to '${capitalize(env)}'`
-    } else {
-      text = `Customize '${capitalize(env)}'`
-    }
-  }
-  return {
-    text,
-    onPress() {
-      GlobalStore.actions.devicePrefs.environment.clearLocalOverrides()
-      if (env !== currentEnv) {
-        GlobalStore.actions.devicePrefs.environment.setEnv(env)
-        onClose()
-        // No need to sign out if the user is already logged out
-        if (!!globalStoreInstance().getState().auth.userID) {
-          GlobalStore.actions.auth.signOut()
-        }
-        _globalCacheRef?.clear()
-      } else {
-        setShowCustomURLOptions(!showCustomURLOptions)
-      }
-    },
-  }
 }

--- a/src/app/system/devTools/DevMenu/Components/FeatureFlagItem.tsx
+++ b/src/app/system/devTools/DevMenu/Components/FeatureFlagItem.tsx
@@ -1,62 +1,40 @@
-import { Text } from "@artsy/palette-mobile"
+import { Flex, Switch, Text } from "@artsy/palette-mobile"
 import { GlobalStore } from "app/store/GlobalStore"
 import { FeatureName, features } from "app/store/config/features"
-import { DevMenuButtonItem } from "app/system/devTools/DevMenu/Components/DevMenuButtonItem"
-import { Alert } from "react-native"
 
 export const FeatureFlagItem: React.FC<{ flagKey: FeatureName }> = ({ flagKey }) => {
   const config = GlobalStore.useAppState((s) => s.artsyPrefs)
   const currentValue = config.features.flags[flagKey]
+  const defaultValue = config.features.defaultFlags[flagKey]
   const isLocalOverrideInEffect = flagKey in config.features.localOverrides
-  const valText = currentValue ? "Yes" : "No"
+  const isOverriddenFromDefault = isLocalOverrideInEffect && currentValue !== defaultValue
   const description = features[flagKey].description ?? flagKey
 
   return (
-    <DevMenuButtonItem
-      title={description}
-      onPress={() => {
-        Alert.alert(description as string, undefined, [
-          {
-            text: "Override with 'Yes'",
-            onPress() {
-              GlobalStore.actions.artsyPrefs.features.setLocalOverride({
-                key: flagKey,
-                value: true,
-              })
-            },
-          },
-          {
-            text: "Override with 'No'",
-            onPress() {
-              GlobalStore.actions.artsyPrefs.features.setLocalOverride({
-                key: flagKey,
-                value: false,
-              })
-            },
-          },
-          {
-            text: isLocalOverrideInEffect ? "Revert to default value" : "Keep default value",
-            onPress() {
-              GlobalStore.actions.artsyPrefs.features.setLocalOverride({
-                key: flagKey,
-                value: null,
-              })
-            },
-            style: "destructive",
-          },
-        ])
-      }}
-      value={
-        isLocalOverrideInEffect ? (
-          <Text variant="sm-display" color="mono100" fontWeight="bold">
-            {valText}
-          </Text>
-        ) : (
-          <Text variant="sm-display" color="mono60">
-            {valText}
-          </Text>
-        )
-      }
-    />
+    <Flex flexDirection="row" alignItems="center" justifyContent="space-between" py="7.5px" px={2}>
+      <Flex flex={1} mr={2}>
+        <Text
+          variant="sm-display"
+          color={isOverriddenFromDefault ? "blue100" : "mono100"}
+          fontWeight={isOverriddenFromDefault ? "bold" : "normal"}
+        >
+          {description}
+        </Text>
+
+        <Text variant="xs" color="mono60" mt="2px">
+          Default: {defaultValue ? "On" : "Off"}
+        </Text>
+      </Flex>
+
+      <Switch
+        value={currentValue}
+        onValueChange={(value) => {
+          GlobalStore.actions.artsyPrefs.features.setLocalOverride({
+            key: flagKey,
+            value,
+          })
+        }}
+      />
+    </Flex>
   )
 }


### PR DESCRIPTION
### Description

Reworks the dev menu's feature flag, dev toggle, and environment UI:

- `FeatureFlagItem` and `DevToggleItem` now use a `Switch` instead of an `Alert`-based picker.
- Feature flags show their default value and highlight (bold + blue) when a local override differs from that default.
- `FeaturesModel` gained a `defaultFlags` computed value (the flag's value ignoring local overrides) so the UI can show it without duplicating the echo/readyForRelease logic.
- The environment switcher (Staging/Production) is now a radio group of pills instead of a single button behind an `Alert`, with a confirm dialog on actual switches (since it signs the user out).
- "Customize URLs" is a separate expand/collapse toggle, gated to beta/dev builds as before. The per-URL preset picker now shows the environment's default value in the alert, and "Reset to default" only appears when an override actually differs from default.

| Android | iOS |
|--------|--------|
| <img width="1080" height="2424" alt="Screenshot_1785921380" src="https://github.com/user-attachments/assets/41764143-6c25-41dd-af5e-1924c6b8bd28" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-04 at 18 27 04" src="https://github.com/user-attachments/assets/0d7d3ad5-bc39-4dd5-a864-e413aefa29df" /> |
| <img width="1080" height="2424" alt="Screenshot_1785921373" src="https://github.com/user-attachments/assets/e780b579-f1f8-408a-8e86-f5741c5059bf" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-05 at 10 47 10" src="https://github.com/user-attachments/assets/5720fe55-9989-451d-8427-bc6b70b95bd1" /> | 


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Redesign dev menu feature flags, dev toggles, and environment switcher to use Switches/radio pills instead of Alerts

<!-- end_changelog_updates -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude:Sonnet-5

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md