### PR TITLE
feat(search): add trending searches to global search overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
   },
   "dependencies": {
     "@artsy/changelog": "0.1.0",
-    "@artsy/cohesion": "4.390.0",
+    "@artsy/cohesion": "4.393.0",
     "@artsy/icons": "3.74.0",
     "@artsy/palette-mobile": "24.9.0",
     "@artsy/to-title-case": "1.2.0",

--- a/src/app/Components/GlobalSearchInput/GlobalSearchInputOverlay.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInputOverlay.tsx
@@ -11,8 +11,10 @@ import { SearchContext } from "app/Scenes/Search/SearchContext"
 import { useRecentSearches } from "app/Scenes/Search/SearchModel"
 import { SearchPills } from "app/Scenes/Search/SearchPills"
 import { SearchResults } from "app/Scenes/Search/SearchResults"
+import { TrendingSearches } from "app/Scenes/Search/TrendingSearches/TrendingSearches"
 import { SEARCH_PILLS } from "app/Scenes/Search/constants"
 import { useBackHandler } from "app/utils/hooks/useBackHandler"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { Suspense, useEffect, useState } from "react"
 import { ScrollView, StyleSheet } from "react-native"
 import { KeyboardController } from "react-native-keyboard-controller"
@@ -47,6 +49,26 @@ const GlobalSearchInputOverlayContent: React.FC<{ query: string }> = ({ query })
   } = useSearch({ query })
 
   const recentSearches = useRecentSearches()
+  const showTrendingSearches = useFeatureFlag("AREnableTrendingSearchesInSearchModal")
+
+  const renderIdleState = () => {
+    if (showTrendingSearches) {
+      return <TrendingSearches />
+    }
+
+    return (
+      <ScrollView
+        keyboardDismissMode="on-drag"
+        keyboardShouldPersistTaps="handled"
+        contentContainerStyle={{
+          paddingHorizontal: space(2),
+          paddingBottom: space(6),
+        }}
+      >
+        {recentSearches.length ? <RecentSearches /> : <GlobalSearchInputOverlayEmptyState />}
+      </ScrollView>
+    )
+  }
 
   return (
     <SearchContext.Provider value={searchProviderValues}>
@@ -71,16 +93,7 @@ const GlobalSearchInputOverlayContent: React.FC<{ query: string }> = ({ query })
           />
         </>
       ) : (
-        <ScrollView
-          keyboardDismissMode="on-drag"
-          keyboardShouldPersistTaps="handled"
-          contentContainerStyle={{
-            paddingHorizontal: space(2),
-            paddingBottom: space(6),
-          }}
-        >
-          {recentSearches.length ? <RecentSearches /> : <GlobalSearchInputOverlayEmptyState />}
-        </ScrollView>
+        renderIdleState()
       )}
     </SearchContext.Provider>
   )

--- a/src/app/Scenes/Search/TrendingSearches/TrendingSearches.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/TrendingSearches.tsx
@@ -1,5 +1,7 @@
+import { ActionType, ContextModule, OwnerType, type RailViewed } from "@artsy/cohesion"
 import { Flex, Join, Skeleton, SkeletonBox, SkeletonText, Spacer } from "@artsy/palette-mobile"
 import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs"
+import { useRecentSearches } from "app/Scenes/Search/SearchModel"
 import { RecentSearchesPillsRail } from "app/Scenes/Search/TrendingSearches/components/RecentSearchesPillsRail"
 import { TrendingArtistsAvatarsRail } from "app/Scenes/Search/TrendingSearches/components/TrendingArtistsAvatarsRail"
 import { TrendingArtworksRail } from "app/Scenes/Search/TrendingSearches/components/TrendingArtworksRail"
@@ -10,8 +12,9 @@ import {
 } from "app/Scenes/Search/TrendingSearches/useTrendingSearches"
 import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
 import { times } from "lodash"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { ScrollView } from "react-native"
+import { useTracking } from "react-tracking"
 
 export const TrendingSearches: React.FC = () => {
   const tabBarHeight = useBottomTabBarHeight()
@@ -34,6 +37,30 @@ export const TrendingSearches: React.FC = () => {
 const TrendingContent: React.FC = () => {
   const [period, setPeriod] = useState<TrendingPeriod>("ONE_DAY")
   const { artists, artworks } = useTrendingSearches(period)
+  const recentSearches = useRecentSearches()
+  const { trackEvent } = useTracking()
+
+  useEffect(() => {
+    const trackRailViewed = (contextModule: ContextModule) => {
+      const event: RailViewed = {
+        action: ActionType.railViewed,
+        context_module: contextModule,
+        context_screen: OwnerType.search,
+      }
+      trackEvent(event)
+    }
+
+    if (recentSearches.length > 0) {
+      trackRailViewed(ContextModule.recentSearchesRail)
+    }
+    if (artists.length > 0) {
+      trackRailViewed(ContextModule.trendingArtistsRail)
+    }
+    if (artworks.length > 0) {
+      trackRailViewed(ContextModule.trendingArtworksRail)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <Flex>

--- a/src/app/Scenes/Search/TrendingSearches/TrendingSearches.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/TrendingSearches.tsx
@@ -1,0 +1,98 @@
+import { Flex, Join, Skeleton, SkeletonBox, SkeletonText, Spacer } from "@artsy/palette-mobile"
+import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs"
+import { RecentSearchesPillsRail } from "app/Scenes/Search/TrendingSearches/components/RecentSearchesPillsRail"
+import { TrendingArtistsAvatarsRail } from "app/Scenes/Search/TrendingSearches/components/TrendingArtistsAvatarsRail"
+import { TrendingArtworksRail } from "app/Scenes/Search/TrendingSearches/components/TrendingArtworksRail"
+import { TrendingPeriodToggle } from "app/Scenes/Search/TrendingSearches/components/TrendingPeriodToggle"
+import {
+  TrendingPeriod,
+  useTrendingSearches,
+} from "app/Scenes/Search/TrendingSearches/useTrendingSearches"
+import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
+import { times } from "lodash"
+import { useState } from "react"
+import { ScrollView } from "react-native"
+
+export const TrendingSearches: React.FC = () => {
+  const tabBarHeight = useBottomTabBarHeight()
+
+  return (
+    <ScrollView
+      keyboardShouldPersistTaps="handled"
+      keyboardDismissMode="on-drag"
+      showsVerticalScrollIndicator={false}
+      contentContainerStyle={{ paddingBottom: tabBarHeight + 24 }}
+    >
+      <Join separator={<Spacer y={2} />}>
+        <RecentSearchesPillsRail />
+        <TrendingSection />
+      </Join>
+    </ScrollView>
+  )
+}
+
+const TrendingContent: React.FC = () => {
+  const [period, setPeriod] = useState<TrendingPeriod>("ONE_DAY")
+  const { artists, artworks } = useTrendingSearches(period)
+
+  return (
+    <Flex>
+      <Join separator={<Spacer y={2} />}>
+        <TrendingArtistsAvatarsRail artists={artists} />
+        <TrendingArtworksRail artworks={artworks} />
+        <TrendingPeriodToggle value={period} onChange={setPeriod} />
+      </Join>
+    </Flex>
+  )
+}
+
+const TrendingSection = withSuspense({
+  Component: TrendingContent,
+  LoadingFallback: () => <TrendingPlaceholder />,
+  ErrorFallback: NoFallback,
+})
+
+const AVATAR_SIZE = 68
+const AVATAR_ITEM_WIDTH = 80
+const AVATAR_ITEM_COUNT = 4
+const RAIL_CARD_HEIGHT = 215
+const RAIL_CARD_WIDTH = 240
+const RAIL_CARD_COUNT = 3
+
+const TrendingPlaceholder: React.FC = () => (
+  <Skeleton>
+    <Flex>
+      <SkeletonText variant="sm-display" mx={2} mb={2}>
+        Trending Artists
+      </SkeletonText>
+
+      <Flex flexDirection="row" px={2} gap={1}>
+        {times(AVATAR_ITEM_COUNT).map((index) => (
+          <Flex key={index} alignItems="center" width={AVATAR_ITEM_WIDTH}>
+            <SkeletonBox width={AVATAR_SIZE} height={AVATAR_SIZE} borderRadius={AVATAR_SIZE / 2} />
+            <Spacer y={0.5} />
+            <SkeletonText variant="xs">Artist Name</SkeletonText>
+          </Flex>
+        ))}
+      </Flex>
+
+      <Spacer y={2} />
+
+      <SkeletonText variant="sm-display" mx={2} mb={2}>
+        Trending Artworks
+      </SkeletonText>
+
+      <Flex flexDirection="row" px={2} gap={2}>
+        {times(RAIL_CARD_COUNT).map((index) => (
+          <Flex key={index} width={RAIL_CARD_WIDTH}>
+            <SkeletonBox width={RAIL_CARD_WIDTH} height={RAIL_CARD_HEIGHT} />
+            <Spacer y={1} />
+            <SkeletonText variant="sm-display">Artist Name</SkeletonText>
+            <SkeletonText variant="xs">Title, Year</SkeletonText>
+            <SkeletonText variant="xs">Price</SkeletonText>
+          </Flex>
+        ))}
+      </Flex>
+    </Flex>
+  </Skeleton>
+)

--- a/src/app/Scenes/Search/TrendingSearches/TrendingSearches.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/TrendingSearches.tsx
@@ -1,23 +1,29 @@
 import { ActionType, ContextModule, OwnerType, type RailViewed } from "@artsy/cohesion"
 import { Flex, Join, Skeleton, SkeletonBox, SkeletonText, Spacer } from "@artsy/palette-mobile"
 import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs"
-import { useRecentSearches } from "app/Scenes/Search/SearchModel"
+import { ARTWORK_RAIL_CARD_IMAGE_HEIGHT } from "app/Components/ArtworkRail/ArtworkRailCardImage"
 import { RecentSearchesPillsRail } from "app/Scenes/Search/TrendingSearches/components/RecentSearchesPillsRail"
 import { TrendingArtistsAvatarsRail } from "app/Scenes/Search/TrendingSearches/components/TrendingArtistsAvatarsRail"
 import { TrendingArtworksRail } from "app/Scenes/Search/TrendingSearches/components/TrendingArtworksRail"
 import { TrendingPeriodToggle } from "app/Scenes/Search/TrendingSearches/components/TrendingPeriodToggle"
+import { AVATAR_ITEM_WIDTH, AVATAR_SIZE } from "app/Scenes/Search/TrendingSearches/constants"
 import {
   TrendingPeriod,
   useTrendingSearches,
 } from "app/Scenes/Search/TrendingSearches/useTrendingSearches"
 import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
 import { times } from "lodash"
-import { useEffect, useState } from "react"
+import { startTransition, useEffect, useState } from "react"
 import { ScrollView } from "react-native"
 import { useTracking } from "react-tracking"
 
 export const TrendingSearches: React.FC = () => {
   const tabBarHeight = useBottomTabBarHeight()
+  const [period, setPeriod] = useState<TrendingPeriod>("ONE_DAY")
+
+  const handlePeriodChange = (next: TrendingPeriod) => {
+    startTransition(() => setPeriod(next))
+  }
 
   return (
     <ScrollView
@@ -28,16 +34,15 @@ export const TrendingSearches: React.FC = () => {
     >
       <Join separator={<Spacer y={2} />}>
         <RecentSearchesPillsRail />
-        <TrendingSection />
+        <TrendingSection period={period} />
+        <TrendingPeriodToggle value={period} onChange={handlePeriodChange} />
       </Join>
     </ScrollView>
   )
 }
 
-const TrendingContent: React.FC = () => {
-  const [period, setPeriod] = useState<TrendingPeriod>("ONE_DAY")
+const TrendingContent: React.FC<{ period: TrendingPeriod }> = ({ period }) => {
   const { artists, artworks } = useTrendingSearches(period)
-  const recentSearches = useRecentSearches()
   const { trackEvent } = useTracking()
 
   useEffect(() => {
@@ -50,9 +55,6 @@ const TrendingContent: React.FC = () => {
       trackEvent(event)
     }
 
-    if (recentSearches.length > 0) {
-      trackRailViewed(ContextModule.recentSearchesRail)
-    }
     if (artists.length > 0) {
       trackRailViewed(ContextModule.trendingArtistsRail)
     }
@@ -67,7 +69,6 @@ const TrendingContent: React.FC = () => {
       <Join separator={<Spacer y={2} />}>
         <TrendingArtistsAvatarsRail artists={artists} />
         <TrendingArtworksRail artworks={artworks} />
-        <TrendingPeriodToggle value={period} onChange={setPeriod} />
       </Join>
     </Flex>
   )
@@ -79,10 +80,7 @@ const TrendingSection = withSuspense({
   ErrorFallback: NoFallback,
 })
 
-const AVATAR_SIZE = 68
-const AVATAR_ITEM_WIDTH = 80
 const AVATAR_ITEM_COUNT = 4
-const RAIL_CARD_HEIGHT = 215
 const RAIL_CARD_WIDTH = 240
 const RAIL_CARD_COUNT = 3
 
@@ -112,7 +110,7 @@ const TrendingPlaceholder: React.FC = () => (
       <Flex flexDirection="row" px={2} gap={2}>
         {times(RAIL_CARD_COUNT).map((index) => (
           <Flex key={index} width={RAIL_CARD_WIDTH}>
-            <SkeletonBox width={RAIL_CARD_WIDTH} height={RAIL_CARD_HEIGHT} />
+            <SkeletonBox width={RAIL_CARD_WIDTH} height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT} />
             <Spacer y={1} />
             <SkeletonText variant="sm-display">Artist Name</SkeletonText>
             <SkeletonText variant="xs">Title, Year</SkeletonText>

--- a/src/app/Scenes/Search/TrendingSearches/__tests__/TrendingSearches.tests.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/__tests__/TrendingSearches.tests.tsx
@@ -1,0 +1,29 @@
+import { screen } from "@testing-library/react-native"
+import { useTrendingSearchesQuery } from "__generated__/useTrendingSearchesQuery.graphql"
+import { TrendingSearches } from "app/Scenes/Search/TrendingSearches/TrendingSearches"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+
+jest.mock("@react-navigation/bottom-tabs", () => ({
+  ...jest.requireActual("@react-navigation/bottom-tabs"),
+  useBottomTabBarHeight: () => 0,
+}))
+
+const { renderWithRelay } = setupTestWrapper<useTrendingSearchesQuery>({
+  Component: TrendingSearches,
+})
+
+describe("TrendingSearches", () => {
+  it("renders trending artists and artworks with the period toggle", async () => {
+    renderWithRelay({
+      Artist: () => ({ internalID: "banksy", name: "Banksy", href: "/artist/banksy" }),
+    })
+
+    await screen.findByText("Banksy")
+
+    expect(screen.getByText("Trending Artists")).toBeOnTheScreen()
+    expect(screen.getByText("Trending Artworks")).toBeOnTheScreen()
+
+    expect(screen.getByRole("button", { selected: true, name: "Today" })).toBeOnTheScreen()
+    expect(screen.getByRole("button", { selected: false, name: "Past 7 Days" })).toBeOnTheScreen()
+  })
+})

--- a/src/app/Scenes/Search/TrendingSearches/components/RecentSearchesPillsRail.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/RecentSearchesPillsRail.tsx
@@ -1,3 +1,4 @@
+import { ActionType, ContextModule, OwnerType, type RailViewed } from "@artsy/cohesion"
 import { CloseIcon } from "@artsy/icons/native"
 import { Flex, Text, Touchable, useSpace } from "@artsy/palette-mobile"
 import { AutosuggestResult } from "app/Components/AutosuggestResults/AutosuggestResults"
@@ -8,7 +9,7 @@ import { TrendingSectionHeader } from "app/Scenes/Search/TrendingSearches/compon
 import { GlobalStore } from "app/store/GlobalStore"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { Schema } from "app/utils/track"
-import { useContext } from "react"
+import { useContext, useEffect } from "react"
 import { FlatList } from "react-native"
 import { useTracking } from "react-tracking"
 
@@ -18,8 +19,21 @@ const PILL_MAX_WIDTH = 220
 export const RecentSearchesPillsRail: React.FC = () => {
   const space = useSpace()
   const recentSearches = useRecentSearches()
+  const { trackEvent } = useTracking()
+  const hasRecentSearches = recentSearches.length > 0
 
-  if (!recentSearches.length) {
+  useEffect(() => {
+    if (!hasRecentSearches) return
+    const event: RailViewed = {
+      action: ActionType.railViewed,
+      context_module: ContextModule.recentSearchesRail,
+      context_screen: OwnerType.search,
+    }
+    trackEvent(event)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  if (!hasRecentSearches) {
     return null
   }
 

--- a/src/app/Scenes/Search/TrendingSearches/components/RecentSearchesPillsRail.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/RecentSearchesPillsRail.tsx
@@ -2,11 +2,15 @@ import { CloseIcon } from "@artsy/icons/native"
 import { Flex, Text, Touchable, useSpace } from "@artsy/palette-mobile"
 import { AutosuggestResult } from "app/Components/AutosuggestResults/AutosuggestResults"
 import { ImageWithFallback } from "app/Components/ImageWithFallback/ImageWithFallback"
+import { SearchContext } from "app/Scenes/Search/SearchContext"
 import { useRecentSearches } from "app/Scenes/Search/SearchModel"
 import { TrendingSectionHeader } from "app/Scenes/Search/TrendingSearches/components/TrendingSectionHeader"
 import { GlobalStore } from "app/store/GlobalStore"
 import { RouterLink } from "app/system/navigation/RouterLink"
+import { Schema } from "app/utils/track"
+import { useContext } from "react"
 import { FlatList } from "react-native"
+import { useTracking } from "react-tracking"
 
 const AVATAR_SIZE = 26
 const PILL_MAX_WIDTH = 220
@@ -41,8 +45,21 @@ export const RecentSearchesPillsRail: React.FC = () => {
 }
 
 const RecentSearchPill: React.FC<{ result: AutosuggestResult }> = ({ result }) => {
+  const { trackEvent } = useTracking()
+  const searchContext = useContext(SearchContext)
+
+  const handlePress = () => {
+    trackEvent({
+      action_type: Schema.ActionNames.ARAnalyticsSearchRecentItemSelected,
+      // @ts-expect-error queryRef is loosely typed in SearchContext
+      query: searchContext?.queryRef?.current ?? "",
+      selected_object_type: result.displayType || result.__typename,
+      selected_object_slug: result.slug,
+    })
+  }
+
   return (
-    <RouterLink to={result.href}>
+    <RouterLink to={result.href} onPress={handlePress}>
       <Flex
         flexDirection="row"
         alignItems="center"

--- a/src/app/Scenes/Search/TrendingSearches/components/RecentSearchesPillsRail.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/RecentSearchesPillsRail.tsx
@@ -1,0 +1,83 @@
+import { CloseIcon } from "@artsy/icons/native"
+import { Flex, Text, Touchable, useSpace } from "@artsy/palette-mobile"
+import { AutosuggestResult } from "app/Components/AutosuggestResults/AutosuggestResults"
+import { ImageWithFallback } from "app/Components/ImageWithFallback/ImageWithFallback"
+import { useRecentSearches } from "app/Scenes/Search/SearchModel"
+import { TrendingSectionHeader } from "app/Scenes/Search/TrendingSearches/components/TrendingSectionHeader"
+import { GlobalStore } from "app/store/GlobalStore"
+import { RouterLink } from "app/system/navigation/RouterLink"
+import { FlatList } from "react-native"
+
+const AVATAR_SIZE = 26
+const PILL_MAX_WIDTH = 220
+
+export const RecentSearchesPillsRail: React.FC = () => {
+  const space = useSpace()
+  const recentSearches = useRecentSearches()
+
+  if (!recentSearches.length) {
+    return null
+  }
+
+  return (
+    <Flex>
+      <TrendingSectionHeader
+        title="Recent Searches"
+        actionLabel="Clear"
+        onActionPress={() => GlobalStore.actions.search.clearRecentSearches()}
+      />
+
+      <FlatList
+        horizontal
+        data={recentSearches}
+        keyboardShouldPersistTaps="handled"
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{ paddingHorizontal: space(2), gap: space(1) }}
+        keyExtractor={(item, index) => `${index}-${item.props.href}`}
+        renderItem={({ item }) => <RecentSearchPill result={item.props} />}
+      />
+    </Flex>
+  )
+}
+
+const RecentSearchPill: React.FC<{ result: AutosuggestResult }> = ({ result }) => {
+  return (
+    <RouterLink to={result.href}>
+      <Flex
+        flexDirection="row"
+        alignItems="center"
+        backgroundColor="mono5"
+        borderRadius={20}
+        pl={0.5}
+        pr={0.5}
+        py={0.5}
+        maxWidth={PILL_MAX_WIDTH}
+      >
+        <Flex
+          width={AVATAR_SIZE}
+          height={AVATAR_SIZE}
+          borderRadius={AVATAR_SIZE / 2}
+          overflow="hidden"
+          backgroundColor="mono10"
+        >
+          <ImageWithFallback src={result.imageUrl} width={AVATAR_SIZE} height={AVATAR_SIZE} />
+        </Flex>
+
+        <Text variant="xs" numberOfLines={1} mx={1} style={{ flexShrink: 1 }}>
+          {result.displayLabel}
+        </Text>
+
+        <Touchable
+          accessibilityRole="button"
+          accessibilityLabel={`Remove ${result.displayLabel} from recent searches`}
+          hitSlop={{ top: 12, bottom: 12, left: 8, right: 12 }}
+          onPress={() => GlobalStore.actions.search.deleteRecentSearch(result)}
+        >
+          <Flex width={22} height={22} alignItems="center" justifyContent="center">
+            <CloseIcon width={14} height={14} fill="mono60" />
+          </Flex>
+        </Touchable>
+      </Flex>
+    </RouterLink>
+  )
+}

--- a/src/app/Scenes/Search/TrendingSearches/components/TrendingArtistsAvatarsRail.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/TrendingArtistsAvatarsRail.tsx
@@ -1,9 +1,11 @@
+import { ActionType, ContextModule, OwnerType, type TappedArtistGroup } from "@artsy/cohesion"
 import { Flex, Text, useSpace } from "@artsy/palette-mobile"
 import { ImageWithFallback } from "app/Components/ImageWithFallback/ImageWithFallback"
 import { TrendingSectionHeader } from "app/Scenes/Search/TrendingSearches/components/TrendingSectionHeader"
 import { TrendingArtist } from "app/Scenes/Search/TrendingSearches/useTrendingSearches"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { FlatList } from "react-native"
+import { useTracking } from "react-tracking"
 
 const AVATAR_SIZE = 68
 const ITEM_WIDTH = 80
@@ -18,9 +20,24 @@ export const TrendingArtistsAvatarsRail: React.FC<TrendingArtistsAvatarsRailProp
   title = "Trending Artists",
 }) => {
   const space = useSpace()
+  const { trackEvent } = useTracking()
 
   if (!artists.length) {
     return null
+  }
+
+  const handleArtistPress = (artist: TrendingArtist, index: number) => {
+    const event: TappedArtistGroup = {
+      action: ActionType.tappedArtistGroup,
+      context_module: ContextModule.trendingArtistsRail,
+      context_screen_owner_type: OwnerType.search,
+      destination_screen_owner_type: OwnerType.artist,
+      destination_screen_owner_id: artist.internalID,
+      destination_screen_owner_slug: artist.slug,
+      horizontal_slide_position: index,
+      type: "thumbnail",
+    }
+    trackEvent(event)
   }
 
   return (
@@ -34,8 +51,12 @@ export const TrendingArtistsAvatarsRail: React.FC<TrendingArtistsAvatarsRailProp
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={{ paddingHorizontal: space(2), gap: space(1) }}
         keyExtractor={(artist) => artist.internalID}
-        renderItem={({ item: artist }) => (
-          <RouterLink to={artist.href} style={{ width: ITEM_WIDTH }}>
+        renderItem={({ item: artist, index }) => (
+          <RouterLink
+            to={artist.href}
+            style={{ width: ITEM_WIDTH }}
+            onPress={() => handleArtistPress(artist, index)}
+          >
             <Flex alignItems="center">
               <Flex
                 width={AVATAR_SIZE}

--- a/src/app/Scenes/Search/TrendingSearches/components/TrendingArtistsAvatarsRail.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/TrendingArtistsAvatarsRail.tsx
@@ -2,13 +2,11 @@ import { ActionType, ContextModule, OwnerType, type TappedArtistGroup } from "@a
 import { Flex, Text, useSpace } from "@artsy/palette-mobile"
 import { ImageWithFallback } from "app/Components/ImageWithFallback/ImageWithFallback"
 import { TrendingSectionHeader } from "app/Scenes/Search/TrendingSearches/components/TrendingSectionHeader"
+import { AVATAR_ITEM_WIDTH, AVATAR_SIZE } from "app/Scenes/Search/TrendingSearches/constants"
 import { TrendingArtist } from "app/Scenes/Search/TrendingSearches/useTrendingSearches"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { FlatList } from "react-native"
 import { useTracking } from "react-tracking"
-
-const AVATAR_SIZE = 68
-const ITEM_WIDTH = 80
 
 interface TrendingArtistsAvatarsRailProps {
   artists: TrendingArtist[]
@@ -54,7 +52,7 @@ export const TrendingArtistsAvatarsRail: React.FC<TrendingArtistsAvatarsRailProp
         renderItem={({ item: artist, index }) => (
           <RouterLink
             to={artist.href}
-            style={{ width: ITEM_WIDTH }}
+            style={{ width: AVATAR_ITEM_WIDTH }}
             onPress={() => handleArtistPress(artist, index)}
           >
             <Flex alignItems="center">

--- a/src/app/Scenes/Search/TrendingSearches/components/TrendingArtistsAvatarsRail.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/TrendingArtistsAvatarsRail.tsx
@@ -1,0 +1,64 @@
+import { Flex, Text, useSpace } from "@artsy/palette-mobile"
+import { ImageWithFallback } from "app/Components/ImageWithFallback/ImageWithFallback"
+import { TrendingSectionHeader } from "app/Scenes/Search/TrendingSearches/components/TrendingSectionHeader"
+import { TrendingArtist } from "app/Scenes/Search/TrendingSearches/useTrendingSearches"
+import { RouterLink } from "app/system/navigation/RouterLink"
+import { FlatList } from "react-native"
+
+const AVATAR_SIZE = 68
+const ITEM_WIDTH = 80
+
+interface TrendingArtistsAvatarsRailProps {
+  artists: TrendingArtist[]
+  title?: string
+}
+
+export const TrendingArtistsAvatarsRail: React.FC<TrendingArtistsAvatarsRailProps> = ({
+  artists,
+  title = "Trending Artists",
+}) => {
+  const space = useSpace()
+
+  if (!artists.length) {
+    return null
+  }
+
+  return (
+    <Flex>
+      <TrendingSectionHeader title={title} />
+
+      <FlatList
+        horizontal
+        data={artists}
+        keyboardShouldPersistTaps="handled"
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{ paddingHorizontal: space(2), gap: space(1) }}
+        keyExtractor={(artist) => artist.internalID}
+        renderItem={({ item: artist }) => (
+          <RouterLink to={artist.href} style={{ width: ITEM_WIDTH }}>
+            <Flex alignItems="center">
+              <Flex
+                width={AVATAR_SIZE}
+                height={AVATAR_SIZE}
+                borderRadius={AVATAR_SIZE / 2}
+                overflow="hidden"
+                backgroundColor="mono10"
+              >
+                <ImageWithFallback
+                  src={artist.coverArtwork?.image?.url}
+                  blurhash={artist.coverArtwork?.image?.blurhash}
+                  width={AVATAR_SIZE}
+                  height={AVATAR_SIZE}
+                />
+              </Flex>
+
+              <Text variant="xs" numberOfLines={2} textAlign="center" mt={0.5}>
+                {artist.name}
+              </Text>
+            </Flex>
+          </RouterLink>
+        )}
+      />
+    </Flex>
+  )
+}

--- a/src/app/Scenes/Search/TrendingSearches/components/TrendingArtworksRail.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/TrendingArtworksRail.tsx
@@ -1,0 +1,21 @@
+import { Flex } from "@artsy/palette-mobile"
+import { ArtworkRail_artworks$key } from "__generated__/ArtworkRail_artworks.graphql"
+import { ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
+import { TrendingSectionHeader } from "app/Scenes/Search/TrendingSearches/components/TrendingSectionHeader"
+
+interface TrendingArtworksRailProps {
+  artworks: ArtworkRail_artworks$key
+  title?: string
+}
+
+export const TrendingArtworksRail: React.FC<TrendingArtworksRailProps> = ({
+  artworks,
+  title = "Trending Artworks",
+}) => {
+  return (
+    <Flex>
+      <TrendingSectionHeader title={title} />
+      <ArtworkRail artworks={artworks} showSaveIcon />
+    </Flex>
+  )
+}

--- a/src/app/Scenes/Search/TrendingSearches/components/TrendingArtworksRail.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/TrendingArtworksRail.tsx
@@ -1,3 +1,4 @@
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { Flex } from "@artsy/palette-mobile"
 import { ArtworkRail_artworks$key } from "__generated__/ArtworkRail_artworks.graphql"
 import { ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
@@ -15,7 +16,12 @@ export const TrendingArtworksRail: React.FC<TrendingArtworksRailProps> = ({
   return (
     <Flex>
       <TrendingSectionHeader title={title} />
-      <ArtworkRail artworks={artworks} showSaveIcon />
+      <ArtworkRail
+        artworks={artworks}
+        showSaveIcon
+        contextModule={ContextModule.trendingArtworksRail}
+        contextScreenOwnerType={OwnerType.search}
+      />
     </Flex>
   )
 }

--- a/src/app/Scenes/Search/TrendingSearches/components/TrendingArtworksRail.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/TrendingArtworksRail.tsx
@@ -13,6 +13,10 @@ export const TrendingArtworksRail: React.FC<TrendingArtworksRailProps> = ({
   artworks,
   title = "Trending Artworks",
 }) => {
+  if (!artworks.length) {
+    return null
+  }
+
   return (
     <Flex>
       <TrendingSectionHeader title={title} />

--- a/src/app/Scenes/Search/TrendingSearches/components/TrendingPeriodToggle.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/TrendingPeriodToggle.tsx
@@ -1,5 +1,7 @@
+import { ActionType, ContextModule, OwnerType, type TappedNavigationTab } from "@artsy/cohesion"
 import { Flex, Text, Touchable, useSpace } from "@artsy/palette-mobile"
 import { TrendingPeriod } from "app/Scenes/Search/TrendingSearches/useTrendingSearches"
+import { useTracking } from "react-tracking"
 
 const PERIOD_OPTIONS: readonly { period: TrendingPeriod; label: string }[] = [
   { period: "ONE_DAY", label: "Today" },
@@ -14,6 +16,20 @@ interface TrendingPeriodToggleProps {
 
 export const TrendingPeriodToggle: React.FC<TrendingPeriodToggleProps> = ({ value, onChange }) => {
   const space = useSpace()
+  const { trackEvent } = useTracking()
+
+  const handlePress = (period: TrendingPeriod, label: string) => {
+    if (period !== value) {
+      const event: TappedNavigationTab = {
+        action: ActionType.tappedNavigationTab,
+        context_module: ContextModule.trendingSearches,
+        context_screen_owner_type: OwnerType.search,
+        subject: label,
+      }
+      trackEvent(event)
+    }
+    onChange(period)
+  }
 
   return (
     <Flex
@@ -34,7 +50,7 @@ export const TrendingPeriodToggle: React.FC<TrendingPeriodToggleProps> = ({ valu
             accessibilityRole="button"
             accessibilityState={{ selected }}
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-            onPress={() => onChange(period)}
+            onPress={() => handlePress(period, label)}
           >
             <Flex
               px={1}

--- a/src/app/Scenes/Search/TrendingSearches/components/TrendingPeriodToggle.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/TrendingPeriodToggle.tsx
@@ -1,0 +1,54 @@
+import { Flex, Text, Touchable, useSpace } from "@artsy/palette-mobile"
+import { TrendingPeriod } from "app/Scenes/Search/TrendingSearches/useTrendingSearches"
+
+const PERIOD_OPTIONS: readonly { period: TrendingPeriod; label: string }[] = [
+  { period: "ONE_DAY", label: "Today" },
+  { period: "SEVEN_DAYS", label: "Past 7 Days" },
+  { period: "THIRTY_DAYS", label: "Past 30 Days" },
+]
+
+interface TrendingPeriodToggleProps {
+  value: TrendingPeriod
+  onChange: (period: TrendingPeriod) => void
+}
+
+export const TrendingPeriodToggle: React.FC<TrendingPeriodToggleProps> = ({ value, onChange }) => {
+  const space = useSpace()
+
+  return (
+    <Flex
+      flexDirection="row"
+      alignItems="center"
+      justifyContent="flex-end"
+      gap={1}
+      pt={1}
+      pb={2}
+      style={{ paddingHorizontal: space(2) }}
+    >
+      {PERIOD_OPTIONS.map(({ period, label }) => {
+        const selected = period === value
+
+        return (
+          <Touchable
+            key={period}
+            accessibilityRole="button"
+            accessibilityState={{ selected }}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            onPress={() => onChange(period)}
+          >
+            <Flex
+              px={1}
+              py={0.5}
+              borderRadius={16}
+              backgroundColor={selected ? "mono10" : "transparent"}
+            >
+              <Text variant="xs" color={selected ? "mono100" : "mono60"}>
+                {label}
+              </Text>
+            </Flex>
+          </Touchable>
+        )
+      })}
+    </Flex>
+  )
+}

--- a/src/app/Scenes/Search/TrendingSearches/components/TrendingSectionHeader.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/TrendingSectionHeader.tsx
@@ -1,0 +1,31 @@
+import { Flex, Text, Touchable } from "@artsy/palette-mobile"
+
+interface TrendingSectionHeaderProps {
+  title: string
+  actionLabel?: string
+  onActionPress?: () => void
+}
+
+export const TrendingSectionHeader: React.FC<TrendingSectionHeaderProps> = ({
+  title,
+  actionLabel,
+  onActionPress,
+}) => {
+  return (
+    <Flex flexDirection="row" alignItems="center" justifyContent="space-between" mx={2} mb={2}>
+      <Text variant="sm-display">{title}</Text>
+
+      {!!actionLabel && !!onActionPress && (
+        <Touchable
+          accessibilityRole="button"
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          onPress={onActionPress}
+        >
+          <Text variant="xs" color="mono60">
+            {actionLabel}
+          </Text>
+        </Touchable>
+      )}
+    </Flex>
+  )
+}

--- a/src/app/Scenes/Search/TrendingSearches/components/__tests__/RecentSearchesPillsRail.tests.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/__tests__/RecentSearchesPillsRail.tests.tsx
@@ -1,0 +1,75 @@
+import { act, fireEvent, screen } from "@testing-library/react-native"
+import { RecentSearch } from "app/Scenes/Search/SearchModel"
+import { RecentSearchesPillsRail } from "app/Scenes/Search/TrendingSearches/components/RecentSearchesPillsRail"
+import { GlobalStore } from "app/store/GlobalStore"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+const [banksy, kaws]: RecentSearch[] = [
+  ["Banksy", "banksy"],
+  ["KAWS", "kaws"],
+].map(([name, slug]) => ({
+  type: "AUTOSUGGEST_RESULT_TAPPED",
+  props: {
+    displayLabel: name,
+    displayType: "Artist",
+    href: `https://artsy.com/artist/${slug}`,
+    imageUrl: "https://example.com/image.jpg",
+    __typename: "Artist",
+  },
+}))
+
+describe("RecentSearchesPillsRail", () => {
+  beforeEach(() => {
+    act(() => {
+      GlobalStore.actions.search.clearRecentSearches()
+    })
+  })
+
+  it("renders nothing when there are no recent searches", () => {
+    renderWithWrappers(<RecentSearchesPillsRail />)
+
+    expect(screen.queryByText("Recent Searches")).not.toBeOnTheScreen()
+  })
+
+  it("renders a pill per recent search", () => {
+    renderWithWrappers(<RecentSearchesPillsRail />)
+
+    act(() => {
+      GlobalStore.actions.search.addRecentSearch(banksy)
+      GlobalStore.actions.search.addRecentSearch(kaws)
+    })
+
+    expect(screen.getByText("Recent Searches")).toBeOnTheScreen()
+    expect(screen.getByText("Banksy")).toBeOnTheScreen()
+    expect(screen.getByText("KAWS")).toBeOnTheScreen()
+  })
+
+  it("removes a single search when its delete button is pressed", () => {
+    renderWithWrappers(<RecentSearchesPillsRail />)
+
+    act(() => {
+      GlobalStore.actions.search.addRecentSearch(banksy)
+      GlobalStore.actions.search.addRecentSearch(kaws)
+    })
+
+    fireEvent.press(screen.getByLabelText("Remove Banksy from recent searches"))
+
+    expect(screen.queryByText("Banksy")).not.toBeOnTheScreen()
+    expect(screen.getByText("KAWS")).toBeOnTheScreen()
+  })
+
+  it("clears all searches when the Clear action is pressed", () => {
+    renderWithWrappers(<RecentSearchesPillsRail />)
+
+    act(() => {
+      GlobalStore.actions.search.addRecentSearch(banksy)
+      GlobalStore.actions.search.addRecentSearch(kaws)
+    })
+
+    fireEvent.press(screen.getByText("Clear"))
+
+    expect(screen.queryByText("Recent Searches")).not.toBeOnTheScreen()
+    expect(screen.queryByText("Banksy")).not.toBeOnTheScreen()
+    expect(screen.queryByText("KAWS")).not.toBeOnTheScreen()
+  })
+})

--- a/src/app/Scenes/Search/TrendingSearches/components/__tests__/TrendingArtistsAvatarsRail.tests.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/__tests__/TrendingArtistsAvatarsRail.tests.tsx
@@ -5,6 +5,7 @@ import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 const artist = (id: string, name: string): TrendingArtist => ({
   internalID: id,
+  slug: id,
   name,
   href: `/artist/${id}`,
   coverArtwork: {

--- a/src/app/Scenes/Search/TrendingSearches/components/__tests__/TrendingArtistsAvatarsRail.tests.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/__tests__/TrendingArtistsAvatarsRail.tests.tsx
@@ -1,0 +1,34 @@
+import { screen } from "@testing-library/react-native"
+import { TrendingArtistsAvatarsRail } from "app/Scenes/Search/TrendingSearches/components/TrendingArtistsAvatarsRail"
+import { TrendingArtist } from "app/Scenes/Search/TrendingSearches/useTrendingSearches"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+const artist = (id: string, name: string): TrendingArtist => ({
+  internalID: id,
+  name,
+  href: `/artist/${id}`,
+  coverArtwork: {
+    image: {
+      url: `https://example.com/${id}.jpg`,
+      blurhash: null,
+    },
+  },
+})
+
+describe("TrendingArtistsAvatarsRail", () => {
+  it("returns nothing when the artists array is empty", () => {
+    renderWithWrappers(<TrendingArtistsAvatarsRail artists={[]} />)
+
+    expect(screen.queryByText("Trending Artists")).not.toBeOnTheScreen()
+  })
+
+  it("renders the default title and each artist's name", () => {
+    renderWithWrappers(
+      <TrendingArtistsAvatarsRail artists={[artist("banksy", "Banksy"), artist("kaws", "KAWS")]} />
+    )
+
+    expect(screen.getByText("Trending Artists")).toBeOnTheScreen()
+    expect(screen.getByText("Banksy")).toBeOnTheScreen()
+    expect(screen.getByText("KAWS")).toBeOnTheScreen()
+  })
+})

--- a/src/app/Scenes/Search/TrendingSearches/components/__tests__/TrendingPeriodToggle.tests.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/__tests__/TrendingPeriodToggle.tests.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import { TrendingPeriodToggle } from "app/Scenes/Search/TrendingSearches/components/TrendingPeriodToggle"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+describe("TrendingPeriodToggle", () => {
+  it("renders all period options", () => {
+    renderWithWrappers(<TrendingPeriodToggle value="ONE_DAY" onChange={jest.fn()} />)
+
+    expect(screen.getByText("Today")).toBeOnTheScreen()
+    expect(screen.getByText("Past 7 Days")).toBeOnTheScreen()
+    expect(screen.getByText("Past 30 Days")).toBeOnTheScreen()
+  })
+
+  it("marks the currently selected option via accessibilityState", () => {
+    renderWithWrappers(<TrendingPeriodToggle value="SEVEN_DAYS" onChange={jest.fn()} />)
+
+    expect(screen.getByRole("button", { selected: true, name: "Past 7 Days" })).toBeOnTheScreen()
+    expect(screen.getByRole("button", { selected: false, name: "Today" })).toBeOnTheScreen()
+  })
+
+  it("calls onChange with the tapped period", () => {
+    const onChange = jest.fn()
+    renderWithWrappers(<TrendingPeriodToggle value="ONE_DAY" onChange={onChange} />)
+
+    fireEvent.press(screen.getByText("Past 30 Days"))
+
+    expect(onChange).toHaveBeenCalledWith("THIRTY_DAYS")
+  })
+})

--- a/src/app/Scenes/Search/TrendingSearches/components/__tests__/TrendingSectionHeader.tests.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/__tests__/TrendingSectionHeader.tests.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import { TrendingSectionHeader } from "app/Scenes/Search/TrendingSearches/components/TrendingSectionHeader"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+describe("TrendingSectionHeader", () => {
+  it("renders the title", () => {
+    renderWithWrappers(<TrendingSectionHeader title="Trending Artists" />)
+
+    expect(screen.getByText("Trending Artists")).toBeOnTheScreen()
+  })
+
+  it("does not render the action when no callback is provided", () => {
+    renderWithWrappers(<TrendingSectionHeader title="Trending Artists" actionLabel="Clear" />)
+
+    expect(screen.queryByText("Clear")).not.toBeOnTheScreen()
+  })
+
+  it("renders the action and fires the callback when tapped", () => {
+    const onActionPress = jest.fn()
+    renderWithWrappers(
+      <TrendingSectionHeader
+        title="Recent Searches"
+        actionLabel="Clear"
+        onActionPress={onActionPress}
+      />
+    )
+
+    fireEvent.press(screen.getByText("Clear"))
+    expect(onActionPress).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/Scenes/Search/TrendingSearches/constants.ts
+++ b/src/app/Scenes/Search/TrendingSearches/constants.ts
@@ -1,0 +1,2 @@
+export const AVATAR_SIZE = 68
+export const AVATAR_ITEM_WIDTH = 80

--- a/src/app/Scenes/Search/TrendingSearches/useTrendingSearches.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/useTrendingSearches.tsx
@@ -9,9 +9,7 @@ export const trendingSearchesQuery = graphql`
     viewer {
       searchDropdown {
         trending(period: $period) {
-          label
           artists(first: 7) {
-            rank
             artist {
               internalID
               slug
@@ -26,7 +24,6 @@ export const trendingSearchesQuery = graphql`
             }
           }
           artworks(first: 10) {
-            rank
             artwork {
               internalID
               slug

--- a/src/app/Scenes/Search/TrendingSearches/useTrendingSearches.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/useTrendingSearches.tsx
@@ -14,6 +14,7 @@ export const trendingSearchesQuery = graphql`
             rank
             artist {
               internalID
+              slug
               name
               href
               coverArtwork {

--- a/src/app/Scenes/Search/TrendingSearches/useTrendingSearches.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/useTrendingSearches.tsx
@@ -1,0 +1,60 @@
+import {
+  TrendingSearchPeriod,
+  useTrendingSearchesQuery,
+} from "__generated__/useTrendingSearchesQuery.graphql"
+import { graphql, useLazyLoadQuery } from "react-relay"
+
+export const trendingSearchesQuery = graphql`
+  query useTrendingSearchesQuery($period: TrendingSearchPeriod!) @cacheable {
+    viewer {
+      searchDropdown {
+        trending(period: $period) {
+          label
+          artists(first: 7) {
+            rank
+            artist {
+              internalID
+              name
+              href
+              coverArtwork {
+                image {
+                  url(version: "larger")
+                  blurhash
+                }
+              }
+            }
+          }
+          artworks(first: 10) {
+            rank
+            artwork {
+              internalID
+              slug
+              href
+              ...ArtworkRail_artworks
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+export type TrendingPeriod = TrendingSearchPeriod
+
+export const useTrendingSearches = (period: TrendingPeriod) => {
+  const data = useLazyLoadQuery<useTrendingSearchesQuery>(
+    trendingSearchesQuery,
+    { period },
+    { fetchPolicy: "store-or-network" }
+  )
+
+  const trending = data.viewer?.searchDropdown.trending
+
+  const artists = trending?.artists?.flatMap((entry) => (entry.artist ? [entry.artist] : [])) ?? []
+  const artworks =
+    trending?.artworks?.flatMap((entry) => (entry.artwork ? [entry.artwork] : [])) ?? []
+
+  return { artists, artworks }
+}
+
+export type TrendingArtist = ReturnType<typeof useTrendingSearches>["artists"][number]

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -173,7 +173,7 @@ export const features = {
   },
   AREnableTrendingSearchesInSearchModal: {
     description: "Show trending artists and artworks in the search overlay",
-    readyForRelease: false,
+    readyForRelease: true,
     showInDevMenu: true,
     echoFlagKey: "AREnableTrendingSearchesInSearchModal",
   },

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -171,6 +171,12 @@ export const features = {
     description: "Update conversations in real time over websockets",
     echoFlagKey: "AREnableConversationsRealtime",
   },
+  AREnableTrendingSearchesInSearchModal: {
+    description: "Show trending artists and artworks in the search overlay",
+    readyForRelease: false,
+    showInDevMenu: true,
+    echoFlagKey: "AREnableTrendingSearchesInSearchModal",
+  },
 } satisfies { [key: string]: FeatureDescriptor }
 
 export interface DevToggleDescriptor {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,12 +22,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@artsy/cohesion@npm:4.390.0":
-  version: 4.390.0
-  resolution: "@artsy/cohesion@npm:4.390.0"
+"@artsy/cohesion@npm:4.393.0":
+  version: 4.393.0
+  resolution: "@artsy/cohesion@npm:4.393.0"
   dependencies:
     core-js: "npm:3"
-  checksum: 10c0/e74c0c851c77ce681b46928918316690a33962c59c273a0a51ce68e7c004053f0327a06e3e951fd07347d004330643d91aff4788ab6ed1d7aad895e1df1dde7c
+  checksum: 10c0/0d373cc71b9d82df4a58b8a7e7c589b0b51ce32f0a1bc1d2f21e20fdd3fb58cc648da03493ac43ba4d6b735f6f3e7ec88da77c4d97358cee111c0baab7cd0b14
   languageName: node
   linkType: hard
 
@@ -13587,7 +13587,7 @@ __metadata:
   resolution: "eigen@workspace:."
   dependencies:
     "@artsy/changelog": "npm:0.1.0"
-    "@artsy/cohesion": "npm:4.390.0"
+    "@artsy/cohesion": "npm:4.393.0"
     "@artsy/icons": "npm:3.74.0"
     "@artsy/palette-mobile": "npm:24.9.0"
     "@artsy/to-title-case": "npm:1.2.0"


### PR DESCRIPTION
Assisted-by: Claude Code

This PR resolves [ONYX-2238]

### Description

- Adds a new `TrendingSearches` screen shown in the global search overlay's idle state (before the user types), gated behind the `AREnableTrendingSearchesInSearchModal` feature flag
- Renders four sections: a horizontal "Recent Searches" pill rail, a Trending Artists avatar rail, a Trending Artworks rail, and a 1D / 1W / 1M period toggle.

### Demo

<video src="https://github.com/user-attachments/assets/93c75ab1-d004-4ccb-b871-e64e1953ba5a" />

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- add trending artists and artworks to the global search overlay's idle state - @nickskalkin 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-2238]: https://artsyproduct.atlassian.net/browse/ONYX-2238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ