### PR TITLE
fix: reset Relay store when switching environments in dev menu

### DIFF
--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -102,7 +102,14 @@ const KeyboardControllerProvider = (props: { children?: React.ReactNode }) => (
 
 const RelayDefaultEnvProvider = (props: { children?: React.ReactNode }) => {
   const Provider = RelayEnvironmentProvider as React.ComponentType<any>
-  return <Provider environment={getRelayEnvironment()}>{props.children}</Provider>
+  // remounts the subtree (and its Relay hooks/Suspense state) whenever the environment is reset,
+  // e.g. when switching between staging/production in the dev menu
+  const env = GlobalStore.useAppState((store) => store.devicePrefs.environment.env)
+  return (
+    <Provider key={env} environment={getRelayEnvironment()}>
+      {props.children}
+    </Provider>
+  )
 }
 
 const SuspenseProvider = (props: { children?: React.ReactNode }) => (

--- a/src/app/system/devTools/DevMenu/Components/EnvironmentOptions.tsx
+++ b/src/app/system/devTools/DevMenu/Components/EnvironmentOptions.tsx
@@ -4,7 +4,7 @@ import { ArtsyNativeModule } from "app/NativeModules/ArtsyNativeModule"
 import { GlobalStore, globalStoreInstance } from "app/store/GlobalStore"
 import { EnvironmentKey, environment } from "app/store/config/EnvironmentModel"
 import { DevMenuButtonItem } from "app/system/devTools/DevMenu/Components/DevMenuButtonItem"
-import { _globalCacheRef } from "app/system/relay/defaultEnvironment"
+import { resetRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { capitalize, compact } from "lodash"
 import { useState } from "react"
 import { Alert, AlertButton, Platform, TouchableHighlight } from "react-native"
@@ -144,7 +144,7 @@ function envMenuOption(
         if (!!globalStoreInstance().getState().auth.userID) {
           GlobalStore.actions.auth.signOut()
         }
-        _globalCacheRef?.clear()
+        resetRelayEnvironment()
       } else {
         setShowCustomURLOptions(!showCustomURLOptions)
       }

--- a/src/app/system/devTools/DevMenu/Components/EnvironmentOptions.tsx
+++ b/src/app/system/devTools/DevMenu/Components/EnvironmentOptions.tsx
@@ -135,16 +135,17 @@ function envMenuOption(
   }
   return {
     text,
-    onPress() {
+    async onPress() {
       GlobalStore.actions.devicePrefs.environment.clearLocalOverrides()
       if (env !== currentEnv) {
-        GlobalStore.actions.devicePrefs.environment.setEnv(env)
-        onClose()
-        // No need to sign out if the user is already logged out
+        // Sign out (and let its cascading state reset settle) before switching environments, so
+        // the app doesn't remount against a stale, mid-sign-out auth state.
         if (!!globalStoreInstance().getState().auth.userID) {
-          GlobalStore.actions.auth.signOut()
+          await GlobalStore.actions.auth.signOut()
         }
+        GlobalStore.actions.devicePrefs.environment.setEnv(env)
         resetRelayEnvironment()
+        onClose()
       } else {
         setShowCustomURLOptions(!showCustomURLOptions)
       }

--- a/src/app/system/relay/defaultEnvironment.ts
+++ b/src/app/system/relay/defaultEnvironment.ts
@@ -60,13 +60,27 @@ const network = new RelayNetworkLayer(
     noThrow: true,
   }
 )
-const store = new Store(new RecordSource(), { gcReleaseBufferSize: 100 })
-const defaultEnvironment = new Environment({ network, store })
+const createStore = () => new Store(new RecordSource(), { gcReleaseBufferSize: 100 })
+
+let defaultEnvironment = new Environment({ network, store: createStore() })
 
 /**
  * If you're in a test file, make sure to use `getMockRelayEnvironment` instead.
  */
 export const getRelayEnvironment = () => defaultEnvironment as IEnvironment
+
+/**
+ * Throws away every normalized record the app has fetched so far, along with the network
+ * response cache, and starts the default Relay environment over with an empty store.
+ *
+ * Needed when the data underneath an existing record ID can change out from under us in a way
+ * Relay can't detect on its own -- e.g. switching between staging/production in the dev menu,
+ * where the same global ID can point to a completely different underlying object.
+ */
+export const resetRelayEnvironment = () => {
+  _globalCacheRef?.clear()
+  defaultEnvironment = new Environment({ network, store: createStore() })
+}
 
 // We could get rid of this, if we could type `getRelayEnvironment`
 // to be a func that returns `Environment` for regular code and


### PR DESCRIPTION
This PR resolves []

### Description

Switching environments (Staging/Production) in the dev menu only cleared the Relay network response cache, not the Relay store. This meant that when one signs out or switches environment, we get briefly old artworks then they disappear! (happens always to me)

Since the store is shared across environments, so normalized records from the environment left after sign out/switching env, could linger under the same global IDs. A screen reading from the store cache could render an object fetched from the wrong backend after a switch, without any network call happening to correct it (unless we request it intentionally)


| iOS | Android |
|--------|--------|
| Cell | Cell | 



### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Fix stale Relay data lingering after switching environments in the dev menu

<!-- end_changelog_updates -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude:Fable-5

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md