### PR TITLE
fix(PHIRE-3400): opt out of async blurhash decoding on crash-prone surfaces

### DIFF
--- a/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx
@@ -1,5 +1,6 @@
 import { Image, Flex } from "@artsy/palette-mobile"
 import { ArtworkRailCardImage_artwork$key } from "__generated__/ArtworkRailCardImage_artwork.graphql"
+import { BLURHASH_DECODE_ASYNC } from "app/utils/blurhashDecodeAsync"
 import { graphql, useFragment } from "react-relay"
 
 export interface ArtworkRailCardImageProps {
@@ -69,8 +70,7 @@ export const ArtworkRailCardImage: React.FC<ArtworkRailCardImageProps> = ({ ...r
           height={displayImageHeight}
           aspectRatio={image.aspectRatio}
           blurhash={image.blurhash}
-          // decodeAsync off: EIGEN-AZBJ crash, will re-evaluate if still needed
-          blurhashDecodeAsync={false}
+          blurhashDecodeAsync={BLURHASH_DECODE_ASYNC}
           resizeMode="cover"
           testID="artwork-rail-card-image"
         />

--- a/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx
@@ -69,6 +69,8 @@ export const ArtworkRailCardImage: React.FC<ArtworkRailCardImageProps> = ({ ...r
           height={displayImageHeight}
           aspectRatio={image.aspectRatio}
           blurhash={image.blurhash}
+          // decodeAsync off: EIGEN-AZBJ crash, will re-evaluate if still needed
+          blurhashDecodeAsync={false}
           resizeMode="cover"
           testID="artwork-rail-card-image"
         />

--- a/src/app/Scenes/Artwork/Components/AboveTheFoldArtworkPlaceholder.tsx
+++ b/src/app/Scenes/Artwork/Components/AboveTheFoldArtworkPlaceholder.tsx
@@ -51,7 +51,12 @@ export const AboveTheFoldPlaceholder: React.FC<AboveTheFoldPlaceholderProps> = (
     <Flex flex={1} pt={2}>
       {/* Artwork thumbnail */}
       <Flex mx="auto" py={2} height={CARD_HEIGHT} justifyContent="center">
-        <ImageSkeleton dimensions={{ width, height }} blurhash={blurhash} />
+        <ImageSkeleton
+          dimensions={{ width, height }}
+          blurhash={blurhash}
+          // decodeAsync off: EIGEN-AZBJ crash, will re-evaluate if still needed
+          blurhashDecodeAsync={false}
+        />
       </Flex>
 
       <Spacer y={4} />

--- a/src/app/Scenes/Artwork/Components/AboveTheFoldArtworkPlaceholder.tsx
+++ b/src/app/Scenes/Artwork/Components/AboveTheFoldArtworkPlaceholder.tsx
@@ -1,6 +1,7 @@
 import { Flex, ImageSkeleton, Join, Spacer } from "@artsy/palette-mobile"
 import { CARD_HEIGHT } from "app/Scenes/Artwork/Components/ArtworkHeader"
 import { useImagePlaceholder } from "app/Scenes/Artwork/helpers"
+import { BLURHASH_DECODE_ASYNC } from "app/utils/blurhashDecodeAsync"
 import { PlaceholderBox, PlaceholderText, RandomNumberGenerator } from "app/utils/placeholders"
 import { times } from "lodash"
 import { useMemo } from "react"
@@ -54,8 +55,7 @@ export const AboveTheFoldPlaceholder: React.FC<AboveTheFoldPlaceholderProps> = (
         <ImageSkeleton
           dimensions={{ width, height }}
           blurhash={blurhash}
-          // decodeAsync off: EIGEN-AZBJ crash, will re-evaluate if still needed
-          blurhashDecodeAsync={false}
+          blurhashDecodeAsync={BLURHASH_DECODE_ASYNC}
         />
       </Flex>
 

--- a/src/app/Scenes/Artwork/Components/ImageCarousel/ImageWithLoadingState.tsx
+++ b/src/app/Scenes/Artwork/Components/ImageCarousel/ImageWithLoadingState.tsx
@@ -1,4 +1,5 @@
 import { Image } from "@artsy/palette-mobile"
+import { BLURHASH_DECODE_ASYNC } from "app/utils/blurhashDecodeAsync"
 import React from "react"
 import { TouchableWithoutFeedback, View, ViewProps } from "react-native"
 
@@ -33,8 +34,7 @@ export const ImageWithLoadingState = React.forwardRef<View, ImageWithLoadingStat
         <View style={[{ width, height }, props.style]} ref={ref}>
           <Image
             blurhash={blurhash}
-            // decodeAsync off: EIGEN-AZBJ crash, will re-evaluate if still needed
-            blurhashDecodeAsync={false}
+            blurhashDecodeAsync={BLURHASH_DECODE_ASYNC}
             src={imageURL}
             performResize={false}
             aspectRatio={width / height}

--- a/src/app/Scenes/Artwork/Components/ImageCarousel/ImageWithLoadingState.tsx
+++ b/src/app/Scenes/Artwork/Components/ImageCarousel/ImageWithLoadingState.tsx
@@ -33,6 +33,8 @@ export const ImageWithLoadingState = React.forwardRef<View, ImageWithLoadingStat
         <View style={[{ width, height }, props.style]} ref={ref}>
           <Image
             blurhash={blurhash}
+            // decodeAsync off: EIGEN-AZBJ crash, will re-evaluate if still needed
+            blurhashDecodeAsync={false}
             src={imageURL}
             performResize={false}
             aspectRatio={width / height}

--- a/src/app/Scenes/HomeView/Components/ActivityRailItem.tsx
+++ b/src/app/Scenes/HomeView/Components/ActivityRailItem.tsx
@@ -13,6 +13,7 @@ import { PartnerOfferBadge } from "app/Scenes/Activity/components/PartnerOffeBad
 import { useMarkNotificationAsRead } from "app/Scenes/Activity/mutations/useMarkNotificationAsRead"
 import { getActivityItemHref } from "app/Scenes/Activity/utils/getActivityItemHref"
 import { RouterLink } from "app/system/navigation/RouterLink"
+import { BLURHASH_DECODE_ASYNC } from "app/utils/blurhashDecodeAsync"
 import { memo } from "react"
 import { graphql, useFragment } from "react-relay"
 
@@ -61,8 +62,7 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = memo((props) =>
               width={ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE}
               height={ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE}
               blurhash={image.blurhash}
-              // decodeAsync off: EIGEN-AZBJ crash, will re-evaluate if still needed
-              blurhashDecodeAsync={false}
+              blurhashDecodeAsync={BLURHASH_DECODE_ASYNC}
             />
           )}
         </Flex>

--- a/src/app/Scenes/HomeView/Components/ActivityRailItem.tsx
+++ b/src/app/Scenes/HomeView/Components/ActivityRailItem.tsx
@@ -61,6 +61,8 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = memo((props) =>
               width={ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE}
               height={ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE}
               blurhash={image.blurhash}
+              // decodeAsync off: EIGEN-AZBJ crash, will re-evaluate if still needed
+              blurhashDecodeAsync={false}
             />
           )}
         </Flex>

--- a/src/app/Scenes/InfiniteDiscovery/Components/ArtworkThumbnail.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/ArtworkThumbnail.tsx
@@ -49,6 +49,8 @@ export const ArtworkThumbnail: React.FC<ArtworkThumbnailProps> = ({
           width={width - borderWidth * 2}
           height={height - borderWidth * 2}
           blurhash={blurhash ?? undefined}
+          // decodeAsync off: EIGEN-AZBJ crash, will re-evaluate if still needed
+          blurhashDecodeAsync={false}
         />
       </View>
     </View>

--- a/src/app/Scenes/InfiniteDiscovery/Components/ArtworkThumbnail.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/ArtworkThumbnail.tsx
@@ -1,4 +1,5 @@
 import { Image, useColor } from "@artsy/palette-mobile"
+import { BLURHASH_DECODE_ASYNC } from "app/utils/blurhashDecodeAsync"
 import { StyleProp, View, ViewStyle } from "react-native"
 
 interface ArtworkThumbnailProps {
@@ -49,8 +50,7 @@ export const ArtworkThumbnail: React.FC<ArtworkThumbnailProps> = ({
           width={width - borderWidth * 2}
           height={height - borderWidth * 2}
           blurhash={blurhash ?? undefined}
-          // decodeAsync off: EIGEN-AZBJ crash, will re-evaluate if still needed
-          blurhashDecodeAsync={false}
+          blurhashDecodeAsync={BLURHASH_DECODE_ASYNC}
         />
       </View>
     </View>

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -9,6 +9,7 @@ import { PaginationBars } from "app/Scenes/InfiniteDiscovery/Components/Paginati
 import { useInfiniteDiscoveryCardSave } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave"
 import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking"
 import { GlobalStore } from "app/store/GlobalStore"
+import { BLURHASH_DECODE_ASYNC } from "app/utils/blurhashDecodeAsync"
 import { sizeToFit } from "app/utils/useSizeToFit"
 import { memo, useEffect, useRef, useState } from "react"
 import { FlatList, GestureResponderEvent, Text as RNText, ViewStyle } from "react-native"
@@ -224,8 +225,7 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
                     width={size.width}
                     height={size.height}
                     blurhash={item?.blurhash}
-                    // decodeAsync off: EIGEN-AZBJ crash, will re-evaluate if still needed
-                    blurhashDecodeAsync={false}
+                    blurhashDecodeAsync={BLURHASH_DECODE_ASYNC}
                   />
                 </Flex>
               )

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -224,6 +224,8 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
                     width={size.width}
                     height={size.height}
                     blurhash={item?.blurhash}
+                    // decodeAsync off: EIGEN-AZBJ crash, will re-evaluate if still needed
+                    blurhashDecodeAsync={false}
                   />
                 </Flex>
               )

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryNegativeSignals.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryNegativeSignals.tsx
@@ -19,6 +19,7 @@ import { useExcludeArtistFromDiscovery } from "app/Scenes/InfiniteDiscovery/hook
 import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking"
 import { GlobalStore } from "app/store/GlobalStore"
 import { RouterLink } from "app/system/navigation/RouterLink"
+import { BLURHASH_DECODE_ASYNC } from "app/utils/blurhashDecodeAsync"
 import { FC } from "react"
 import { Alert } from "react-native"
 import RNShare from "react-native-share"
@@ -128,8 +129,7 @@ export const InfiniteDiscoveryNegativeSignals: FC<InfiniteDiscoveryNegativeSigna
                 src={data.image.url}
                 aspectRatio={data.image.aspectRatio}
                 blurhash={data.image.blurhash}
-                // decodeAsync off: EIGEN-AZBJ crash, will re-evaluate if still needed
-                blurhashDecodeAsync={false}
+                blurhashDecodeAsync={BLURHASH_DECODE_ASYNC}
               />
             </RouterLink>
           )}

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryNegativeSignals.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryNegativeSignals.tsx
@@ -128,6 +128,8 @@ export const InfiniteDiscoveryNegativeSignals: FC<InfiniteDiscoveryNegativeSigna
                 src={data.image.url}
                 aspectRatio={data.image.aspectRatio}
                 blurhash={data.image.blurhash}
+                // decodeAsync off: EIGEN-AZBJ crash, will re-evaluate if still needed
+                blurhashDecodeAsync={false}
               />
             </RouterLink>
           )}

--- a/src/app/utils/blurhashDecodeAsync.ts
+++ b/src/app/utils/blurhashDecodeAsync.ts
@@ -1,0 +1,11 @@
+import { Platform } from "react-native"
+
+/**
+ * react-native-blurhash emits its RN load events from the background decode queue when
+ * decodeAsync is on. On iOS those land in the main-thread-only, view-manager-wide legacy
+ * interop event map, so concurrent decodes can race it and crash (EIGEN-AZBJ). Decode
+ * synchronously on iOS until that is fixed upstream; Android is unaffected.
+ *
+ * Decodes are 16x16, so the synchronous cost is negligible.
+ */
+export const BLURHASH_DECODE_ASYNC = Platform.OS !== "ios"


### PR DESCRIPTION
This PR resolves [PHIRE-3400]

### Description

Addresses [EIGEN-AZBJ](https://artsynet.sentry.io/issues/EIGEN-AZBJ), an unhandled iOS crash (`EXC_BAD_ACCESS` on `isEqual:`) — 55 occurrences across 37 users since March, spanning app versions 9.0.1 → 9.15.0, so it is not a regression from any single release.

**Root cause.** `react-native-blurhash` decodes on a background queue when `decodeAsync` is on, but it also emits its RN load events (`onLoadStart` / `onLoadEnd` / `onError`) from that same background thread. Those events land in `RCTLegacyViewManagerInteropCoordinator`'s event-interceptor map, which is main-thread-only and shared by *every* blurhash view — so a burst of concurrent decodes can race the main thread mutating that map as views mount and unmount, and read a freed key. The library already hops to the main thread before touching UIKit (`setImageContainerImage`) but not for the three emitters; that asymmetry is the underlying defect.

Our `ImageSkeleton` amplifies it: it's deliberately short-lived (mounts while loading, unmounts on `onLoadEnd`), which guarantees exactly the mount/unmount churn the race needs.

**What this PR does.** `palette-mobile` enables `decodeAsync` by default, so this opts out via a shared `BLURHASH_DECODE_ASYNC` constant (`app/utils/blurhashDecodeAsync.ts`) on the surfaces the crash was actually reported on. The opt-out is **iOS-only** — the race is in the iOS legacy interop event map, so Android keeps async decoding:

| Surface | Sentry events | Notes |
|---|---|---|
| Artwork detail | 17/37 | entered via deep link, push, email or the iOS widget; crashes between `ArtworkAboveTheFold` resolving and `ArtworkBelowTheFold` starting |
| Home feed cold launch | 12/37 | every rail hydrates at once |
| Infinite Discovery | 5/37 | one component backs both the main deck and new-user onboarding |

Blurhash decodes are 16×16, so the synchronous cost should be negligible.

**Deliberately not changed.** `ArtworkGridItem` (only 1 event, and fast-scroll masonry is the strongest legitimate case for async decode) and `Components/ArtworkCard/ArtworkCard.tsx` (no importers — likely dead code, worth removing separately).

**Testing note.** No visual change — same blurhash placeholder, decoded on the main thread instead of a background one. Nearly every crash event has zero touch breadcrumbs and a trail under ~2s from process start, so this fires during launch-time hydration, not user interaction; the best repro is a push/widget/deep-link into an artwork on a cold app rather than tapping through the UI.

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### iOS user-facing changes

- Fix a crash on app launch caused by async blurhash decoding

<!-- end_changelog_updates -->

</details>

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md


[PHIRE-3400]: https://artsyproduct.atlassian.net/browse/PHIRE-3400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ