### PR TITLE
build(deps): pin node-forge to 1.4.0 in bin to patch high severity advisories

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -5,6 +5,7 @@
     "form-data": "Pinned to fix GHSA-hmw2-7cc7-3qxx (CRLF injection). eas-cli exact-pins the vulnerable form-data@4.0.0 with no fixed release; remove this once eas-cli bumps it upstream.",
     "minimatch": "Pinned to fix GHSA-7r86-cg39-jmmj (ReDoS). eas-cli exact-pins the vulnerable minimatch@5.1.2 with no fixed release; remove this once eas-cli bumps it upstream.",
     "tar": "Pinned to fix multiple node-tar advisories (GHSA-9ppj-qmqm-q256, GHSA-qffp-2rhf-9h96, GHSA-83g3-92jg-28cx, GHSA-34x7-hfp2-rc4v, GHSA-r6q2-hw4h-h46w, GHSA-8qq5-rm4j-mr97). eas-cli exact-pins the vulnerable tar@6.2.1, which has no patched release on the 6.x line; remove this once eas-cli bumps past its exact pin (eas-cli@19+ already depends on tar 7.x).",
+    "node-forge": "Pinned to fix multiple node-forge advisories (GHSA-2328-f5f3-gj25, GHSA-q67f-28xg-22rw, GHSA-ppp5-5v6c-4jwp, GHSA-5gfm-wpxj-wjgq). eas-cli exact-pins the vulnerable node-forge@1.3.1; every other consumer in this workspace already resolves to the patched 1.4.0. Remove this once eas-cli bumps past its exact pin.",
     "@xmldom/xmldom": "Pinned to fix multiple xmldom advisories (GHSA-wh4c-j3r5-mjhp, GHSA-x6wf-f3px-wcqx, GHSA-f6ww-3ggp-fr8h, GHSA-j759-j44w-7fr8, GHSA-2v35-w6hq-6mfw). @expo/plist depends on the vulnerable @xmldom/xmldom@~0.7.7, which has no patched release on the 0.7.x line; remove this once @expo/plist bumps past 0.7.x."
   },
   "devDependencies": {
@@ -14,6 +15,7 @@
     "form-data": "4.0.6",
     "minimatch@npm:5.1.2": "5.1.8",
     "tar@npm:6.2.1": "7.5.22",
+    "node-forge@npm:1.3.1": "1.4.0",
     "@xmldom/xmldom@npm:~0.7.7": "0.8.13"
   }
 }

--- a/bin/yarn.lock
+++ b/bin/yarn.lock
@@ -3120,14 +3120,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-forge@npm:1.3.1":
-  version: 1.3.1
-  resolution: "node-forge@npm:1.3.1"
-  checksum: 10c0/e882819b251a4321f9fc1d67c85d1501d3004b4ee889af822fd07f64de3d1a8e272ff00b689570af0465d65d6bf5074df9c76e900e0aff23e60b847f2a46fbe8
-  languageName: node
-  linkType: hard
-
-"node-forge@npm:^1.2.1, node-forge@npm:^1.3.1":
+"node-forge@npm:1.4.0, node-forge@npm:^1.2.1, node-forge@npm:^1.3.1":
   version: 1.4.0
   resolution: "node-forge@npm:1.4.0"
   checksum: 10c0/67330a5f1f95257a4c8a93b7d555abe87b5f15e350123aa396c97a21a8ca94f9c6549008eb2c73668a91e0d7e3a905785acbd8f8bd0751c29401292011f8f8e1


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Clears 4 open **high severity** Dependabot alerts on `bin/yarn.lock`. All four are fixed in `node-forge@1.4.0`, and three of the four consumers in this workspace already resolve to it — but `eas-cli@16.9.0` **exact-pins** `node-forge@1.3.1`, so a plain upgrade can't reach it. Fixed with a `resolutions` pin, following the same pattern already used in `bin/package.json` for `form-data`, `minimatch`, `tar`, and `@xmldom/xmldom`.

```jsonc
// bin/package.json
"resolutions": {
  "node-forge@npm:1.3.1": "1.4.0"
}
```

| Alert | Package | Vulnerable range | Was | Now | Advisory |
|---|---|---|---|---|---|
| [#319](https://github.com/artsy/eigen/security/dependabot/319) | `node-forge` | `<= 1.3.3` | 1.3.1 | **1.4.0** | [GHSA-2328-f5f3-gj25](https://github.com/advisories/GHSA-2328-f5f3-gj25) — `basicConstraints` bypass in certificate chain verification (RFC 5280 violation) |
| [#318](https://github.com/artsy/eigen/security/dependabot/318) | `node-forge` | `< 1.4.0` | 1.3.1 | **1.4.0** | [GHSA-q67f-28xg-22rw](https://github.com/advisories/GHSA-q67f-28xg-22rw) — Ed25519 signature forgery, missing `S > L` check |
| [#317](https://github.com/artsy/eigen/security/dependabot/317) | `node-forge` | `< 1.4.0` | 1.3.1 | **1.4.0** | [GHSA-ppp5-5v6c-4jwp](https://github.com/advisories/GHSA-ppp5-5v6c-4jwp) — RSA-PKCS signature forgery via ASN.1 extra field |
| [#222](https://github.com/artsy/eigen/security/dependabot/222) | `node-forge` | `< 1.3.2` | 1.3.1 | **1.4.0** | [GHSA-5gfm-wpxj-wjgq](https://github.com/advisories/GHSA-5gfm-wpxj-wjgq) — interpretation conflict via ASN.1 validator desynchronization |

#### Before / after

`yarn why node-forge` in `bin/`:

| Consumer | Requests | Before | After |
|---|---|---|---|
| `eas-cli@16.9.0` | `1.3.1` (exact) | 1.3.1 ⚠️ | **1.4.0** |
| `@expo/code-signing-certificates` | `^1.2.1` | 1.4.0 | 1.4.0 |
| `@expo/pkcs12` | `^1.2.1` | 1.4.0 | 1.4.0 |
| `jks-js` | `^1.3.1` | 1.4.0 | 1.4.0 |

The pin collapses the duplicate lockfile entry — `node-forge` is now a single 1.4.0 resolution for the whole `bin` workspace. Since the three sibling consumers were already on 1.4.0, this only aligns eas-cli with what was in the tree anyway; 1.3.1 → 1.4.0 is a minor bump.

Also added a `dependenciesComments` entry noting the pin can be dropped once eas-cli bumps past its exact pin, matching the existing comments.

#### Verification

- `yarn install` in `bin/` succeeds; diff is `bin/package.json` + `bin/yarn.lock` only
- `yarn why node-forge` shows a single 1.4.0 resolution across all four consumers
- `yarn eas --version` → `eas-cli/16.9.0 darwin-arm64 node-v24.6.0` ✅

#### Related

- Sibling PR bumping `ip-address` / `brace-expansion` on the root lockfile (5 more high severity alerts)
- Still open afterwards: `parse-git-config` (#190) — no patched version exists, only fix is bumping `danger` 11 → 13, which drops the dep entirely; and `concurrent-ruby` (#403), RubyGems, out of scope

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Pin `node-forge` to 1.4.0 in the `bin` workspace to clear 4 high severity Dependabot alerts from eas-cli's exact pin

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
