### PR TITLE
fix(DI-332): Adds fallback for auction result images 

### DIFF
--- a/src/app/Components/Lists/AuctionResultListItem.tsx
+++ b/src/app/Components/Lists/AuctionResultListItem.tsx
@@ -38,6 +38,8 @@ const AuctionResultListItem: React.FC<Props> = memo(
   }) => {
     const tracking = useTracking()
     const [couldNotLoadImage, setCouldNotLoadImage] = useState(false)
+    const [imageUrl, setImageUrl] = useState(auctionResult.images?.thumbnail?.url)
+    const [triedFallback, setTriedFallback] = useState(false)
 
     const QAInfo: React.FC = () => (
       <QAInfoManualPanel position="absolute" top={0} left={95}>
@@ -96,14 +98,25 @@ const AuctionResultListItem: React.FC<Props> = memo(
                   width: 100,
                 }}
                 source={{
-                  uri: auctionResult.images.thumbnail.url,
+                  uri: imageUrl,
                 }}
                 onError={() => {
-                  addBreadcrumb({
-                    message: `Failed to load auction result image for id: ${auctionResult.internalID}`,
-                    level: "info",
-                  })
-                  setCouldNotLoadImage(true)
+                  //if .jpg failed, try .png
+                  if (!triedFallback && imageUrl?.endsWith(".jpg")) {
+                    const pngUrl = imageUrl.replace(".jpg", ".png")
+                    addBreadcrumb({
+                      message: `Failed to load .jpg, trying .png fallback for id: ${auctionResult.internalID}`,
+                      level: "info",
+                    })
+                    setImageUrl(pngUrl)
+                    setTriedFallback(true)
+                  } else {
+                    addBreadcrumb({
+                      message: `Failed to load auction result image for id: ${auctionResult.internalID}`,
+                      level: "info",
+                    })
+                    setCouldNotLoadImage(true)
+                  }
                 }}
                 resizeMode={FastImage.resizeMode.cover}
               />

--- a/src/app/Components/Lists/AuctionResultListItem.tsx
+++ b/src/app/Components/Lists/AuctionResultListItem.tsx
@@ -38,7 +38,7 @@ const AuctionResultListItem: React.FC<Props> = memo(
   }) => {
     const tracking = useTracking()
     const [couldNotLoadImage, setCouldNotLoadImage] = useState(false)
-    const [imageUrl, setImageUrl] = useState(auctionResult.images?.thumbnail?.url)
+    const [imageUrl, setImageUrl] = useState(auctionResult.images?.thumbnail?.url ?? undefined)
     const [triedFallback, setTriedFallback] = useState(false)
 
     const QAInfo: React.FC = () => (

--- a/src/app/Components/Lists/__tests__/AuctionResultListItem.tests.tsx
+++ b/src/app/Components/Lists/__tests__/AuctionResultListItem.tests.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable testing-library/await-async-queries, testing-library/no-node-access */
-import { fireEvent, screen } from "@testing-library/react-native"
+import { act, fireEvent, screen } from "@testing-library/react-native"
 import { AuctionResultListItemTestsQuery } from "__generated__/AuctionResultListItemTestsQuery.graphql"
 import { AuctionResultListItemFragmentContainer } from "app/Components/Lists/AuctionResultListItem"
 import { RouterLink } from "app/system/navigation/RouterLink"
@@ -246,5 +246,93 @@ describe("AuctionResults", () => {
 
     expect(mockOnPress).toHaveBeenCalled()
     expect(navigate).not.toHaveBeenCalled()
+  })
+
+  describe("Image fallback behavior", () => {
+    it("falls back to .png when .jpg image fails to load", () => {
+      const tree = renderWithWrappersLEGACY(<TestRenderer />).root
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        Artist: () => ({
+          auctionResultsConnection: {
+            edges: [
+              {
+                node: {
+                  id: "an-id",
+                  internalID: "internal-id",
+                  images: {
+                    thumbnail: {
+                      url: "https://d2v80f5yrouhh2.cloudfront.net/test/thumbnail.jpg",
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        }),
+      })
+
+      const FastImage = require("@d11/react-native-fast-image").default
+      const fastImage = tree.findAllByType(FastImage)[0]
+
+      // Verify initial URL is .jpg
+      expect(fastImage.props.source.uri).toBe(
+        "https://d2v80f5yrouhh2.cloudfront.net/test/thumbnail.jpg"
+      )
+
+      // Simulate image load failure
+      act(() => {
+        fastImage.props.onError()
+      })
+
+      // Should now try .png
+      const updatedFastImage = tree.findAllByType(FastImage)[0]
+      expect(updatedFastImage.props.source.uri).toBe(
+        "https://d2v80f5yrouhh2.cloudfront.net/test/thumbnail.png"
+      )
+    })
+
+    it("shows NoArtIcon when both .jpg and .png fail to load", () => {
+      const tree = renderWithWrappersLEGACY(<TestRenderer />).root
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        Artist: () => ({
+          auctionResultsConnection: {
+            edges: [
+              {
+                node: {
+                  id: "an-id",
+                  internalID: "internal-id",
+                  images: {
+                    thumbnail: {
+                      url: "https://d2v80f5yrouhh2.cloudfront.net/test/thumbnail.jpg",
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        }),
+      })
+
+      const FastImage = require("@d11/react-native-fast-image").default
+      const NoArtIcon = require("@artsy/icons/native").NoArtIcon
+      const fastImage = tree.findAllByType(FastImage)[0]
+
+      // First failure (.jpg -> .png)
+      act(() => {
+        fastImage.props.onError()
+      })
+
+      // Get the newly rendered FastImage
+      const updatedFastImage = tree.findAllByType(FastImage)[0]
+
+      // Second failure (.png -> NoArtIcon)
+      act(() => {
+        updatedFastImage.props.onError()
+      })
+
+      // Should show NoArtIcon
+      const noArtIcon = tree.findAllByType(NoArtIcon)
+      expect(noArtIcon.length).toBe(1)
+    })
   })
 })


### PR DESCRIPTION
This PR resolves [DI-332](https://www.notion.so/373cab0764a0813ba530f6d1233461f1) <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes a bug where some auction result images were not displaying on staging on both ios and android - showing placeholders icons instead. The issue only affected some auction results while others loaded fine. While the image URLs were all correct, when the app attempted to load images with .jpg extensions, CloudFront returned 403 AccessDenied errors because the actual files stored in the S3 bucket were actually .png files.

This is likely due to a mismatch between the image data/extension that Metaphysics is returning and the actual images being stored in S3, and the app is trying to load image files with the wrong extension. This fix adds a client-side fallback that tries loading the .png version if the .jpg fails, so images display correctly regardless of this potential mismatch.

Follow up: This may require additional changes in gravity / diffusion 

| Platform | Before | After |
|---|---|---|
| Android | <img src="https://github.com/user-attachments/assets/56682fe6-bbb7-4af0-bc79-6dde46b76c3c" width="200" /> | <img src="https://github.com/user-attachments/assets/019512c9-8f1d-4017-a968-268d10e00526" width="200" /> |
| iOS | <img src="https://github.com/user-attachments/assets/e0da465f-6c25-49ef-933e-1931ccef0eaf" width="200" /> | <img src="https://github.com/user-attachments/assets/3fc1ef8f-9e14-4bea-b674-f1ef0dd73039" width="200" /> |



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="https://github.com/user-attachments/assets/56682fe6-bbb7-4af0-bc79-6dde46b76c3c" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Adds fallback for auction result images 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
