### PR TITLE
fix: CascadingEndTimesBanner use correct Text component & disable prefetching for external link

### DIFF
--- a/src/app/Scenes/Artwork/Components/CascadingEndTimesBanner.tsx
+++ b/src/app/Scenes/Artwork/Components/CascadingEndTimesBanner.tsx
@@ -1,6 +1,5 @@
 import { Flex, Text } from "@artsy/palette-mobile"
 import { RouterLink } from "app/system/navigation/RouterLink"
-import { Text as RNText } from "react-native"
 
 interface CascadingEndTimesBannerProps {
   cascadingEndTimeInterval: number
@@ -22,11 +21,11 @@ export const CascadingEndTimesBanner: React.FC<CascadingEndTimesBannerProps> = (
         {canBeExtended
           ? "Closing times may be extended due to last-minute competitive bidding. "
           : `Lots will close at ${cascadingEndTimeInterval}-minute intervals. `}
-
-        <RouterLink to={CASCADING_AUCTION_HELP_ARTICLE_LINK} hasChildTouchable>
-          <RNText style={{ textDecorationLine: "underline" }}>
+        {/* External link — prefetch disabled so the text renders properly inline */}
+        <RouterLink to={CASCADING_AUCTION_HELP_ARTICLE_LINK} disablePrefetch hasChildTouchable>
+          <Text style={{ textDecorationLine: "underline" }} color="mono0">
             Learn more about cascading end times
-          </RNText>
+          </Text>
         </RouterLink>
       </Text>
     </Flex>


### PR DESCRIPTION
This PR resolves [PBRW-2004] <!-- eg [PROJECT-XXXX] -->

### Description
| Platform | Before | After |
|---|---|---|
| Android dark | <img width="1080" height="2400" alt="darkB4" src="https://github.com/user-attachments/assets/acbbb6cc-d26d-48b0-8640-a53938ff88d2" /> | <img width="1080" height="2400" alt="darkAfter" src="https://github.com/user-attachments/assets/1eeecf16-756f-4af4-b5d5-2cb59b5883ea" /> |
| android light | <img width="1080" height="2400" alt="lightB4" src="https://github.com/user-attachments/assets/08ddbde8-1c85-48e2-b1bf-44d7de8c0d63" /> | <img width="1080" height="2400" alt="lightAfter" src="https://github.com/user-attachments/assets/d7e40c99-0d8c-4f88-b409-b019b2b2c62c" /> |
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->




<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix CascadingEndTimesBanner use correct Text component & disable prefetching for external link

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-2004]: https://artsyproduct.atlassian.net/browse/PBRW-2004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ