### PR TITLE
fix(PHIRE-3333): Add expo-update ID to segment events when used

### DIFF
--- a/src/app/utils/track/AddExpoUpdateIdPlugin.ts
+++ b/src/app/utils/track/AddExpoUpdateIdPlugin.ts
@@ -10,7 +10,7 @@ export class AddExpoUpdateIdPlugin extends Plugin {
     }
 
     event.context = event.context || {}
-    const app = { ...(event.context.app || {}), updateId: Updates.updateId }
+    const app = { ...(event.context.app || {}), expoUpdateId: Updates.updateId }
     event.context.app = app
 
     return event

--- a/src/app/utils/track/AddExpoUpdateIdPlugin.ts
+++ b/src/app/utils/track/AddExpoUpdateIdPlugin.ts
@@ -1,0 +1,18 @@
+import { Plugin, PluginType, SegmentEvent } from "@segment/analytics-react-native"
+import * as Updates from "expo-updates"
+
+export class AddExpoUpdateIdPlugin extends Plugin {
+  type = PluginType.enrichment
+
+  async execute(event: SegmentEvent) {
+    if (Updates.isEmbeddedLaunch || !Updates.updateId) {
+      return event
+    }
+
+    event.context = event.context || {}
+    const app = { ...(event.context.app || {}), updateId: Updates.updateId }
+    event.context.app = app
+
+    return event
+  }
+}

--- a/src/app/utils/track/SegmentTrackingProvider.ts
+++ b/src/app/utils/track/SegmentTrackingProvider.ts
@@ -2,6 +2,7 @@ import { SegmentClient, createClient } from "@segment/analytics-react-native"
 import { BrazePlugin } from "@segment/analytics-react-native-plugin-braze"
 import { addBreadcrumb } from "@sentry/react-native"
 import { AddAppNamePlugin } from "app/utils/track/AddAppNamePlugin"
+import { AddExpoUpdateIdPlugin } from "app/utils/track/AddExpoUpdateIdPlugin"
 import { visualize } from "app/utils/visualizer"
 import { Platform } from "react-native"
 import Keys from "react-native-keys"
@@ -33,6 +34,7 @@ export const SegmentTrackingProvider: TrackingProvider = {
     analytics = createClient({ writeKey: writeKey })
     analytics.add({ plugin: new BrazePlugin() })
     analytics.add({ plugin: new AddAppNamePlugin() })
+    analytics.add({ plugin: new AddExpoUpdateIdPlugin() })
   },
 
   identify: (userId, traits) => {

--- a/src/app/utils/track/__tests__/AddExpoUpdateIdPlugin.tests.ts
+++ b/src/app/utils/track/__tests__/AddExpoUpdateIdPlugin.tests.ts
@@ -22,7 +22,7 @@ describe("AddExpoUpdateIdPlugin", () => {
 
     const result = await plugin.execute(event as any)
 
-    expect(result?.context?.app).toEqual({ updateId: "aaaa-bbbb-cccc" })
+    expect(result?.context?.app).toEqual({ expoUpdateId: "aaaa-bbbb-cccc" })
   })
 
   it("does not add an update id when running the embedded bundle", async () => {
@@ -42,7 +42,7 @@ describe("AddExpoUpdateIdPlugin", () => {
     expect(result?.context?.app).toEqual({
       name: "eigen",
       version: "9.16.0",
-      updateId: "aaaa-bbbb-cccc",
+      expoUpdateId: "aaaa-bbbb-cccc",
     })
   })
 
@@ -51,7 +51,7 @@ describe("AddExpoUpdateIdPlugin", () => {
 
     const result = await plugin.execute(event as any)
 
-    expect(result?.context?.app).toEqual({ updateId: "aaaa-bbbb-cccc" })
+    expect(result?.context?.app).toEqual({ expoUpdateId: "aaaa-bbbb-cccc" })
   })
 })
 

--- a/src/app/utils/track/__tests__/AddExpoUpdateIdPlugin.tests.ts
+++ b/src/app/utils/track/__tests__/AddExpoUpdateIdPlugin.tests.ts
@@ -1,0 +1,61 @@
+jest.mock("expo-updates", () => ({
+  get isEmbeddedLaunch() {
+    return mockUpdates.isEmbeddedLaunch
+  },
+  get updateId() {
+    return mockUpdates.updateId
+  },
+}))
+
+import { AddExpoUpdateIdPlugin } from "app/utils/track/AddExpoUpdateIdPlugin"
+
+describe("AddExpoUpdateIdPlugin", () => {
+  beforeEach(() => {
+    mockUpdates.isEmbeddedLaunch = false
+    mockUpdates.updateId = "aaaa-bbbb-cccc"
+  })
+
+  const plugin = new AddExpoUpdateIdPlugin()
+
+  it("adds the expo update id to context.app when an OTA update is running", async () => {
+    const event = { context: {} }
+
+    const result = await plugin.execute(event as any)
+
+    expect(result?.context?.app).toEqual({ updateId: "aaaa-bbbb-cccc" })
+  })
+
+  it("does not add an update id when running the embedded bundle", async () => {
+    mockUpdates.isEmbeddedLaunch = true
+    const event = { context: {} }
+
+    const result = await plugin.execute(event as any)
+
+    expect(result?.context?.app).toBeUndefined()
+  })
+
+  it("preserves existing context.app keys", async () => {
+    const event = { context: { app: { name: "eigen", version: "9.16.0" } } }
+
+    const result = await plugin.execute(event as any)
+
+    expect(result?.context?.app).toEqual({
+      name: "eigen",
+      version: "9.16.0",
+      updateId: "aaaa-bbbb-cccc",
+    })
+  })
+
+  it("does not throw when the event has no context", async () => {
+    const event = {}
+
+    const result = await plugin.execute(event as any)
+
+    expect(result?.context?.app).toEqual({ updateId: "aaaa-bbbb-cccc" })
+  })
+})
+
+const mockUpdates: any = {
+  isEmbeddedLaunch: false,
+  updateId: "aaaa-bbbb-cccc",
+}

--- a/src/setupJest.tsx
+++ b/src/setupJest.tsx
@@ -127,6 +127,8 @@ jest.mock("expo-updates", () => {
     fetchUpdateAsync: jest.fn(),
     checkForUpdateAsync: jest.fn(),
     reloadAsync: jest.fn(),
+    isEnabled: true,
+    isEmbeddedLaunch: false,
     channel: "channel",
     runtimeVersion: "runtimeVersion",
     updateId: "updateId",
@@ -392,6 +394,8 @@ jest.mock("@segment/analytics-react-native", () => ({
   setup: () => null,
   identify: () => null,
   reset: () => null,
+  Plugin: class Plugin {},
+  PluginType: { enrichment: "enrichment" },
 }))
 
 jest.mock("@segment/analytics-react-native-plugin-braze", () => ({}))


### PR DESCRIPTION
This PR resolves [PHIRE-3333] <!-- eg [PROJECT-XXXX] -->

### Description

This PR adds a new field for expo-update ID inside the app context in Segment analytics in case the app is using a hotfix from expo-update



### Screenshots (from segment)
| Android | iOS |
|---|---|
| <img width="482" height="369" alt="image" src="https://github.com/user-attachments/assets/b8d3c015-e489-4e6e-a0b3-d19b4fb30846" /> | <img width="510" height="450" alt="image" src="https://github.com/user-attachments/assets/d82e87ce-3a0d-4ba7-8e0f-8bb4729dfdc7" /> |




### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Add expoUpdateId in segment events if the app is using an expo-update bundle

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3333]: https://artsyproduct.atlassian.net/browse/PHIRE-3333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ