### PR TITLE
fix(security): pin nanoid to 3.3.18 to resolve dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -356,6 +356,7 @@
     "shell-quote": "1.9.0",
     "@jest/fake-timers@npm:^29.7.0": "patch:@jest/fake-timers@npm%3A29.7.0#~/.yarn/patches/@jest-fake-timers-npm-29.7.0-e4174d1b56.patch",
     "fast-xml-parser": "5.10.1",
+    "nanoid": "3.3.18",
     "postcss": "8.5.23",
     "sharp": "0.35.0",
     "tmp": "0.2.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20000,16 +20000,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:3.3.8":
-  version: 3.3.8
-  resolution: "nanoid@npm:3.3.8"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10c0/4b1bb29f6cfebf3be3bc4ad1f1296fb0a10a3043a79f34fbffe75d1621b4318319211cd420549459018ea3592f0d2f159247a6f874911d6d26eaaadda2478120
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.1, nanoid@npm:^3.3.11, nanoid@npm:^3.3.16":
+"nanoid@npm:3.3.18":
   version: 3.3.18
   resolution: "nanoid@npm:3.3.18"
   bin:


### PR DESCRIPTION
This PR resolves [PHIRE-3396] [dependabot #473](https://github.com/artsy/eigen/security/dependabot/473) and [dependabot #475](https://github.com/artsy/eigen/security/dependabot/475)

### Description

`@react-navigation/devtools` pinned an exact vulnerable `nanoid@3.3.8` transitive dependency, which a normal lockfile refresh couldn't move past. Added a `nanoid: 3.3.18` entry to `resolutions` in `package.json` to force a single patched version across the dependency tree, and regenerated `yarn.lock`.

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**. (no runtime code path affected — dependency-only change)
  - [x] **iOS**. (no runtime code path affected — dependency-only change)
- [x] I hid my changes behind a **feature flag**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **app state migration**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

[PHIRE-3396]: https://artsyproduct.atlassian.net/browse/PHIRE-3396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ