### PR TITLE
refactor(scripts): guard beta deploys against same-hour build number

### DIFF
--- a/scripts/deploys/check_build_status_gh
+++ b/scripts/deploys/check_build_status_gh
@@ -1,74 +1,198 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# check_build_status_gh.sh
-# Usage: ./check_build_status_gh.sh <platform>
-# Example: ./check_build_status_gh.sh ios
+# check_build_status_gh
+# Usage: ./check_build_status_gh <platform>
+# Example: ./check_build_status_gh ios
+#
+# Guards against two betas landing in the same build number.
+#
+# Beta build numbers are an hour bucket: iOS stamps CFBundleVersion as
+# %Y.%m.%d.%H (Fastfile `set_build_version_ios`) and Android stamps versionCode
+# as %Y%m%d%H (`get_next_android_build_version`). The Sentry release is derived
+# from it — `ios-<version>-<build>` / `android-<version>-<code>` — so two betas
+# of the same platform in the same UTC hour share one Sentry release and the
+# second build's sourcemap upload overwrites the first's.
+#
+# So the limit is one beta per platform per UTC hour, NOT one per 60 minutes:
+# 07:58 then 08:02 is fine (different buckets), 07:05 then 07:58 is not.
+#
+# Two things are checked, both scoped to the platform being deployed (the Sentry
+# release name is platform-prefixed, so iOS and Android cannot collide):
+#
+#   1. Does the tag this build will push already exist? fastlane pushes
+#      `<platform>-<version>-<build>`, so an existing tag is an exact, unambiguous
+#      "this hour is taken".
+#   2. Is a beta for this platform currently running? It has not stamped its
+#      build number yet, so it may well land in this same bucket.
+#
+# fastlane has its own same-hour check (`testflight_build_already_shipped?` /
+# `firebase_build_already_shipped?`) but it only sees builds that already
+# finished shipping — two runs started in the same hour both pass it before
+# either uploads. This catches it up front instead.
+#
+# If the conflict is a release candidate (its commit is the tip of an `rc-v*`
+# branch) overriding would corrupt the build about to ship, so a plain "y" is
+# not accepted — it takes typing `override-rc`.
 
 source .env.releases
 
-PLATFORM=$1
+PLATFORM="${1:-}"
 
 if [ -z "$PLATFORM" ]; then
   echo "Platform argument is required (e.g., ios or android)."
   exit 1
 fi
 
-if [ "$PLATFORM" = "ios" ]; then
+APP_VERSION=$(jq -r '.version' app.json)
+
+# Must match the stamping in fastlane/Fastfile. UTC, because CI runners are UTC.
+case "$PLATFORM" in
+ios)
+  BUILD_NUMBER=$(date -u +%Y.%m.%d.%H)
   WORKFLOW_FILES=("build-deploy-ios-testflight.yml" "build-deploy-ios-firebase.yml")
-elif [ "$PLATFORM" = "android" ]; then
+  ;;
+android)
+  BUILD_NUMBER=$(date -u +%Y%m%d%H)
   WORKFLOW_FILES=("build-deploy-android-playstore.yml" "build-deploy-android-firebase.yml")
-else
+  ;;
+*)
   echo "Unsupported platform: $PLATFORM. Supported platforms are ios and android."
   exit 1
-fi
+  ;;
+esac
 
-# Check if GITHUB_TOKEN is set
+EXPECTED_TAG="${PLATFORM}-${APP_VERSION}-${BUILD_NUMBER}"
+
 if [ -z "${GITHUB_TOKEN:-}" ]; then
   echo "Error: GITHUB_TOKEN could not be found."
   echo "Please run 'yarn setup:releases' to set up the environment variables."
   exit 1
 fi
 
-echo "Checking if there is a $PLATFORM build in progress..."
+# Release-candidate commits: rc-release-automation force-pushes an `rc-v*` tip to
+# the beta branches, so an RC beta's commit is the tip of an rc-v* branch.
+rc_shas=$(git ls-remote --heads origin 'refs/heads/rc-v*' | awk '{print $1}')
+is_rc_sha() { [ -n "$1" ] && grep -qx "$1" <<<"$rc_shas"; }
 
-total_running_runs=0
+echo "Checking for another $PLATFORM beta in UTC hour ${BUILD_NUMBER} (build ${EXPECTED_TAG})..."
 
-# Check each workflow for the platform using the filename directly (avoids pagination issues with name lookup)
-for WORKFLOW_FILE in "${WORKFLOW_FILES[@]}"; do
-  echo "Checking workflow: $WORKFLOW_FILE"
-
-  # Check for running workflow runs using the workflow filename directly
-  response=$(curl -s \
+gh_api() {
+  curl -s \
     -H "Authorization: Bearer $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github.v3+json" \
-    "https://api.github.com/repos/artsy/eigen/actions/workflows/$WORKFLOW_FILE/runs?status=in_progress&per_page=1")
+    "https://api.github.com/repos/artsy/eigen/$1"
+}
 
-  if echo "$response" | jq -e '.message' > /dev/null 2>&1; then
+# Beta commits live on the beta branches and are often not in the local clone,
+# so fall back to the API for the commit subject.
+commit_subject() {
+  git log -1 --format=%s "$1" 2>/dev/null ||
+    gh_api "commits/$1" | jq -r '.commit.message // ""' | head -1
+}
+
+conflicts=""
+rc_conflict=false
+
+# --- 1. has this hour's build number already been used? -----------------------
+# These are annotated tags, so `refs/tags/X` is the tag object and `refs/tags/X^{}`
+# is the commit it points at. We want the commit: the tag object's SHA is not a
+# commit at all, so it would never match an rc-v tip (and has no commit message).
+# The trailing `*` is what makes ls-remote emit the `^{}` line.
+tag_refs=$(git ls-remote --tags origin "refs/tags/${EXPECTED_TAG}*")
+existing_tag_sha=$(awk -v ref="refs/tags/${EXPECTED_TAG}^{}" '$2 == ref {print $1}' <<<"$tag_refs")
+if [ -z "$existing_tag_sha" ]; then
+  # Lightweight tag: the ref already points straight at the commit.
+  existing_tag_sha=$(awk -v ref="refs/tags/${EXPECTED_TAG}" '$2 == ref {print $1}' <<<"$tag_refs")
+fi
+
+if [ -n "$existing_tag_sha" ]; then
+  marker=""
+  if is_rc_sha "$existing_tag_sha"; then
+    marker="  🚨 RELEASE CANDIDATE"
+    rc_conflict=true
+  fi
+  subject=$(commit_subject "$existing_tag_sha")
+  conflicts+="  - build ${BUILD_NUMBER} is already taken — tag ${EXPECTED_TAG}${marker}"$'\n'
+  conflicts+="      ${existing_tag_sha:0:8} — ${subject}"$'\n'
+fi
+
+# --- 2. is a beta for this platform running right now? ------------------------
+# It has not stamped its build number yet, so it may land in this same bucket.
+for WORKFLOW_FILE in "${WORKFLOW_FILES[@]}"; do
+  response=$(gh_api "actions/workflows/$WORKFLOW_FILE/runs?status=in_progress&per_page=10")
+
+  if echo "$response" | jq -e '.message' >/dev/null 2>&1; then
     error_message=$(echo "$response" | jq -r '.message')
     echo "Error: GitHub API returned an error for '$WORKFLOW_FILE': $error_message"
     echo "Please run 'yarn setup:releases' to refresh your credentials."
     exit 1
   fi
 
-  running_runs=$(echo "$response" | jq -r '(.total_count // 0)')
+  matches=$(echo "$response" | jq -r \
+    '.workflow_runs[] | [.head_sha, .name, .display_title, .html_url] | @tsv')
 
-  if [ "$running_runs" -gt 0 ]; then
-    echo "Found $running_runs running build(s) for '$WORKFLOW_FILE'"
-    total_running_runs=$((total_running_runs + running_runs))
-  fi
+  [ -z "$matches" ] && continue
+
+  while IFS=$'\t' read -r sha name title url; do
+    [ -z "$sha" ] && continue
+    marker=""
+    if is_rc_sha "$sha"; then
+      marker="  🚨 RELEASE CANDIDATE"
+      rc_conflict=true
+    fi
+    conflicts+="  - running now — ${name} — ${sha:0:8} — ${title}${marker}"$'\n'
+    conflicts+="      ${url}"$'\n'
+  done <<<"$matches"
 done
 
-if [ "$total_running_runs" -gt 0 ]; then
-    echo "Another $PLATFORM build is running ($total_running_runs total)."
-    read -p "There is a build currently running. Are you sure you want to overwrite it? (y/n) " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-        echo "Proceeding with creating the $PLATFORM beta..."
-    else
-        echo "Aborting..."
-        exit 1
-    fi
+# --- 3. near the top of the hour? --------------------------------------------
+# The build number is stamped when the fastlane step runs, several minutes after
+# the trigger, so a late-in-the-hour trigger can land in either bucket.
+minute=$(date -u +%-M)
+if [ "$minute" -ge 50 ]; then
+  next_hour=$(date -u -v+1H +%H 2>/dev/null || date -u -d '+1 hour' +%H)
+  echo
+  echo "⏰ Heads up: it is $(date -u +%H:%M) UTC, so this build may stamp hour"
+  echo "   $(date -u +%H) or hour ${next_hour} depending on when the build step runs."
+  echo "   Waiting until the top of the hour makes the build number predictable."
+fi
+
+if [ -z "$conflicts" ]; then
+  echo "Build ${BUILD_NUMBER} is free and no $PLATFORM beta is running. Proceeding with creating the $PLATFORM beta..."
+  exit 0
+fi
+
+echo
+echo "⚠️  Conflicting $PLATFORM beta for UTC hour ${BUILD_NUMBER}:"
+echo
+printf '%s' "$conflicts"
+echo
+echo "Betas of the same platform in the same UTC hour share build number ${BUILD_NUMBER},"
+echo "so they share one Sentry release and the second upload overwrites the first's"
+echo "sourcemaps. Waiting until the next UTC hour avoids this entirely."
+echo
+
+if [ "$rc_conflict" = true ]; then
+  echo "🚨 The conflict is a RELEASE CANDIDATE — DO NOT override."
+  echo "   Overriding will corrupt the build that is about to ship. Wait for the RC"
+  echo "   builds to finish and check with the release owner first."
+  echo
+  read -r -p "   If you are certain, type 'override-rc' to continue (anything else aborts): " REPLY
+  echo
+  if [ "$REPLY" = "override-rc" ]; then
+    echo "Overriding a release candidate on purpose. Proceeding with the $PLATFORM beta..."
+    exit 0
+  fi
+  echo "Aborting..."
+  exit 1
+fi
+
+read -r -p "Are you sure you want to deploy anyway? (y/n) " -n 1
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  echo "Proceeding with creating the $PLATFORM beta..."
 else
-    echo "No other $PLATFORM build running. Proceeding with creating the beta..."
+  echo "Aborting..."
+  exit 1
 fi

--- a/scripts/deploys/check_build_status_gh
+++ b/scripts/deploys/check_build_status_gh
@@ -5,35 +5,22 @@ set -euo pipefail
 # Usage: ./check_build_status_gh <platform>
 # Example: ./check_build_status_gh ios
 #
-# Guards against two betas landing in the same build number.
+# Blocks two betas of the same platform landing in the same build number.
 #
-# Beta build numbers are an hour bucket: iOS stamps CFBundleVersion as
-# %Y.%m.%d.%H (Fastfile `set_build_version_ios`) and Android stamps versionCode
-# as %Y%m%d%H (`get_next_android_build_version`). The Sentry release is derived
-# from it — `ios-<version>-<build>` / `android-<version>-<code>` — so two betas
-# of the same platform in the same UTC hour share one Sentry release and the
-# second build's sourcemap upload overwrites the first's.
+# Build numbers are a UTC hour bucket (Fastfile stamps iOS `%Y.%m.%d.%H`,
+# Android `%Y%m%d%H`) and the Sentry release is derived from them, so same-hour
+# betas share a release and the second sourcemap upload overwrites the first's.
+# One per platform per hour bucket, not one per 60 minutes: 07:58 then 08:02 is
+# fine, 07:05 then 07:58 is not.
 #
-# So the limit is one beta per platform per UTC hour, NOT one per 60 minutes:
-# 07:58 then 08:02 is fine (different buckets), 07:05 then 07:58 is not.
+# Checks, per platform (release names are platform-prefixed, so iOS and Android
+# can't collide): (1) does the tag fastlane is about to push already exist, and
+# (2) is a beta running right now, having not yet stamped its build number.
+# fastlane's own check only sees builds that finished shipping, so two runs
+# started in the same hour both pass it before either uploads.
 #
-# Two things are checked, both scoped to the platform being deployed (the Sentry
-# release name is platform-prefixed, so iOS and Android cannot collide):
-#
-#   1. Does the tag this build will push already exist? fastlane pushes
-#      `<platform>-<version>-<build>`, so an existing tag is an exact, unambiguous
-#      "this hour is taken".
-#   2. Is a beta for this platform currently running? It has not stamped its
-#      build number yet, so it may well land in this same bucket.
-#
-# fastlane has its own same-hour check (`testflight_build_already_shipped?` /
-# `firebase_build_already_shipped?`) but it only sees builds that already
-# finished shipping — two runs started in the same hour both pass it before
-# either uploads. This catches it up front instead.
-#
-# If the conflict is a release candidate (its commit is the tip of an `rc-v*`
-# branch) overriding would corrupt the build about to ship, so a plain "y" is
-# not accepted — it takes typing `override-rc`.
+# Overriding an `rc-v*` tip would corrupt the build about to ship, so that case
+# refuses a plain "y" and requires typing `override-rc`.
 
 source .env.releases
 
@@ -46,7 +33,7 @@ fi
 
 APP_VERSION=$(jq -r '.version' app.json)
 
-# Must match the stamping in fastlane/Fastfile. UTC, because CI runners are UTC.
+# Must match fastlane/Fastfile's stamping. UTC, because CI runners are UTC.
 case "$PLATFORM" in
 ios)
   BUILD_NUMBER=$(date -u +%Y.%m.%d.%H)
@@ -70,8 +57,8 @@ if [ -z "${GITHUB_TOKEN:-}" ]; then
   exit 1
 fi
 
-# Release-candidate commits: rc-release-automation force-pushes an `rc-v*` tip to
-# the beta branches, so an RC beta's commit is the tip of an rc-v* branch.
+# rc-release-automation pushes an `rc-v*` tip to the beta branches, so an RC
+# beta's commit is the tip of an rc-v* branch.
 rc_shas=$(git ls-remote --heads origin 'refs/heads/rc-v*' | awk '{print $1}')
 is_rc_sha() { [ -n "$1" ] && grep -qx "$1" <<<"$rc_shas"; }
 
@@ -84,8 +71,7 @@ gh_api() {
     "https://api.github.com/repos/artsy/eigen/$1"
 }
 
-# Beta commits live on the beta branches and are often not in the local clone,
-# so fall back to the API for the commit subject.
+# Beta commits are often not in the local clone, so fall back to the API.
 commit_subject() {
   git log -1 --format=%s "$1" 2>/dev/null ||
     gh_api "commits/$1" | jq -r '.commit.message // ""' | head -1
@@ -95,14 +81,13 @@ conflicts=""
 rc_conflict=false
 
 # --- 1. has this hour's build number already been used? -----------------------
-# These are annotated tags, so `refs/tags/X` is the tag object and `refs/tags/X^{}`
-# is the commit it points at. We want the commit: the tag object's SHA is not a
-# commit at all, so it would never match an rc-v tip (and has no commit message).
-# The trailing `*` is what makes ls-remote emit the `^{}` line.
+# These tags are annotated, so we want `refs/tags/X^{}` (the commit) and not
+# `refs/tags/X` (the tag object, which can never match an rc-v tip). The
+# trailing `*` is what makes ls-remote emit the `^{}` line at all.
 tag_refs=$(git ls-remote --tags origin "refs/tags/${EXPECTED_TAG}*")
 existing_tag_sha=$(awk -v ref="refs/tags/${EXPECTED_TAG}^{}" '$2 == ref {print $1}' <<<"$tag_refs")
 if [ -z "$existing_tag_sha" ]; then
-  # Lightweight tag: the ref already points straight at the commit.
+  # Lightweight tag: the ref points straight at the commit.
   existing_tag_sha=$(awk -v ref="refs/tags/${EXPECTED_TAG}" '$2 == ref {print $1}' <<<"$tag_refs")
 fi
 
@@ -118,7 +103,7 @@ if [ -n "$existing_tag_sha" ]; then
 fi
 
 # --- 2. is a beta for this platform running right now? ------------------------
-# It has not stamped its build number yet, so it may land in this same bucket.
+# It hasn't stamped its build number yet, so it may land in this same bucket.
 for WORKFLOW_FILE in "${WORKFLOW_FILES[@]}"; do
   response=$(gh_api "actions/workflows/$WORKFLOW_FILE/runs?status=in_progress&per_page=10")
 
@@ -147,8 +132,8 @@ for WORKFLOW_FILE in "${WORKFLOW_FILES[@]}"; do
 done
 
 # --- 3. near the top of the hour? --------------------------------------------
-# The build number is stamped when the fastlane step runs, several minutes after
-# the trigger, so a late-in-the-hour trigger can land in either bucket.
+# The stamp happens minutes after the trigger, so a late trigger can land in
+# either bucket.
 minute=$(date -u +%-M)
 if [ "$minute" -ge 50 ]; then
   next_hour=$(date -u -v+1H +%H 2>/dev/null || date -u -d '+1 hour' +%H)


### PR DESCRIPTION
This PR resolves [PHIRE-3358] <!-- eg [PROJECT-XXXX] -->

### Description

Two betas of the same platform triggered in the same UTC hour get the **same build number**, and therefore the same Sentry release — so the second build's sourcemap upload overwrites the first's, leaving one of the two betas with unusable stack traces.

So the real limit is **one beta per platform per UTC hour**: 07:58 → 08:02 is fine (different buckets), 07:05 → 07:58 is not. Release names are platform-prefixed, so iOS and Android can never collide with each other and the guard is scoped per platform.

#### What `scripts/deploys/check_build_status_gh` now does

1. **Is this hour's build number already used?** fastlane pushes `<platform>-<app.json version>-<build>`, so `git ls-remote` for that exact tag is an unambiguous "this hour is taken" — no timestamp approximation.
2. **Is a beta for this platform running right now?** (`?status=in_progress`) — it hasn't stamped its build number yet, so it may still land in this bucket. Each conflict is printed with its SHA, commit subject and run URL.
3. **Boundary warning** past minute 50 — the stamp happens a few minutes after the trigger, so a late trigger may land in either bucket.
4. **Release-candidate protection** — if a conflicting commit is the tip of an `rc-v*` branch, overriding would corrupt the build about to ship, so a plain `y` is refused and the user must type `override-rc`.

#### Every message the script can print

<details><summary>All output paths (exit codes in brackets)</summary>

**Bad invocation / setup**

```
Platform argument is required (e.g., ios or android).                    [1]
```
```
Unsupported platform: <x>. Supported platforms are ios and android.     [1]
```
```
Error: GITHUB_TOKEN could not be found.                                  [1]
Please run 'yarn setup:releases' to set up the environment variables.
```
```
Error: GitHub API returned an error for '<workflow>.yml': <api message>  [1]
Please run 'yarn setup:releases' to refresh your credentials.
```

**Always printed first**

```
Checking for another ios beta in UTC hour 2026.08.13.09 (build ios-9.15.0-2026.08.13.09)...
```

**Boundary warning** — added past minute 50, in front of whichever outcome follows; it never decides anything on its own

```
⏰ Heads up: it is 09:52 UTC, so this build may stamp hour
   09 or hour 10 depending on when the build step runs.
   Waiting until the top of the hour makes the build number predictable.
```

**All clear**

```
Build 2026.08.13.09 is free and no ios beta is running. Proceeding with creating the ios beta...   [0]
```

**Conflict found** — the header, then one entry per conflict, then the explanation

```
⚠️  Conflicting ios beta for UTC hour 2026.08.13.09:

  - build 2026.08.13.09 is already taken — tag ios-9.15.0-2026.08.13.09
      66acb6fa — fix: artist bio rendering on artwork screen
  - running now — Deploy iOS Beta to TestFlight — 8d49a354 — build(ci): remove ninja
      https://github.com/artsy/eigen/actions/runs/...

Betas of the same platform in the same UTC hour share build number 2026.08.13.09,
so they share one Sentry release and the second upload overwrites the first's
sourcemaps. Waiting until the next UTC hour avoids this entirely.
```

Either conflict line gains a `  🚨 RELEASE CANDIDATE` suffix when its commit is an `rc-v*` tip.

**Then one of two prompts.** Normal conflict:

```
Are you sure you want to deploy anyway? (y/n)
```
- `y`/`Y` → `Proceeding with creating the ios beta...` [0]
- anything else → `Aborting...` [1]

Release-candidate conflict (a plain `y` is *not* enough here):

```
🚨 The conflict is a RELEASE CANDIDATE — DO NOT override.
   Overriding will corrupt the build that is about to ship. Wait for the RC
   builds to finish and check with the release owner first.

   If you are certain, type 'override-rc' to continue (anything else aborts):
```
- exactly `override-rc` → `Overriding a release candidate on purpose. Proceeding with the ios beta...` [0]
- anything else, `y` included → `Aborting...` [1]

</details>
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- guard beta deploys against same-hour build number

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3358]: https://artsyproduct.atlassian.net/browse/PHIRE-3358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ