### PR TITLE
chore(PHIRE-3082): update expo-updates runtimeVersion to use app version instead of native fingerprint

### DIFF
--- a/.github/workflows/expo-fingerprint-check.yml
+++ b/.github/workflows/expo-fingerprint-check.yml
@@ -148,7 +148,9 @@ jobs:
           fi
 
       - name: Upload new fingerprint to S3
-        if: steps.compare.outputs.changed == 'true' && (steps.check-s3-cache.outputs.needs_ios_build == 'true' || steps.check-s3-cache.outputs.needs_android_build == 'true')
+        # Independent of needs_*_build on purpose — this file also gates OTA publishes, so it must
+        # track main's fingerprint whenever it changes, not just when a rebuild happens.
+        if: steps.compare.outputs.changed == 'true'
         run: |
           echo "📤 Uploading new fingerprint to S3..."
           echo "${{ steps.generate-fingerprint.outputs.fingerprint }}" > latest.txt

--- a/.github/workflows/expo-fingerprint-check.yml
+++ b/.github/workflows/expo-fingerprint-check.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch: # Allows manual trigger
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   check-fingerprint:
@@ -114,39 +113,6 @@ jobs:
             echo "🔄 Fingerprints differ - native builds required"
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
-
-      - name: Open PR to update runtimeVersion in app.json
-        if: steps.compare.outputs.changed == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.EIGEN_GITHUB_PAT_TOKEN }}
-        run: |
-          FINGERPRINT="${{ steps.generate-fingerprint.outputs.fingerprint }}"
-          BRANCH="ci/update-expo-runtime-version-${FINGERPRINT:0:8}"
-
-          # Skip if branch already exists (e.g. workflow re-run for same fingerprint)
-          if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null 2>&1; then
-            echo "Branch $BRANCH already exists, skipping PR creation"
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          jq --arg version "$FINGERPRINT" '.expo.runtimeVersion = $version' app.json > app.json.tmp && mv app.json.tmp app.json
-
-          git checkout -b "$BRANCH"
-          git add app.json
-          git commit -m "chore: update expo runtimeVersion to ${FINGERPRINT:0:8}"
-          git push origin "$BRANCH"
-
-          PR_URL=$(gh pr create \
-            --title "chore: update expo runtimeVersion to ${FINGERPRINT:0:8}" \
-            --body "Automated PR: updates \`runtimeVersion\` in \`app.json\` to match the new native fingerprint \`$FINGERPRINT\`. #nochangelog" \
-            --base main \
-            --head "$BRANCH")
-
-          gh pr merge "$PR_URL" --auto --squash
-          echo "✅ PR created with auto-merge enabled: $PR_URL"
 
       - name: Check S3 for existing cached builds
         id: check-s3-cache

--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ commits.txt
 # native code hash
 file_hashes.txt
 native-hash.txt
+reference-fingerprint.txt
 
 .manifests
 

--- a/app.json
+++ b/app.json
@@ -14,11 +14,8 @@
         }
       }
     },
-    "platforms": [
-      "ios",
-      "android"
-    ],
-    "runtimeVersion": "9.15.0",
+    "platforms": ["ios", "android"],
+    "runtimeVersion": "9.16.0",
     "owner": "artsy_org",
     "extra": {
       "eas": {

--- a/app.json
+++ b/app.json
@@ -18,7 +18,7 @@
       "ios",
       "android"
     ],
-    "runtimeVersion": "73ba989240a6ab9c2e23247eeb8f3c638130f6cf",
+    "runtimeVersion": "9.15.0",
     "owner": "artsy_org",
     "extra": {
       "eas": {

--- a/docs/build_caching.md
+++ b/docs/build_caching.md
@@ -123,7 +123,12 @@ Runs on every push to `main`. It:
 3. Compares the two — if they match, no builds are needed
 4. If they differ, checks S3 for existing cached builds for each platform (in case the fingerprint changed but a build was already uploaded for it)
 5. Outputs `needs_ios_build` and `needs_android_build` flags as artifacts for downstream workflows
-6. Saves the new fingerprint to S3 if builds are needed
+6. Saves the new fingerprint to S3 whenever it changed — regardless of whether a build was needed
+
+> `latest.txt` is also the reference the Expo Updates deploy gate compares against (see
+> [Deploying to Expo Updates](deploy_to_expo_updates.md#how-updates-are-matched-to-builds)), so it has
+> to track main's fingerprint even when a cache hit means no rebuild happens. Otherwise it goes stale
+> and starts blocking legitimate updates.
 
 ### 2. `ios-expo-build` ([.github/workflows/ios-expo-build.yml](../.github/workflows/ios-expo-build.yml))
 

--- a/docs/debugging_expo_updates.md
+++ b/docs/debugging_expo_updates.md
@@ -1,6 +1,6 @@
 # Debugging Expo Updates (Devs)
 
-The most common problem is fetching an update and it does not run or crashes on launch. This likely means the native code in the beta is different and is incompatible with the code that your update needs to run on.
+The most common problem is your native code being incompatible with the build you're deploying to. The deploy script catches this up front by comparing fingerprints and refusing to publish (see [Deploying to Expo Updates](deploy_to_expo_updates.md#how-updates-are-matched-to-builds)); if it slips through, the update fetches but crashes on launch.
 
 **Note:** Native code includes not just our native code but any native code in dependencies our app relies on.
 
@@ -45,6 +45,12 @@ Deploy an update using these [instructions](./deploy_to_expo_updates.md) and pul
 The QA configuration is a release configuration, code is optimized so debugging doesn't work properly, you can change the optimization level to None in build settings if you need this.
 
 ### Known gotchas
+
+#### Deploy blocked with "Native code has drifted"
+
+Expected, not a bug — your branch's native code doesn't match the build the update would land on, and publishing anyway would crash it on launch. Rebase or deploy a new beta depending on which side is stale, per [Debugging Expo Updates (Devs)](#debugging-expo-updates-devs) above.
+
+If you're deploying from a branch that isn't based on current main — a hotfix branch cut from a release tag, say — then the default comparison against the latest beta is the wrong one. Use `--check-against-version` to compare against the shipped build for the current app version instead.
 
 #### Code changes not auto refreshing app
 

--- a/docs/deploy_a_hotfix.md
+++ b/docs/deploy_a_hotfix.md
@@ -6,7 +6,8 @@ There are 2 methods of deploying hot fixes depending on the issue:
 
 1. **Expo Updates (js) Releases**: If the issue only affects javascript code we can deploy a hotfix with Expo updates and users will get the update automatically on the next run of the app.
 
-> [!IMPORTANT] > **Expo Updates is not yet available for production hotfixes, please follow the `Native release hotfix process`**
+> [!IMPORTANT]
+> **Expo Updates is not yet available for production hotfixes, please follow the `Native release hotfix process`**
 
 2. **Native Releases**: If the issue affects native code we must deploy new build and send through the app review process as normal. Note this build will still need to go through the review process and user's will need to update so this is only a mitigation not an immediate fix. If a faster release is necessary you can request an expedited review for the app store but this should be done sparingly and is not guaranteed to be approved. Google Play does not offer expedited reviews but their review process is typically faster.
 

--- a/docs/deploy_a_hotfix.md
+++ b/docs/deploy_a_hotfix.md
@@ -4,10 +4,11 @@ Occasionally a bug is found in a live release that requires a quick mitigation. 
 
 There are 2 methods of deploying hot fixes depending on the issue:
 
-1. **Expo Updates (js) Releases**: If the issue only affects javascript code we can deploy a hotfix with Expo updates and users will get the update automatically on the next run of the app.
+1. **Expo Updates (js) Releases**: If the issue only affects javascript code we can deploy a hotfix with Expo updates and users will get the update automatically on the next run of the app. This is the faster path — use it whenever the fix is JS-only.
 
 > [!IMPORTANT]
-> **Expo Updates is not yet available for production hotfixes, please follow the `Native release hotfix process`**
+>
+> > **Expo Updates is not yet available for production hotfixes, please follow the `Native release hotfix process`**
 
 2. **Native Releases**: If the issue affects native code we must deploy new build and send through the app review process as normal. Note this build will still need to go through the review process and user's will need to update so this is only a mitigation not an immediate fix. If a faster release is necessary you can request an expedited review for the app store but this should be done sparingly and is not guaranteed to be approved. Google Play does not offer expedited reviews but their review process is typically faster.
 
@@ -98,18 +99,21 @@ You will need to be logged in to the `artsy_mobile` account, credentials in 1pas
 
 Let `#practice-mobile` know you will be deploying a hotfix and to hold off deploying to expo updates or betas.
 
+Since the canary channel checks for `main`'s native code fingerprint, we would need to pass `--check-against-version` to check the shipped version's fingerprint.
+
 Run the script to deploy the hotfix to the canary channel:
-`./scripts/deploys/expo-updates/deploy-to-expo-updates 'canary' 'hotfix description'`
+
+`./scripts/deploys/expo-updates/deploy-to-expo-updates 'canary' 'hotfix description' --check-against-version`
 
 By default this deploys to both platforms. Pass `--platform ios` or `--platform android` to target just one, e.g. if the fix is platform-specific:
 
-`./scripts/deploys/expo-updates/deploy-to-expo-updates 'canary' 'hotfix description' --platform ios`
+`./scripts/deploys/expo-updates/deploy-to-expo-updates 'canary' 'hotfix description' --check-against-version --platform ios`
 
 ## Test your update in the firebase equivalent of the production app
 
 Find and download the equivalent build in firebase app tester to the production app, it should have the same build number as the latest submissions found in step 1.
 
-Enable the dev menu and download the expo updates bundle from the staging deployment.
+Enable the dev menu and download the expo-updates bundle from the canary channel.
 Test that the fix is working as intended and do some basic QA to make sure the app is functioning correctly.
 
 ## Deploy the update to production
@@ -121,7 +125,7 @@ Make sure to monitor the app as it rolls out to users.
 
 `./scripts/deploys/expo-updates/deploy-to-production <rollout_percentage>`
 
-For example if you wanted to rollout to 50% of users you would pass `50` for rollout_percentage. If it is critical to get the fix out fast
+For example if you wanted to rollout to 50% of users you would pass `50` for `rollout_percentage`. If it is critical to get the fix out fast
 you can pass `100` otherwise it is suggested you pass `50` and monitor before updating to 100%.
 
 ### Update rollout
@@ -130,7 +134,7 @@ If all looks good with the fix you can update the rollout to all users:
 
 `./scripts/deploys/expo-updates/update-rollout`
 
-This will start an interactive dialog where you can choose the release you want to update the rollout for. Remember to update for both iOS and Android!
+This will start an interactive dialog where you can choose the release you want to update the rollout for.
 
 </details>
 

--- a/docs/deploy_a_hotfix.md
+++ b/docs/deploy_a_hotfix.md
@@ -6,8 +6,7 @@ There are 2 methods of deploying hot fixes depending on the issue:
 
 1. **Expo Updates (js) Releases**: If the issue only affects javascript code we can deploy a hotfix with Expo updates and users will get the update automatically on the next run of the app.
 
-> [!IMPORTANT]
-> **Expo Updates is not yet available for production hotfixes, please follow the `Native release hotfix process`**
+> [!IMPORTANT] > **Expo Updates is not yet available for production hotfixes, please follow the `Native release hotfix process`**
 
 2. **Native Releases**: If the issue affects native code we must deploy new build and send through the app review process as normal. Note this build will still need to go through the review process and user's will need to update so this is only a mitigation not an immediate fix. If a faster release is necessary you can request an expedited review for the app store but this should be done sparingly and is not guaranteed to be approved. Google Play does not offer expedited reviews but their review process is typically faster.
 
@@ -100,6 +99,10 @@ Let `#practice-mobile` know you will be deploying a hotfix and to hold off deplo
 
 Run the script to deploy the hotfix to the canary channel:
 `./scripts/deploys/expo-updates/deploy-to-expo-updates 'canary' 'hotfix description'`
+
+By default this deploys to both platforms. Pass `--platform ios` or `--platform android` to target just one, e.g. if the fix is platform-specific:
+
+`./scripts/deploys/expo-updates/deploy-to-expo-updates 'canary' 'hotfix description' --platform ios`
 
 ## Test your update in the firebase equivalent of the production app
 

--- a/docs/deploy_to_expo_updates.md
+++ b/docs/deploy_to_expo_updates.md
@@ -37,6 +37,29 @@ Then run:
 ./scripts/deploys/expo-updates/deploy-to-expo-updates canary
 ```
 
+Full usage:
+
+```
+./scripts/deploys/expo-updates/deploy-to-expo-updates <deployment> [description] [rollout_percentage] [--platform ios|android|all] [--check-against-version]
+```
+
+By default an update goes out to both platforms. Pass `--platform ios` or `--platform android` to target one.
+
+### How updates are matched to builds
+
+An update is only delivered to a build whose `runtimeVersion` matches. We key `runtimeVersion` on the **app version** (`version` in `app.json`, e.g. `9.15.0`), so an update stays compatible with every build of that release. `runtimeVersion` is kept in sync automatically whenever the app version is bumped — you should never need to edit it by hand.
+
+Because the app version doesn't say anything about native code, the deploy script verifies that separately: before publishing, it compares the current native [fingerprint](build_caching.md) against a reference and refuses to publish if they differ. This is what stops a JS bundle that expects new native code from reaching a build that doesn't have it (which would crash on launch).
+
+The reference depends on the channel:
+
+- **canary / staging** → the latest beta's fingerprint (`s3://mobile-cached-builds/eigen-expo-fingerprint/latest.txt`)
+- **production** → the fingerprint of the build actually shipped for the current app version (`.../<version>.txt`, written when a beta is promoted to the store)
+
+If native code has drifted you'll see `❌ Native code has drifted from ...` and the publish stops. That's working as intended — deploy a new beta rather than trying to force the update out.
+
+`--check-against-version` switches canary/staging to compare against the current app version's shipped fingerprint instead of the latest beta's. Use it when you're deploying from a branch that isn't based on current main — a hotfix branch cut from an old release tag, for example. It's a no-op for production, which already does this.
+
 ### Using in app
 
 In the latest beta from firebase open Dev Menu -> Expo Updates -> Select your channel (e.g. Canary). The app will exit. Reopen the app and your changes should be running.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -259,25 +259,12 @@ lane :promote_beta_ios do
 
   tag_and_push(tag: "ios-#{next_app_store_version}-#{formatted_build_number}-submission")
 
-  `git fetch --tags 2>/dev/null`
-  ship_tags = `git tag -l 'ios-*-#{formatted_build_number}'`.split("\n")
-  promoted_fingerprint = nil
-  if ship_tags.length == 1
-    tag_message = `git for-each-ref refs/tags/#{ship_tags.first} --format='%(contents)'`.strip
-    promoted_fingerprint = tag_message.sub('fingerprint:', '').strip if tag_message.start_with?('fingerprint:')
+  promoted_fingerprint = resolve_promoted_fingerprint(platform: 'ios', build_number: formatted_build_number)
+  if promoted_fingerprint
+    sh("echo '#{promoted_fingerprint}' | aws s3 cp - s3://mobile-cached-builds/eigen-expo-fingerprint/#{next_app_store_version}.txt")
+  else
+    UI.important("Skipping the fingerprint upload for #{next_app_store_version} — fix this manually before publishing any Expo Update for this version.")
   end
-
-  if promoted_fingerprint.nil? || promoted_fingerprint.empty?
-    UI.important("⚠️ Could not find a fingerprint tag for build #{formatted_build_number} (found #{ship_tags.length} matching tag(s)).")
-    if UI.confirm("Is your current local checkout the exact release-candidate commit for this build? Only confirm if you're certain — this computes the fingerprint from whatever's currently checked out, as a fallback.")
-      promoted_fingerprint = sh("npx @expo/fingerprint fingerprint:generate | jq -r '.hash'").strip
-      UI.important("Computed fallback fingerprint from current checkout: #{promoted_fingerprint}")
-    else
-      UI.user_error!("Cannot determine the fingerprint for build #{formatted_build_number}. Aborting promotion.")
-    end
-  end
-
-  sh("echo '#{promoted_fingerprint}' | aws s3 cp - s3://mobile-cached-builds/eigen-expo-fingerprint/#{next_app_store_version}.txt")
 
   sentry_slack_ios(build_number: formatted_build_number, version: next_app_store_version)
 
@@ -455,25 +442,12 @@ lane :promote_beta_android do
   vname, vcode = set_build_version_android(version_code: selected_version_code)
   tag_and_push(tag: "android-#{vname}-#{vcode}-submission")
 
-  `git fetch --tags 2>/dev/null`
-  ship_tags = `git tag -l 'android-*-#{vcode}'`.split("\n")
-  promoted_fingerprint = nil
-  if ship_tags.length == 1
-    tag_message = `git for-each-ref refs/tags/#{ship_tags.first} --format='%(contents)'`.strip
-    promoted_fingerprint = tag_message.sub('fingerprint:', '').strip if tag_message.start_with?('fingerprint:')
+  promoted_fingerprint = resolve_promoted_fingerprint(platform: 'android', build_number: vcode)
+  if promoted_fingerprint
+    sh("echo '#{promoted_fingerprint}' | aws s3 cp - s3://mobile-cached-builds/eigen-expo-fingerprint/#{vname}.txt")
+  else
+    UI.important("Skipping the fingerprint upload for #{vname} — fix this manually before publishing any Expo Update for this version.")
   end
-
-  if promoted_fingerprint.nil? || promoted_fingerprint.empty?
-    UI.important("⚠️ Could not find a fingerprint tag for build #{vcode} (found #{ship_tags.length} matching tag(s)).")
-    if UI.confirm("Is your current local checkout the exact release-candidate commit for this build? Only confirm if you're certain — this computes the fingerprint from whatever's currently checked out, as a fallback.")
-      promoted_fingerprint = sh("npx @expo/fingerprint fingerprint:generate | jq -r '.hash'").strip
-      UI.important("Computed fallback fingerprint from current checkout: #{promoted_fingerprint}")
-    else
-      UI.user_error!("Cannot determine the fingerprint for build #{vcode}. Aborting promotion.")
-    end
-  end
-
-  sh("echo '#{promoted_fingerprint}' | aws s3 cp - s3://mobile-cached-builds/eigen-expo-fingerprint/#{vname}.txt")
 
   sentry_slack_android(build_number: vcode, version: vname)
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -81,12 +81,8 @@ lane :ship_beta_ios do |options|
 
   # Builds the app
   sync_signing_ios(deployment_target: deployment_target)
-  tag_and_push(tag: "ios-#{latest_version}-#{bundle_version}")
-
-  # Record this version's native fingerprint so a production Expo Update publish
-  # can later be gated against what's actually being shipped as this version.
   current_fingerprint = sh("npx @expo/fingerprint fingerprint:generate | jq -r '.hash'").strip
-  sh("echo '#{current_fingerprint}' | aws s3 cp - s3://mobile-cached-builds/eigen-expo-fingerprint/#{latest_version}.txt")
+  tag_and_push(tag: "ios-#{latest_version}-#{bundle_version}", message: "fingerprint:#{current_fingerprint}")
 
   # Add badge if firebase deployment
   if deployment_target == 'firebase'
@@ -263,6 +259,26 @@ lane :promote_beta_ios do
 
   tag_and_push(tag: "ios-#{next_app_store_version}-#{formatted_build_number}-submission")
 
+  `git fetch --tags 2>/dev/null`
+  ship_tags = `git tag -l 'ios-*-#{formatted_build_number}'`.split("\n")
+  promoted_fingerprint = nil
+  if ship_tags.length == 1
+    tag_message = `git for-each-ref refs/tags/#{ship_tags.first} --format='%(contents)'`.strip
+    promoted_fingerprint = tag_message.sub('fingerprint:', '').strip if tag_message.start_with?('fingerprint:')
+  end
+
+  if promoted_fingerprint.nil? || promoted_fingerprint.empty?
+    UI.important("⚠️ Could not find a fingerprint tag for build #{formatted_build_number} (found #{ship_tags.length} matching tag(s)).")
+    if UI.confirm("Is your current local checkout the exact release-candidate commit for this build? Only confirm if you're certain — this computes the fingerprint from whatever's currently checked out, as a fallback.")
+      promoted_fingerprint = sh("npx @expo/fingerprint fingerprint:generate | jq -r '.hash'").strip
+      UI.important("Computed fallback fingerprint from current checkout: #{promoted_fingerprint}")
+    else
+      UI.user_error!("Cannot determine the fingerprint for build #{formatted_build_number}. Aborting promotion.")
+    end
+  end
+
+  sh("echo '#{promoted_fingerprint}' | aws s3 cp - s3://mobile-cached-builds/eigen-expo-fingerprint/#{next_app_store_version}.txt")
+
   sentry_slack_ios(build_number: formatted_build_number, version: next_app_store_version)
 
   UI.success('All done!')
@@ -362,12 +378,8 @@ lane :ship_beta_android do |options|
   end
 
   set_git_properties_android
-  tag_and_push(tag: "android-#{vname}-#{vcode}")
-
-  # Record this version's native fingerprint so a production Expo Update publish
-  # can later be gated against what's actually being shipped as this version.
   current_fingerprint = sh("npx @expo/fingerprint fingerprint:generate | jq -r '.hash'").strip
-  sh("echo '#{current_fingerprint}' | aws s3 cp - s3://mobile-cached-builds/eigen-expo-fingerprint/#{vname}.txt")
+  tag_and_push(tag: "android-#{vname}-#{vcode}", message: "fingerprint:#{current_fingerprint}")
 
   build_type = deployment_target == 'play_store' ? 'release' : 'beta'
   if deployment_target == 'firebase'
@@ -442,6 +454,27 @@ lane :promote_beta_android do
 
   vname, vcode = set_build_version_android(version_code: selected_version_code)
   tag_and_push(tag: "android-#{vname}-#{vcode}-submission")
+
+  `git fetch --tags 2>/dev/null`
+  ship_tags = `git tag -l 'android-*-#{vcode}'`.split("\n")
+  promoted_fingerprint = nil
+  if ship_tags.length == 1
+    tag_message = `git for-each-ref refs/tags/#{ship_tags.first} --format='%(contents)'`.strip
+    promoted_fingerprint = tag_message.sub('fingerprint:', '').strip if tag_message.start_with?('fingerprint:')
+  end
+
+  if promoted_fingerprint.nil? || promoted_fingerprint.empty?
+    UI.important("⚠️ Could not find a fingerprint tag for build #{vcode} (found #{ship_tags.length} matching tag(s)).")
+    if UI.confirm("Is your current local checkout the exact release-candidate commit for this build? Only confirm if you're certain — this computes the fingerprint from whatever's currently checked out, as a fallback.")
+      promoted_fingerprint = sh("npx @expo/fingerprint fingerprint:generate | jq -r '.hash'").strip
+      UI.important("Computed fallback fingerprint from current checkout: #{promoted_fingerprint}")
+    else
+      UI.user_error!("Cannot determine the fingerprint for build #{vcode}. Aborting promotion.")
+    end
+  end
+
+  sh("echo '#{promoted_fingerprint}' | aws s3 cp - s3://mobile-cached-builds/eigen-expo-fingerprint/#{vname}.txt")
+
   sentry_slack_android(build_number: vcode, version: vname)
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -83,6 +83,11 @@ lane :ship_beta_ios do |options|
   sync_signing_ios(deployment_target: deployment_target)
   tag_and_push(tag: "ios-#{latest_version}-#{bundle_version}")
 
+  # Record this version's native fingerprint so a production Expo Update publish
+  # can later be gated against what's actually being shipped as this version.
+  current_fingerprint = sh("npx @expo/fingerprint fingerprint:generate | jq -r '.hash'").strip
+  sh("echo '#{current_fingerprint}' | aws s3 cp - s3://mobile-cached-builds/eigen-expo-fingerprint/#{latest_version}.txt")
+
   # Add badge if firebase deployment
   if deployment_target == 'firebase'
     puts "Adding badge for firebase deployment..."
@@ -359,6 +364,11 @@ lane :ship_beta_android do |options|
   set_git_properties_android
   tag_and_push(tag: "android-#{vname}-#{vcode}")
 
+  # Record this version's native fingerprint so a production Expo Update publish
+  # can later be gated against what's actually being shipped as this version.
+  current_fingerprint = sh("npx @expo/fingerprint fingerprint:generate | jq -r '.hash'").strip
+  sh("echo '#{current_fingerprint}' | aws s3 cp - s3://mobile-cached-builds/eigen-expo-fingerprint/#{vname}.txt")
+
   build_type = deployment_target == 'play_store' ? 'release' : 'beta'
   if deployment_target == 'firebase'
     # Firebase is internal QA on real devices — all modern Android phones are arm64-v8a.
@@ -624,13 +634,20 @@ lane :deploy_to_expo_updates do |options|
       #{expo_command} | tail -n1 && \
       popd > /dev/null")
 
-  # Export environment variables for Sentry sourcemap upload
-  ENV['SENTRY_RELEASE'] = "#{platform}-#{release_name_base}"
+  # `--platform all` publishes both platforms in one eas update call, so the
+  # dist/ export contains both platforms' bundles. Loop the Sentry upload and
+  # git tag per platform so releases/tags stay platform-scoped, matching
+  # eigenSentryReleaseName()'s "<ios|android>-<release>" format at runtime.
+  # For a single-platform publish (platform:ios or platform:android) this loop
+  # just runs once.
+  platforms_to_tag = platform == 'all' ? ['ios', 'android'] : [platform]
 
-  puts "🔧 Uploading sourcemaps to Sentry with release: #{platform}-#{release_name_base}"
-  sh("cd .. && npx sentry-expo-upload-sourcemaps dist")
-
-  tag_and_push(tag: "#{platform}-#{release_name_base}")
+  platforms_to_tag.each do |p|
+    ENV['SENTRY_RELEASE'] = "#{p}-#{release_name_base}"
+    puts "🔧 Uploading sourcemaps to Sentry with release: #{p}-#{release_name_base}"
+    sh("cd .. && npx sentry-expo-upload-sourcemaps dist")
+    tag_and_push(tag: "#{p}-#{release_name_base}")
+  end
 
   puts "🚀 Deploying to #{deployment_name} with description '#{description}' for platform #{platform}"
   puts "🎯 Rollout: #{rollout_percentage}%" if rollout_percentage

--- a/fastlane/utility_fastlane.rb
+++ b/fastlane/utility_fastlane.rb
@@ -6,6 +6,7 @@ desc "Updates the version string in app.json"
 lane :update_version_string do |options|
   new_version = options[:version] || prompt(text: "What is the new human-readable release version?")
   $APP_JSON['version'] = new_version
+  $APP_JSON['expo']['runtimeVersion'] = new_version
   write_contents_to_file($APP_JSON_PATH, JSON.pretty_generate($APP_JSON))
 end
 

--- a/fastlane/utility_fastlane.rb
+++ b/fastlane/utility_fastlane.rb
@@ -353,6 +353,31 @@ def git_tag_commit_message(tag)
   msg.empty? ? nil : msg
 end
 
+def resolve_promoted_fingerprint(platform:, build_number:)
+  # Looks up the ship-time tag for the exact build being promoted (ios-*-<build_number> /
+  # android-*-<build_number>) and reads back the fingerprint from its annotation message.
+  # Falls back to an interactive confirm-and-recompute if the tag can't be found unambiguously.
+  `git fetch --tags 2>/dev/null`
+  ship_tags = `git tag -l '#{platform}-*-#{build_number}'`.split("\n")
+  promoted_fingerprint = nil
+  if ship_tags.length == 1
+    tag_message = `git for-each-ref refs/tags/#{ship_tags.first} --format='%(contents)'`.strip
+    promoted_fingerprint = tag_message.sub('fingerprint:', '').strip if tag_message.start_with?('fingerprint:')
+  end
+
+  if promoted_fingerprint.nil? || promoted_fingerprint.empty?
+    UI.important("⚠️ Could not find a fingerprint tag for build #{build_number} (found #{ship_tags.length} matching tag(s)).")
+    if UI.confirm("Is your current local checkout the exact release-candidate commit for this build? Only confirm if you're certain — this computes the fingerprint from whatever's currently checked out, as a fallback.")
+      promoted_fingerprint = sh("npx @expo/fingerprint fingerprint:generate | jq -r '.hash'").strip
+      UI.important("Computed fallback fingerprint from current checkout: #{promoted_fingerprint}")
+    else
+      UI.error("Could not determine the fingerprint for build #{build_number}. The Expo Updates gate for this version will be unusable until s3://mobile-cached-builds/eigen-expo-fingerprint/<version>.txt is set manually.")
+    end
+  end
+
+  promoted_fingerprint
+end
+
 def should_silence_beta_failure?
   # Set this var in circleci if you want to silence beta failure alerts for a while
   # E.g. you are working on a ci change

--- a/fastlane/utility_fastlane.rb
+++ b/fastlane/utility_fastlane.rb
@@ -168,8 +168,13 @@ lane :tag_and_push do |options|
   # Do a tag, we use a http git remote so we can have push access
   # as the default remote for circle is read-only
   tag = options[:tag].strip
+  message = options[:message]
   `git tag -d "#{tag}"`
-  add_git_tag tag: tag
+  if message
+    add_git_tag(tag: tag, message: message)
+  else
+    add_git_tag(tag: tag)
+  end
   `git remote add http https://github.com/artsy/eigen.git || true`
   # use no-verify to skip the pre-push hook
   `git push http #{tag} -f --no-verify`

--- a/scripts/deploys/expo-updates/check-native-fingerprint-synced
+++ b/scripts/deploys/expo-updates/check-native-fingerprint-synced
@@ -1,14 +1,18 @@
 #!/bin/bash
 set -euxo pipefail
 
-if [ "$#" -ne 1 ]; then
-  echo "Usage: $0 <canary|staging|production>"
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "Usage: $0 <canary|staging|production> [--check-against-version]"
   exit 1
 fi
 
 deployment=$1
+check_against_version=false
+if [ "${2:-}" = "--check-against-version" ]; then
+  check_against_version=true
+fi
 
-if [ "$deployment" = "production" ]; then
+if [ "$deployment" = "production" ] || [ "$check_against_version" = true ]; then
   version=$(jq -r '.version' app.json)
   reference_path="s3://mobile-cached-builds/eigen-expo-fingerprint/${version}.txt"
   reference_label="the shipped build for version ${version}"

--- a/scripts/deploys/expo-updates/check-native-fingerprint-synced
+++ b/scripts/deploys/expo-updates/check-native-fingerprint-synced
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euxo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <canary|staging|production>"
+  exit 1
+fi
+
+deployment=$1
+
+if [ "$deployment" = "production" ]; then
+  version=$(jq -r '.version' app.json)
+  reference_path="s3://mobile-cached-builds/eigen-expo-fingerprint/${version}.txt"
+  reference_label="the shipped build for version ${version}"
+else
+  reference_path="s3://mobile-cached-builds/eigen-expo-fingerprint/latest.txt"
+  reference_label="the latest beta build"
+fi
+
+current_fingerprint=$(npx @expo/fingerprint fingerprint:generate | jq -r '.hash')
+
+if ! aws s3 cp "$reference_path" ./reference-fingerprint.txt > /dev/null; then
+  echo "❌ No fingerprint record found at $reference_path — cannot verify native compatibility against $reference_label." >&2
+  exit 1
+fi
+
+reference_fingerprint=$(cat ./reference-fingerprint.txt)
+
+if [ "$current_fingerprint" != "$reference_fingerprint" ]; then
+  echo "❌ Native code has drifted from $reference_label." >&2
+  echo "   Current fingerprint:   $current_fingerprint" >&2
+  echo "   Reference fingerprint: $reference_fingerprint" >&2
+  echo "   Per process, native changes require a new native beta build — do not publish this as an Expo Update." >&2
+  exit 1
+fi
+
+echo "✅ Native fingerprint matches $reference_label ($current_fingerprint). Safe to publish via Expo Updates."

--- a/scripts/deploys/expo-updates/deploy-to-expo-updates
+++ b/scripts/deploys/expo-updates/deploy-to-expo-updates
@@ -73,7 +73,6 @@ else
   # reset changes made to app.json
   git checkout app.json
   git checkout dist/.gitkeep
-  git checkout reference-fingerprint.txt
 fi
 
 echo "Release to $deployment deployment successful."

--- a/scripts/deploys/expo-updates/deploy-to-expo-updates
+++ b/scripts/deploys/expo-updates/deploy-to-expo-updates
@@ -73,6 +73,7 @@ else
   # reset changes made to app.json
   git checkout app.json
   git checkout dist/.gitkeep
+  git checkout reference-fingerprint.txt
 fi
 
 echo "Release to $deployment deployment successful."

--- a/scripts/deploys/expo-updates/deploy-to-expo-updates
+++ b/scripts/deploys/expo-updates/deploy-to-expo-updates
@@ -2,12 +2,14 @@
 set -euxo pipefail
 
 platform="all"
+check_against_version=false
 positional_args=()
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --platform=*) platform="${1#--platform=}"; shift ;;
     --platform) platform="${2:-}"; shift 2 ;;
+    --check-against-version) check_against_version=true; shift ;;
     *) positional_args+=("$1"); shift ;;
   esac
 done
@@ -15,10 +17,13 @@ done
 set -- "${positional_args[@]}"
 
 if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
-  echo "Usage: $0 <deployment> [description] [rollout_percentage] [--platform ios|android|all]"
+  echo "Usage: $0 <deployment> [description] [rollout_percentage] [--platform ios|android|all] [--check-against-version]"
   echo "Deployment must be either 'canary', 'staging' or 'production'."
   echo "Rollout percentage is optional (integer from 0 to 100)."
   echo "Platform is optional ('ios', 'android' or 'all'). Defaults to 'all'."
+  echo "--check-against-version checks against this version's own shipped fingerprint instead of"
+  echo "the latest beta's — useful for hotfix branches, which are cut from an old release rather"
+  echo "than main. No-op for 'production', which already checks against its own version by default."
   exit 1
 fi
 
@@ -36,9 +41,15 @@ if [ "$platform" != "ios" ] && [ "$platform" != "android" ] && [ "$platform" != 
   exit 1
 fi
 
-# Block the publish if native code has drifted since the relevant reference build —
-# an Expo Update built from a drifted native surface can crash a shipped binary on launch.
-./scripts/deploys/expo-updates/check-native-fingerprint-synced "$deployment"
+if [ "$check_against_version" = true ]; then
+  # For hotfix branches cut from an old release: check against this version's own shipped
+  # fingerprint instead of the latest beta's, since that's the comparison that actually matters.
+  ./scripts/deploys/expo-updates/check-native-fingerprint-synced "$deployment" --check-against-version
+else
+  # Block the publish if native code has drifted since the relevant reference build —
+  # an Expo Update built from a drifted native surface can crash a shipped binary on launch.
+  ./scripts/deploys/expo-updates/check-native-fingerprint-synced "$deployment"
+fi
 
 # Get the description from the command-line argument if provided, otherwise use the last commit hash and description
 description=""

--- a/scripts/deploys/expo-updates/deploy-to-expo-updates
+++ b/scripts/deploys/expo-updates/deploy-to-expo-updates
@@ -1,10 +1,24 @@
 #!/bin/bash
 set -euxo pipefail
 
+platform="all"
+positional_args=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --platform=*) platform="${1#--platform=}"; shift ;;
+    --platform) platform="${2:-}"; shift 2 ;;
+    *) positional_args+=("$1"); shift ;;
+  esac
+done
+
+set -- "${positional_args[@]}"
+
 if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
-  echo "Usage: $0 <deployment> [description] [rollout_percentage]"
+  echo "Usage: $0 <deployment> [description] [rollout_percentage] [--platform ios|android|all]"
   echo "Deployment must be either 'canary', 'staging' or 'production'."
   echo "Rollout percentage is optional (integer from 0 to 100)."
+  echo "Platform is optional ('ios', 'android' or 'all'). Defaults to 'all'."
   exit 1
 fi
 
@@ -15,6 +29,16 @@ if [ "$deployment" != "canary" ] && [ "$deployment" != "staging" ] && [ "$deploy
   echo "Deployment must be either 'canary', 'staging' or 'production'."
   exit 1
 fi
+
+if [ "$platform" != "ios" ] && [ "$platform" != "android" ] && [ "$platform" != "all" ]; then
+  echo "Invalid platform option: $platform"
+  echo "Platform must be either 'ios', 'android' or 'all'."
+  exit 1
+fi
+
+# Block the publish if native code has drifted since the relevant reference build —
+# an Expo Update built from a drifted native surface can crash a shipped binary on launch.
+./scripts/deploys/expo-updates/check-native-fingerprint-synced "$deployment"
 
 # Get the description from the command-line argument if provided, otherwise use the last commit hash and description
 description=""
@@ -32,11 +56,9 @@ if [ -n "${3:-}" ]; then
 fi
 
 if [ -n "$rollout" ]; then
-  bundle exec fastlane deploy_to_expo_updates deployment_name:$deployment description:"$description" platform:ios "$rollout"
-  bundle exec fastlane deploy_to_expo_updates deployment_name:$deployment description:"$description" platform:android "$rollout"
+  bundle exec fastlane deploy_to_expo_updates deployment_name:$deployment description:"$description" platform:$platform "$rollout"
 else
-  bundle exec fastlane deploy_to_expo_updates deployment_name:$deployment description:"$description" platform:ios
-  bundle exec fastlane deploy_to_expo_updates deployment_name:$deployment description:"$description" platform:android
+  bundle exec fastlane deploy_to_expo_updates deployment_name:$deployment description:"$description" platform:$platform
   # reset changes made to app.json
   git checkout app.json
   git checkout dist/.gitkeep

--- a/scripts/deploys/expo-updates/rollback-update
+++ b/scripts/deploys/expo-updates/rollback-update
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euxo pipefail
+
+./bin/node_modules/.bin/eas update:rollback
+

--- a/scripts/deploys/expo-updates/rollback-update
+++ b/scripts/deploys/expo-updates/rollback-update
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -euxo pipefail
-
-./bin/node_modules/.bin/eas update:rollback
-


### PR DESCRIPTION
This PR resolves [PHIRE-3082] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR does the following:
- Switches `runtimeVersion` from a native-code fingerprint hash to the app's version string
- Adds a script to keep a record of the native-code fingerprint for each released version, named `${app_version}.txt`, alongside the current `latest.txt`.
- Adds a gate script that blocks a publish if native code has drifted from the relevant reference build — the last beta (for canary/staging) or the actual build shipped for the current version (for production) — instead of silently shipping a bundle that could crash a binary that doesn't have it.
- Adds a `--platform ios|android|all` flag to `deploy-to-expo-updates` (defaults to `all`) for targeting a single platform.
- Retires the auto-PR bot that used to bump `runtimeVersion` on every fingerprint drift, since it's no longer needed.
- Keeps Sentry releases and git tags platform-scoped (`ios-…`/`android-…`) even when publishing both platforms in one `--platform all` call.

**How to deploy**

```bash
# unchanged — defaults to all platforms
./scripts/deploys/expo-updates/deploy-to-expo-updates canary "fix login crash"

# new — target a single platform for a platform-specific fix
./scripts/deploys/expo-updates/deploy-to-expo-updates canary "fix login crash" --platform ios

# rollout percentage still works the same way, flag can go anywhere
./scripts/deploys/expo-updates/deploy-to-expo-updates production "hotfix" 50 --platform android
```

**Notes**

- When native code hasn't changed since the reference build (aka v9.14.0), the gate passes silently and the publish proceeds exactly as before.

- When native code has changed since the reference build, the publish is blocked with `❌ Native code has drifted from …` instead of shipping a bundle that could crash on launch.

- When no `--platform` flag is passed, the script creates one update bundle that gets published to both iOS and Android, and both platforms get Sentry release and a git tag.
- When `--platform ios` (or `android`) is passed, the update publishes to only that platform, and only that platform's Sentry release and git tag get created.
- When a beta is shipped via `ship_beta_ios`/`ship_beta_android`, that version's native fingerprint is added to the build tag in git.
- When a beta is promoted to the stores, that build's fingerprint is recorded in S3; this is what production publishes get checked against later.
- When `.version` is bumped through `update_version_string`, `runtimeVersion` is bumped to match automatically, so they can never drift apart.


### Follow-ups
- [ ] Test the new flow thoroughly on canary/staging on both platforms

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Update expo-updates runtimeVerison to use app version + native code fingerprint gate

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3082]: https://artsyproduct.atlassian.net/browse/PHIRE-3082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ