### PR TITLE
feat: add latest-remote-fingerprint script

### DIFF
--- a/fingerprint.config.js
+++ b/fingerprint.config.js
@@ -1,6 +1,10 @@
 /** @type {import('@expo/fingerprint').Config} */
 const config = {
-  sourceSkips: ["ExpoConfigRuntimeVersionIfString", "ExpoConfigVersions"],
+  sourceSkips: [
+    "ExpoConfigRuntimeVersionIfString",
+    "ExpoConfigVersions",
+    "PackageJsonAndroidAndIosScriptsIfNotContainRun",
+  ],
   ignorePaths: [
     // Android build artifacts (everywhere including inside node_modules)
     "**/android/build/**/*",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "route-drift": "tsx scripts/route-drift/generate.ts",
     "navigate-to-route": "./scripts/utils/navigate-to-route",
     "navigate-to-route-android": "./scripts/utils/navigate-to-route-android",
+    "latest-remote-fingerprint": "./scripts/utils/latest-remote-fingerprint",
     "init-metaflags": "jq -Rn '{ }' | sponge metaflags.json",
     "install:all": "./scripts/setup/install",
     "ios:no-cache": "react-native run-ios --udid=\"$(xcrun simctl list | awk -F'[()]' '/(Booted)/ { print $2 }')\"",

--- a/scripts/utils/latest-remote-fingerprint
+++ b/scripts/utils/latest-remote-fingerprint
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Prints the fingerprint that CI last cached a native build for (without downloading a local copy).
+# Use this to check the remote value of the latest fingerprint.
+aws s3 cp s3://mobile-cached-builds/eigen-expo-fingerprint/latest.txt -


### PR DESCRIPTION
This PR resolves [PHIRE-3395] <!-- eg [PROJECT-XXXX] -->

### Description

Adds `yarn latest-remote-fingerprint` script that prints out the state of latest.txt fingerprint from s3 now that we no longer save it in app.json so we can easily compare and debug in case of issues.

Also adds `PackageJsonAndroidAndIosScriptsIfNotContainRun` to fingerprint ignore: _package.json scripts if android and ios items do not contain "run". Because prebuild will change the scripts in package.json, this is useful to generate a consistent fingerprint before and after prebuild._

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- add latest-remote-fingerprint script for debugging

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3395]: https://artsyproduct.atlassian.net/browse/PHIRE-3395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ