### PR TITLE
chore(release): v9.15.0 RC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,9 +165,6 @@ commands:
     steps:
       - android/change_java_version:
           java_version: 17
-      - run:
-          name: Install ninja
-          command: sudo apt-get install ninja-build
       - checkout
       - generate-checksums
       - restore_cache:

--- a/.github/actions/setup-android-environment/action.yml
+++ b/.github/actions/setup-android-environment/action.yml
@@ -13,10 +13,6 @@ runs:
         java-version: "17"
         cache: "gradle"
 
-    - name: Install ninja
-      run: sudo apt-get update && sudo apt-get install ninja-build
-      shell: bash
-
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v5
 

--- a/android/app/src/main/java/net/artsy/app/ArtsyNativeModule.java
+++ b/android/app/src/main/java/net/artsy/app/ArtsyNativeModule.java
@@ -1,5 +1,6 @@
 package net.artsy.app;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
@@ -36,6 +37,18 @@ public class ArtsyNativeModule extends ReactContextBaseJavaModule {
     @Override
     public String getName() {
         return "ArtsyNativeModule";
+    }
+
+    // Backgrounds the app (returns to the launcher) without finishing the activity,
+    // mirroring Android's default "back at the root" behavior. Used to intercept the
+    // hardware back button on screens where JS handles back but still wants the
+    // standard background behavior in some states.
+    @ReactMethod
+    public void moveTaskToBack() {
+        Activity activity = getCurrentActivity();
+        if (activity != null) {
+            activity.moveTaskToBack(true);
+        }
     }
 
     @Override

--- a/app.json
+++ b/app.json
@@ -14,11 +14,8 @@
         }
       }
     },
-    "platforms": [
-      "ios",
-      "android"
-    ],
-    "runtimeVersion": "90e95d0b1d4863f68d052b0ad4d45647d86c8a6b",
+    "platforms": ["ios", "android"],
+    "runtimeVersion": "73ba989240a6ab9c2e23247eeb8f3c638130f6cf",
     "owner": "artsy_org",
     "extra": {
       "eas": {

--- a/src/app/Components/ArtworkGrids/GenericGrid.tsx
+++ b/src/app/Components/ArtworkGrids/GenericGrid.tsx
@@ -77,7 +77,7 @@ export const GenericGrid: React.FC<Props & PropsForArtwork> = ({
   )
 }
 
-const genericGridFragment = graphql`
+export const genericGridFragment = graphql`
   fragment GenericGrid_artworks on Artwork @relay(plural: true) {
     id
     internalID
@@ -92,15 +92,19 @@ const genericGridFragment = graphql`
 
 export default GenericGrid
 
-export const GenericGridPlaceholder: React.FC<{ width: number }> = ({ width }) => {
+export const GenericGridPlaceholder: React.FC<{ width: number; numRows?: number }> = ({
+  width,
+  numRows,
+}) => {
   const numColumns = isTablet() ? 3 : 2
   const rng = new RandomNumberGenerator(3432)
+  const rowCount = numRows ?? (isTablet() ? 10 : 5)
 
   return (
     <Stack horizontal>
       {times(numColumns).map((i) => (
         <Stack key={i} spacing={4} width={(width + 20) / numColumns - 20}>
-          {times(isTablet() ? 10 : 5).map((j) => (
+          {times(rowCount).map((j) => (
             <ArtworkGridItemPlaceholder key={j} seed={rng.next()} />
           ))}
         </Stack>

--- a/src/app/NativeModules/ArtsyNativeModule.tsx
+++ b/src/app/NativeModules/ArtsyNativeModule.tsx
@@ -17,4 +17,12 @@ export const ArtsyNativeModule = {
     Platform.OS === "ios"
       ? NativeModules.ArtsyNativeModule.isBetaOrDev
       : (NativeModules.ArtsyNativeModule.getConstants().isBeta as boolean) || __DEV__,
+  /**
+   * Backgrounds the app (Android only). No-op on iOS, which has no hardware back button.
+   */
+  moveTaskToBack: () => {
+    if (Platform.OS === "android") {
+      NativeModules.ArtsyNativeModule.moveTaskToBack()
+    }
+  },
 }

--- a/src/app/Scenes/Artwork/Components/CascadingEndTimesBanner.tsx
+++ b/src/app/Scenes/Artwork/Components/CascadingEndTimesBanner.tsx
@@ -1,6 +1,5 @@
 import { Flex, Text } from "@artsy/palette-mobile"
 import { RouterLink } from "app/system/navigation/RouterLink"
-import { Text as RNText } from "react-native"
 
 interface CascadingEndTimesBannerProps {
   cascadingEndTimeInterval: number
@@ -22,11 +21,11 @@ export const CascadingEndTimesBanner: React.FC<CascadingEndTimesBannerProps> = (
         {canBeExtended
           ? "Closing times may be extended due to last-minute competitive bidding. "
           : `Lots will close at ${cascadingEndTimeInterval}-minute intervals. `}
-
-        <RouterLink to={CASCADING_AUCTION_HELP_ARTICLE_LINK} hasChildTouchable>
-          <RNText style={{ textDecorationLine: "underline" }}>
+        {/* External link — prefetch disabled so the text renders properly inline */}
+        <RouterLink to={CASCADING_AUCTION_HELP_ARTICLE_LINK} disablePrefetch hasChildTouchable>
+          <Text style={{ textDecorationLine: "underline" }} color="mono0">
             Learn more about cascading end times
-          </RNText>
+          </Text>
         </RouterLink>
       </Text>
     </Flex>

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
@@ -7,11 +7,13 @@ import {
   SkeletonBox,
   SkeletonText,
   Spacer,
+  useScreenDimensions,
 } from "@artsy/palette-mobile"
 import { ArtworkGridItem_artwork$data } from "__generated__/ArtworkGridItem_artwork.graphql"
 import { ArtworkRail_artworks$data } from "__generated__/ArtworkRail_artworks.graphql"
 import { HomeViewSectionArtworksQuery } from "__generated__/HomeViewSectionArtworksQuery.graphql"
 import { HomeViewSectionArtworks_section$key } from "__generated__/HomeViewSectionArtworks_section.graphql"
+import { GenericGridPlaceholder } from "app/Components/ArtworkGrids/GenericGrid"
 import { ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
 import {
   ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
@@ -31,6 +33,7 @@ import { extractNodes } from "app/utils/extractNodes"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
 import { isDislikeArtworksEnabledFor } from "app/utils/isDislikeArtworksEnabledFor"
+import { NUM_COLUMNS_MASONRY } from "app/utils/masonryHelpers"
 import { useMemoizedRandom } from "app/utils/placeholders"
 import { times } from "lodash"
 import { memo, useEffect, useState } from "react"
@@ -42,6 +45,8 @@ interface HomeViewSectionArtworksProps extends FlexProps {
 }
 
 const GRID_MAX_ARTWORKS_COUNT = 4
+// Matches the height of the palette Button rendered below the grid.
+const VIEW_MORE_BUTTON_HEIGHT = 50
 
 export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = ({
   section: sectionProp,
@@ -267,8 +272,14 @@ const homeViewSectionArtworksQuery = graphql`
   }
 `
 
-export const HomeViewSectionArtworksPlaceholder: React.FC<FlexProps> = (flexProps) => {
+export const HomeViewSectionArtworksPlaceholder: React.FC<
+  FlexProps & { shouldShowInGrid?: boolean }
+> = ({ shouldShowInGrid, ...flexProps }) => {
   const randomValue = useMemoizedRandom()
+
+  if (shouldShowInGrid) {
+    return <HomeViewSectionArtworksGridPlaceholder {...flexProps} />
+  }
 
   return (
     <Skeleton>
@@ -304,9 +315,41 @@ export const HomeViewSectionArtworksPlaceholder: React.FC<FlexProps> = (flexProp
   )
 }
 
+// Mirrors what HomeViewSectionArtworksGrid renders: a capped masonry grid followed by the
+// "View More" button, so grid sections don't flash a rail-shaped skeleton first.
+const HomeViewSectionArtworksGridPlaceholder: React.FC<FlexProps> = (flexProps) => {
+  const { width } = useScreenDimensions()
+
+  return (
+    <Skeleton>
+      <Flex {...flexProps}>
+        <Flex mx={2}>
+          <SkeletonText variant="sm-display">Artworks Grid</SkeletonText>
+          <Spacer y={2} />
+        </Flex>
+
+        <Flex mx={2} flexDirection="row">
+          <GenericGridPlaceholder
+            width={width - 40}
+            numRows={GRID_MAX_ARTWORKS_COUNT / NUM_COLUMNS_MASONRY}
+          />
+        </Flex>
+
+        <Spacer y={2} />
+
+        <Flex mx={2}>
+          <SkeletonBox height={VIEW_MORE_BUTTON_HEIGHT} width="100%" />
+        </Flex>
+      </Flex>
+    </Skeleton>
+  )
+}
+
 export const HomeViewSectionArtworksQueryRenderer: React.FC<SectionSharedProps> = memo(
   withSuspense({
-    Component: ({ sectionID, index, refetchKey, ...flexProps }) => {
+    // `shouldShowInGrid` is only consumed by the loading fallback, so it is dropped here rather
+    // than forwarded on to the section.
+    Component: ({ sectionID, index, refetchKey, shouldShowInGrid: _, ...flexProps }) => {
       const enableHidingDislikedArtworks = useFeatureFlag("AREnableHidingDislikedArtworks")
       const liveSectionIDs = useLiveHomeViewSectionIDs()
 

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworksGrid.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworksGrid.tsx
@@ -2,12 +2,15 @@ import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { Button, Flex } from "@artsy/palette-mobile"
 import { ArtworkGridItem_artwork$data } from "__generated__/ArtworkGridItem_artwork.graphql"
 import { GenericGrid_artworks$key } from "__generated__/GenericGrid_artworks.graphql"
-import GenericGrid from "app/Components/ArtworkGrids/GenericGrid"
+import { genericGridFragment } from "app/Components/ArtworkGrids/GenericGrid"
+import { MasonryArtworkGridItem } from "app/Components/ArtworkGrids/MasonryArtworkGridItem"
 import HomeAnalytics from "app/Scenes/HomeView/helpers/homeAnalytics"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
-import { useLayoutEffect, useRef, useState } from "react"
-import { View } from "react-native"
+import { MasonryArtworkItem, NUM_COLUMNS_MASONRY, getColumnIndex } from "app/utils/masonryHelpers"
+import { times } from "lodash"
+import { useRef } from "react"
+import { useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 
 interface HomeViewSectionArtworksGridProps {
@@ -23,31 +26,31 @@ interface HomeViewSectionArtworksGridProps {
   contextModule: ContextModule
 }
 
+/**
+ * A small, fixed-size grid of artworks.
+ *
+ * The artworks are laid out by hand rather than by a masonry `FlashList`: the list only draws its
+ * items on a second render cycle, which made the section flash — empty grid, then a lone "View
+ * More" button, then the artworks. At this size virtualization buys us nothing, and rendering
+ * directly means the whole section paints at once.
+ */
 export const HomeViewSectionArtworksGrid: React.FC<HomeViewSectionArtworksGridProps> = ({
-  artworks,
+  artworks: artworksProp,
   moreHref,
   onMorePress,
   onArtworkPress,
   trackItemImpressions,
   contextModule,
 }) => {
-  const [hasGridLaidOut, setHasGridLaidOut] = useState(false)
-  const gridContainerRef = useRef<View>(null)
   const { trackEvent } = useTracking()
   const enableItemsViewsTracking = useFeatureFlag("ARImpressionsTrackingHomeItemViews")
   const trackedGridItems = useRef<Set<string>>(new Set()).current
 
-  useLayoutEffect(() => {
-    gridContainerRef.current?.measureInWindow((_x, _y, _width, height) => {
-      if (height > 0) {
-        setHasGridLaidOut(true)
-      }
-    })
-  }, [artworks])
+  const artworks = useFragment(genericGridFragment, artworksProp)
 
   // Handles per-item visibility updates for the nested HomeView grid.
   // We use this instead of list-level viewability callbacks for the grid path,
-  // because the masonry list is nested inside the HomeView list.
+  // because the grid is nested inside the HomeView list.
   const handleGridItemVisibilityChange = (
     artworkID: string,
     itemIndex: number,
@@ -76,23 +79,33 @@ export const HomeViewSectionArtworksGrid: React.FC<HomeViewSectionArtworksGridPr
 
   return (
     <Flex mx={2} gap={2}>
-      <View ref={gridContainerRef}>
-        <GenericGrid
-          artworks={artworks}
-          contextModule={contextModule}
-          contextScreenOwnerType={OwnerType.home}
-          onPress={onArtworkPress}
-          fitToFrame
-          onItemVisibilityChange={handleGridItemVisibilityChange}
-        />
-      </View>
-      {hasGridLaidOut ? (
-        <RouterLink to={moreHref} hasChildTouchable onPress={onMorePress}>
-          <Button block variant="outline">
-            View More
-          </Button>
-        </RouterLink>
-      ) : null}
+      {/* Mirrors the masonry list's own insets: full width, then a single unit of padding */}
+      <Flex mx={-2} px={1} flexDirection="row" accessibilityLabel="Artworks Content View">
+        {times(NUM_COLUMNS_MASONRY).map((column) => (
+          <Flex key={column} flex={1}>
+            {artworks.map((artwork, index) =>
+              getColumnIndex(index) === column ? (
+                <MasonryArtworkGridItem
+                  key={artwork.id}
+                  index={index}
+                  item={artwork as unknown as MasonryArtworkItem}
+                  contextModule={contextModule}
+                  contextScreenOwnerType={OwnerType.home}
+                  onPress={onArtworkPress}
+                  fitToFrame
+                  onItemVisibilityChange={handleGridItemVisibilityChange}
+                />
+              ) : null
+            )}
+          </Flex>
+        ))}
+      </Flex>
+
+      <RouterLink to={moreHref} hasChildTouchable onPress={onMorePress}>
+        <Button block variant="outline">
+          View More
+        </Button>
+      </RouterLink>
     </Flex>
   )
 }

--- a/src/app/Scenes/HomeView/Sections/Section.tsx
+++ b/src/app/Scenes/HomeView/Sections/Section.tsx
@@ -55,7 +55,14 @@ export const Section: React.FC<SectionProps> = memo(({ section, ...rest }) => {
     case "HomeViewSectionActivity":
       return <HomeViewSectionActivityQueryRenderer sectionID={section.internalID} {...rest} />
     case "HomeViewSectionArtworks":
-      return <HomeViewSectionArtworksQueryRenderer sectionID={section.internalID} {...rest} />
+      return (
+        <HomeViewSectionArtworksQueryRenderer
+          sectionID={section.internalID}
+          // Lets the loading fallback match the layout the section will render in
+          shouldShowInGrid={section.component?.type === "ArtworksGrid"}
+          {...rest}
+        />
+      )
     case "HomeViewSectionCard":
       return <HomeViewSectionCardQueryRenderer sectionID={section.internalID} {...rest} />
     case "HomeViewSectionCards": {

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionArtworksGrid.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionArtworksGrid.tests.tsx
@@ -1,18 +1,20 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
+import { HomeViewSectionArtworksGridTestsQuery } from "__generated__/HomeViewSectionArtworksGridTestsQuery.graphql"
 import { HomeViewSectionArtworksGrid } from "app/Scenes/HomeView/Sections/HomeViewSectionArtworksGrid"
 import HomeAnalytics from "app/Scenes/HomeView/helpers/homeAnalytics"
+import { extractNodes } from "app/utils/extractNodes"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
-import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
 
-const mockGenericGrid = jest.fn()
+const mockGridItem = jest.fn()
 
 type ItemVisibilityChange = (artworkID: string, index: number, visible: boolean) => void
 
-jest.mock("app/Components/ArtworkGrids/GenericGrid", () => ({
-  __esModule: true,
-  default: (props: { onItemVisibilityChange?: ItemVisibilityChange }) => {
-    mockGenericGrid(props)
+jest.mock("app/Components/ArtworkGrids/MasonryArtworkGridItem", () => ({
+  MasonryArtworkGridItem: (props: { onItemVisibilityChange?: ItemVisibilityChange }) => {
+    mockGridItem(props)
     return null
   },
 }))
@@ -26,24 +28,39 @@ describe("HomeViewSectionArtworksGrid", () => {
   const onArtworkPress = jest.fn()
   const gridContextModule = "newWorksForYouGrid" as ContextModule
 
+  const getWrapper = (props?: Partial<React.ComponentProps<typeof HomeViewSectionArtworksGrid>>) =>
+    setupTestWrapper<HomeViewSectionArtworksGridTestsQuery>({
+      Component: ({ artworksConnection }) => (
+        <HomeViewSectionArtworksGrid
+          artworks={extractNodes(artworksConnection)}
+          moreHref="/view-all"
+          onMorePress={onMorePress}
+          onArtworkPress={onArtworkPress}
+          trackItemImpressions
+          contextModule={gridContextModule}
+          {...props}
+        />
+      ),
+      query: graphql`
+        query HomeViewSectionArtworksGridTestsQuery @relay_test_operation {
+          artworksConnection(first: 4) {
+            edges {
+              node {
+                ...GenericGrid_artworks
+              }
+            }
+          }
+        }
+      `,
+    })
+
   const renderComponent = (
-    props?: Partial<React.ComponentProps<typeof HomeViewSectionArtworksGrid>>
-  ) => {
-    return renderWithWrappers(
-      <HomeViewSectionArtworksGrid
-        artworks={[] as any}
-        moreHref="/view-all"
-        onMorePress={onMorePress}
-        onArtworkPress={onArtworkPress}
-        trackItemImpressions
-        contextModule={gridContextModule}
-        {...props}
-      />
-    )
-  }
+    props?: Partial<React.ComponentProps<typeof HomeViewSectionArtworksGrid>>,
+    mockResolvers?: Parameters<ReturnType<typeof getWrapper>["renderWithRelay"]>[0]
+  ) => getWrapper(props).renderWithRelay(mockResolvers)
 
   const getVisibilityCallback = (): ItemVisibilityChange => {
-    const firstCallProps = mockGenericGrid.mock.calls[0]?.[0] as {
+    const firstCallProps = mockGridItem.mock.calls[0]?.[0] as {
       onItemVisibilityChange?: ItemVisibilityChange
     }
 
@@ -52,7 +69,7 @@ describe("HomeViewSectionArtworksGrid", () => {
   }
 
   beforeEach(() => {
-    mockGenericGrid.mockClear()
+    mockGridItem.mockClear()
     mockTrackEvent.mockClear()
     ;(useFeatureFlag as jest.Mock).mockReturnValue(true)
   })
@@ -88,15 +105,32 @@ describe("HomeViewSectionArtworksGrid", () => {
     )
   })
 
-  it("passes home analytics context to the artwork grid", () => {
+  it("passes home analytics context to every artwork", () => {
     renderComponent()
 
-    expect(mockGenericGrid).toHaveBeenCalledWith(
+    expect(mockGridItem).toHaveBeenCalledWith(
       expect.objectContaining({
         contextModule: gridContextModule,
         contextScreenOwnerType: OwnerType.home,
       })
     )
+  })
+
+  it("renders every artwork it is given, so impressions can be tracked for each", () => {
+    renderComponent(undefined, {
+      FilterArtworksConnection: () => ({
+        edges: [
+          { node: { id: "artwork-1" } },
+          { node: { id: "artwork-2" } },
+          { node: { id: "artwork-3" } },
+          { node: { id: "artwork-4" } },
+        ],
+      }),
+    })
+
+    expect(mockGridItem).toHaveBeenCalledTimes(4)
+    // Positions are the artworks' own, not their position within a column
+    expect(mockGridItem.mock.calls.map(([props]) => props.index).sort()).toEqual([0, 1, 2, 3])
   })
 
   it("does not track when impression tracking is disabled", () => {

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet.tsx
@@ -1,12 +1,27 @@
 import { useColor, useScreenDimensions } from "@artsy/palette-mobile"
 import BottomSheet, { BottomSheetBackdrop, BottomSheetBackdropProps } from "@gorhom/bottom-sheet"
 import { ArtworkCardBottomSheetHandle } from "app/Components/ArtworkCard/ArtworkCardBottomSheetHandle"
+import { ArtsyNativeModule } from "app/NativeModules/ArtsyNativeModule"
 import { NewUserOnboardingAboutTheWorkTab } from "app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingAboutTheWorkTab" // pragma: allowlist secret
-import { FC, useCallback } from "react"
+import { useBackHandler } from "app/utils/hooks/useBackHandler"
+import { FC, useCallback, useRef } from "react"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 interface NewUserOnboardingArtworkCardBottomSheetProps {
   artworkID: string
+}
+
+export const handleOnboardingArtworkSheetBack = (args: {
+  isExpanded: boolean
+  collapse: () => void
+  background: () => void
+}): boolean => {
+  if (args.isExpanded) {
+    args.collapse()
+  } else {
+    args.background()
+  }
+  return true
 }
 
 export const NewUserOnboardingArtworkCardBottomSheet: FC<
@@ -15,6 +30,22 @@ export const NewUserOnboardingArtworkCardBottomSheet: FC<
   const { height } = useScreenDimensions()
   const { bottom, top } = useSafeAreaInsets()
   const color = useColor()
+  const bottomSheetRef = useRef<BottomSheet>(null)
+  const isExpandedRef = useRef(false)
+
+  // InfiniteDiscovery is a dead-end in onboarding, so always handle hardware back
+  // ourselves to keep it from popping back to the previous step.
+  useBackHandler(
+    useCallback(
+      () =>
+        handleOnboardingArtworkSheetBack({
+          isExpanded: isExpandedRef.current,
+          collapse: () => bottomSheetRef.current?.collapse(),
+          background: ArtsyNativeModule.moveTaskToBack,
+        }),
+      []
+    )
+  )
 
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
@@ -31,6 +62,7 @@ export const NewUserOnboardingArtworkCardBottomSheet: FC<
 
   return (
     <BottomSheet
+      ref={bottomSheetRef}
       enableDynamicSizing={true}
       enablePanDownToClose={false}
       snapPoints={[bottom + 60]}
@@ -39,6 +71,7 @@ export const NewUserOnboardingArtworkCardBottomSheet: FC<
       backdropComponent={renderBackdrop}
       backgroundStyle={{ backgroundColor: color("mono0") }}
       handleComponent={ArtworkCardBottomSheetHandle}
+      onChange={(index) => (isExpandedRef.current = index > 0)}
     >
       <NewUserOnboardingAboutTheWorkTab artworkID={artworkID} />
     </BottomSheet>

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/NewUserOnboardingArtworkCardBottomSheet.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/NewUserOnboardingArtworkCardBottomSheet.tests.tsx
@@ -1,0 +1,26 @@
+import { handleOnboardingArtworkSheetBack } from "app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet"
+
+describe("handleOnboardingArtworkSheetBack", () => {
+  it("collapses the sheet (and does not background) when expanded", () => {
+    const collapse = jest.fn()
+    const background = jest.fn()
+
+    const handled = handleOnboardingArtworkSheetBack({ isExpanded: true, collapse, background })
+
+    expect(collapse).toHaveBeenCalledTimes(1)
+    expect(background).not.toHaveBeenCalled()
+    // returns true so the native stack doesn't pop back to the previous onboarding step
+    expect(handled).toBe(true)
+  })
+
+  it("backgrounds the app (and does not collapse) when already collapsed", () => {
+    const collapse = jest.fn()
+    const background = jest.fn()
+
+    const handled = handleOnboardingArtworkSheetBack({ isExpanded: false, collapse, background })
+
+    expect(background).toHaveBeenCalledTimes(1)
+    expect(collapse).not.toHaveBeenCalled()
+    expect(handled).toBe(true)
+  })
+})

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/FollowArtistsOrderedSet.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/FollowArtistsOrderedSet.tsx
@@ -53,6 +53,7 @@ const FollowArtistsOrderedSet: React.FC<FollowArtistsOrderedSetProps> = ({
   return (
     <FlatList
       showsVerticalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
       contentContainerStyle={{ paddingBottom: SCROLLVIEW_PADDING_BOTTOM_OFFSET }}
       ListHeaderComponent={
         <>

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
@@ -21,7 +21,7 @@ import {
 } from "./config"
 
 export const Introduction: React.FC = () => {
-  const { replace } = useNavigation<NativeStackNavigationProp<NavigationStack>>()
+  const { replace, navigate } = useNavigation<NativeStackNavigationProp<NavigationStack>>()
   const [welcomeQueryRef, loadWelcomeQuery] =
     useQueryLoader<WelcomeStepQuery>(WelcomeStepScreenQuery)
   const { trackStartedOnboarding, trackAnsweredExperienceQuestion } = useOnboardingTracking()
@@ -38,12 +38,14 @@ export const Introduction: React.FC = () => {
   const handleDone = useCallback(
     (experience: Experience) => {
       if (experience === "beginner") {
-        replace("InfiniteDiscovery")
+        // push not replace so back events are not swallowed
+        // prevent go back in the components themselves
+        navigate("InfiniteDiscovery")
       } else {
         replace("FollowArtists")
       }
     },
-    [replace]
+    [replace, navigate]
   )
 
   const { currentStep, next, selectExperience } = useConfig({ onDone: handleDone })

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
@@ -2,7 +2,7 @@ import { ActionType, ContextModule } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { Introduction } from "app/Scenes/Onboarding/Screens/Onboarding/Introduction"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
-import { mockReplace } from "app/utils/tests/navigationMocks"
+import { mockNavigate, mockReplace } from "app/utils/tests/navigationMocks"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 jest.mock("../Components/QuestionStep", () => {
@@ -113,7 +113,7 @@ describe("Introduction", () => {
       expect(screen.getByText("Browse next")).toBeOnTheScreen()
 
       fireEvent.press(screen.getByText("Browse next"))
-      expect(mockReplace).toHaveBeenCalledWith("InfiniteDiscovery")
+      expect(mockNavigate).toHaveBeenCalledWith("InfiniteDiscovery")
     })
   })
 })

--- a/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/OnboardingSearchResults.tsx
+++ b/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/OnboardingSearchResults.tsx
@@ -56,6 +56,7 @@ const OnboardingSearchResults: React.FC<OnboardingSearchResultsProps> = ({
   return (
     <FlatList
       showsVerticalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
       data={searchResults}
       contentContainerStyle={{
         paddingBottom: SCROLLVIEW_PADDING_BOTTOM_OFFSET,

--- a/src/setupJest.tsx
+++ b/src/setupJest.tsx
@@ -506,6 +506,7 @@ function getNativeModules(): OurNativeModules {
       getPushToken: jest.fn(),
       getRecentPushPayloads: jest.fn(),
       clearUserData: jest.fn(),
+      moveTaskToBack: jest.fn(),
     },
   }
 }


### PR DESCRIPTION
## Release Candidate 9.15.0

This branch was automatically created as the release candidate for version 9.15.0.

> ⚠️ Do not merge this PR. It is used for tracking the release and 🍒 cherry-picking fixes only.

## Changelog

### Cross-platform user-facing changes
- feat: use more efficient queries for orders in partner offer conversation context — araujobarret (#13814)
- Fix Relay rate limiter getting stuck after sustained traffic, causing repeated "Rate limit exceeded" errors (e.g. on the Artist screen) — gkartalis (#13825)
- fix milliseconds showing in timers — MrSltun (#13830)
- copy update on edit profile — gkartalis (#13832)
- Removed the background overlay on the "your saves get stored here" onboarding tooltip — iskounen (#13836)
- Skip new onboarding artwork montage for users with Reduce Motion enabled — iskounen (#13807)
- Fix onboarding browse-prompt step to follow the device's Dark Mode setting — iskounen (#13844)
- Updated copy on the onboarding "interim question" step and removed the "Skip to Home" option — iskounen (#13861)
- Fix onboarding answer-pill sizing and text alignment — iskounen (#13870)
- add missing alias routes, route matching minor speedup - brian — brainbicycle (#13868)

### Dev changes
- Add `yarn clean:light` and `yarn repair:light` for faster, JS-only environment resets, and fix `yarn clean` failing when run twice in a row. — gkartalis (#13824)
- fixes form data vulnerability — gkartalis (#13828)
- early exit if beta version has already been used — gkartalis (#13831)
- Added a local Reanimated-based CTA button for the Follow Artists onboarding screen to avoid a react-spring/Reanimated animation conflict — iskounen (#13829)
- home view artworks tracking - mounir, daria — MounirDhahri (#13823)
- QA-document release automation now posts via release-lookout's Slack bot instead of a webhook, with the changelog threaded as a reply under the main announcement. — gkartalis (#13834)
- bump fastlane deps — MrSltun (#13845)
- using TapGestureHandler to allow users to either tap or swipe within Follow Artists bottomsheet — JanaeHijaz (#13837)
- Bump `@segment/analytics-react-native` to 2.24.0 and `@segment/sovran-react-native` to 1.1.4, and drop the local Segment Yarn patch now that the New Architecture `trackDeepLinks` fix is upstream. — gkartalis (#13854)
- Bump `jest-junit` to 17.0.0 and `unleash-proxy-client` to 3.8.2 to drop vulnerable transitive `uuid` versions. — gkartalis (#13855)
- Bump vulnerable transitive dependencies in `yarn.lock` (qs, yaml, on-headers, send, micromatch, brace-expansion, fast-xml-parser) and remove the unused `awesome-typescript-loader` devDependency — gkartalis (#13853)
- fixes yarn lock issue on main — gkartalis (#13857)
- early exit when userLocation is undefined — gkartalis (#13859)
- The automated QA document is now duplicated by Notion server-side, so its tables keep the template's row order, column order and board layouts. — gkartalis (#13858)
- copy updates — JanaeHijaz (#13843)
- build(deps): bump view shot to better support new arch — gkartalis (#13864)
- route drift report script - brian — brainbicycle (#13849)
- bumped up the CTA — JanaeHijaz (#13879)
- Redesign dev menu feature flags, dev toggles, and environment switcher to use Switches/radio pills instead of Alerts — MounirDhahri (#13880)
- Bump `ip-address` and `brace-expansion` transitive deps to clear 5 high severity Dependabot alerts — gkartalis (#13882)
- added missing context_module to infinite discovery event tracking — JanaeHijaz (#13887)
- bump concurrent-ruby to fix vulnerability — gkartalis (#13889)
- docs: update release captain docs — gkartalis (#13885)
- updated context_module for infinite discovery follow artists cta (onboarding flow) — JanaeHijaz (#13892)
- bump eas cli to latest — gkartalis (#13893)
- build(deps): bump js-yaml to 3.15.1/4.3.1 — gkartalis (#13897)

#nochangelog