### PR TITLE
fix: make beginner onboarding non-root to fix back behavior

### DIFF
--- a/android/app/src/main/java/net/artsy/app/ArtsyNativeModule.java
+++ b/android/app/src/main/java/net/artsy/app/ArtsyNativeModule.java
@@ -1,5 +1,6 @@
 package net.artsy.app;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
@@ -36,6 +37,18 @@ public class ArtsyNativeModule extends ReactContextBaseJavaModule {
     @Override
     public String getName() {
         return "ArtsyNativeModule";
+    }
+
+    // Backgrounds the app (returns to the launcher) without finishing the activity,
+    // mirroring Android's default "back at the root" behavior. Used to intercept the
+    // hardware back button on screens where JS handles back but still wants the
+    // standard background behavior in some states.
+    @ReactMethod
+    public void moveTaskToBack() {
+        Activity activity = getCurrentActivity();
+        if (activity != null) {
+            activity.moveTaskToBack(true);
+        }
     }
 
     @Override

--- a/src/app/NativeModules/ArtsyNativeModule.tsx
+++ b/src/app/NativeModules/ArtsyNativeModule.tsx
@@ -17,4 +17,12 @@ export const ArtsyNativeModule = {
     Platform.OS === "ios"
       ? NativeModules.ArtsyNativeModule.isBetaOrDev
       : (NativeModules.ArtsyNativeModule.getConstants().isBeta as boolean) || __DEV__,
+  /**
+   * Backgrounds the app (Android only). No-op on iOS, which has no hardware back button.
+   */
+  moveTaskToBack: () => {
+    if (Platform.OS === "android") {
+      NativeModules.ArtsyNativeModule.moveTaskToBack()
+    }
+  },
 }

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet.tsx
@@ -1,12 +1,27 @@
 import { useColor, useScreenDimensions } from "@artsy/palette-mobile"
 import BottomSheet, { BottomSheetBackdrop, BottomSheetBackdropProps } from "@gorhom/bottom-sheet"
 import { ArtworkCardBottomSheetHandle } from "app/Components/ArtworkCard/ArtworkCardBottomSheetHandle"
+import { ArtsyNativeModule } from "app/NativeModules/ArtsyNativeModule"
 import { NewUserOnboardingAboutTheWorkTab } from "app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingAboutTheWorkTab" // pragma: allowlist secret
-import { FC, useCallback } from "react"
+import { useBackHandler } from "app/utils/hooks/useBackHandler"
+import { FC, useCallback, useRef } from "react"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 interface NewUserOnboardingArtworkCardBottomSheetProps {
   artworkID: string
+}
+
+export const handleOnboardingArtworkSheetBack = (args: {
+  isExpanded: boolean
+  collapse: () => void
+  background: () => void
+}): boolean => {
+  if (args.isExpanded) {
+    args.collapse()
+  } else {
+    args.background()
+  }
+  return true
 }
 
 export const NewUserOnboardingArtworkCardBottomSheet: FC<
@@ -15,6 +30,22 @@ export const NewUserOnboardingArtworkCardBottomSheet: FC<
   const { height } = useScreenDimensions()
   const { bottom, top } = useSafeAreaInsets()
   const color = useColor()
+  const bottomSheetRef = useRef<BottomSheet>(null)
+  const isExpandedRef = useRef(false)
+
+  // InfiniteDiscovery is a dead-end in onboarding, so always handle hardware back
+  // ourselves to keep it from popping back to the previous step.
+  useBackHandler(
+    useCallback(
+      () =>
+        handleOnboardingArtworkSheetBack({
+          isExpanded: isExpandedRef.current,
+          collapse: () => bottomSheetRef.current?.collapse(),
+          background: ArtsyNativeModule.moveTaskToBack,
+        }),
+      []
+    )
+  )
 
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
@@ -31,6 +62,7 @@ export const NewUserOnboardingArtworkCardBottomSheet: FC<
 
   return (
     <BottomSheet
+      ref={bottomSheetRef}
       enableDynamicSizing={true}
       enablePanDownToClose={false}
       snapPoints={[bottom + 60]}
@@ -39,6 +71,7 @@ export const NewUserOnboardingArtworkCardBottomSheet: FC<
       backdropComponent={renderBackdrop}
       backgroundStyle={{ backgroundColor: color("mono0") }}
       handleComponent={ArtworkCardBottomSheetHandle}
+      onChange={(index) => (isExpandedRef.current = index > 0)}
     >
       <NewUserOnboardingAboutTheWorkTab artworkID={artworkID} />
     </BottomSheet>

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/NewUserOnboardingArtworkCardBottomSheet.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/NewUserOnboardingArtworkCardBottomSheet.tests.tsx
@@ -1,0 +1,26 @@
+import { handleOnboardingArtworkSheetBack } from "app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet"
+
+describe("handleOnboardingArtworkSheetBack", () => {
+  it("collapses the sheet (and does not background) when expanded", () => {
+    const collapse = jest.fn()
+    const background = jest.fn()
+
+    const handled = handleOnboardingArtworkSheetBack({ isExpanded: true, collapse, background })
+
+    expect(collapse).toHaveBeenCalledTimes(1)
+    expect(background).not.toHaveBeenCalled()
+    // returns true so the native stack doesn't pop back to the previous onboarding step
+    expect(handled).toBe(true)
+  })
+
+  it("backgrounds the app (and does not collapse) when already collapsed", () => {
+    const collapse = jest.fn()
+    const background = jest.fn()
+
+    const handled = handleOnboardingArtworkSheetBack({ isExpanded: false, collapse, background })
+
+    expect(background).toHaveBeenCalledTimes(1)
+    expect(collapse).not.toHaveBeenCalled()
+    expect(handled).toBe(true)
+  })
+})

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
@@ -21,7 +21,7 @@ import {
 } from "./config"
 
 export const Introduction: React.FC = () => {
-  const { replace } = useNavigation<NativeStackNavigationProp<NavigationStack>>()
+  const { replace, navigate } = useNavigation<NativeStackNavigationProp<NavigationStack>>()
   const [welcomeQueryRef, loadWelcomeQuery] =
     useQueryLoader<WelcomeStepQuery>(WelcomeStepScreenQuery)
   const { trackStartedOnboarding, trackAnsweredExperienceQuestion } = useOnboardingTracking()
@@ -38,12 +38,14 @@ export const Introduction: React.FC = () => {
   const handleDone = useCallback(
     (experience: Experience) => {
       if (experience === "beginner") {
-        replace("InfiniteDiscovery")
+        // push not replace so back events are not swallowed
+        // prevent go back in the components themselves
+        navigate("InfiniteDiscovery")
       } else {
         replace("FollowArtists")
       }
     },
-    [replace]
+    [replace, navigate]
   )
 
   const { currentStep, next, selectExperience } = useConfig({ onDone: handleDone })

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
@@ -2,7 +2,7 @@ import { ActionType, ContextModule } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { Introduction } from "app/Scenes/Onboarding/Screens/Onboarding/Introduction"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
-import { mockReplace } from "app/utils/tests/navigationMocks"
+import { mockNavigate, mockReplace } from "app/utils/tests/navigationMocks"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 jest.mock("../Components/QuestionStep", () => {
@@ -113,7 +113,7 @@ describe("Introduction", () => {
       expect(screen.getByText("Browse next")).toBeOnTheScreen()
 
       fireEvent.press(screen.getByText("Browse next"))
-      expect(mockReplace).toHaveBeenCalledWith("InfiniteDiscovery")
+      expect(mockNavigate).toHaveBeenCalledWith("InfiniteDiscovery")
     })
   })
 })

--- a/src/setupJest.tsx
+++ b/src/setupJest.tsx
@@ -506,6 +506,7 @@ function getNativeModules(): OurNativeModules {
       getPushToken: jest.fn(),
       getRecentPushPayloads: jest.fn(),
       clearUserData: jest.fn(),
+      moveTaskToBack: jest.fn(),
     },
   }
 }


### PR DESCRIPTION

This PR resolves [PBRW-1995] <!-- eg [PROJECT-XXXX] -->

### Description


The beginner onboarding flow was being added via replace making it the root to prevent going back to previous screens, the other consequence is that android back events then are not sent to javascript. 

This instead navigates as normal, prevents back behavior via backhandler, handles the dismissing the modal if open, adds a small native method to background the app if modal is closed. 

iOS unaffected. 

| Platform | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/d5f0630b-6a3b-4b82-8005-fe42c530eb6a" width="400" /> | <video src="https://github.com/user-attachments/assets/8fa661de-4dc8-4ade-9902-eb9586aea2a9" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |




Assisted-By: Claude <noreply@anthropic.com>

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- make experienced onboarding non-root to fix back behavior - brian

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-1995]: https://artsyproduct.atlassian.net/browse/PBRW-1995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ