### PR TITLE
fix(ci): prevent a poisoned CocoaPods cache from drifting the iOS Expo fingerprint

### DIFF
--- a/.github/actions/setup-ios-environment/action.yml
+++ b/.github/actions/setup-ios-environment/action.yml
@@ -10,19 +10,15 @@ runs:
     # Exact-match only, no restore-keys. A prefix fallback restores a Pods/ resolved against a
     # different Podfile.lock, so `pod install` reconciles stale state and rewrites the lockfile
     # — and that rewritten state then gets saved under the *exact* key, poisoning it so every
-    # later exact-key hit reproduces the drift. Requiring an exact match (and installing clean
-    # otherwise) is what stops a poisoned entry from being created in the first place.
+    # later exact-key hit reproduces the drift. Requiring an exact match is what stops a poisoned
+    # entry from being created: with no restore-keys a miss restores nothing, and every runner we
+    # use (GitHub-hosted and Blacksmith alike) is ephemeral, so `pod install` starts from no Pods/.
     - name: Cache Pods (exact match only)
       id: cache-pods
       uses: actions/cache@v4
       with:
         path: ios/Pods
         key: pods-v3-${{ runner.os }}-${{ hashFiles('**/Podfile.lock') }}
-
-    - name: Clean Pods on cache miss
-      if: steps.cache-pods.outputs.cache-hit != 'true'
-      run: rm -rf ios/Pods
-      shell: bash
 
     # Just downloaded spec files, not resolved install state, so a stale prefix match here is safe
     # and speeds up cold `pod install` runs without affecting the resulting Podfile.lock.

--- a/.github/actions/setup-ios-environment/action.yml
+++ b/.github/actions/setup-ios-environment/action.yml
@@ -44,33 +44,25 @@ runs:
       run: yarn pod-install
       shell: bash
 
-    # TEMP (fingerprint drift debugging): `pod install` should leave the committed
-    # Podfile.lock untouched. CI's fingerprint disagrees with the committed file's sha1,
-    # so capture whether pod install rewrote it and exactly how. The cache-hit value tells
-    # us whether drift correlates with a cache miss (stale-Pods reconciliation) or happens
-    # on hits too (environmental). Remove once the drift is understood.
-    - name: Report Podfile.lock drift
+    # `pod install` must leave the committed Podfile.lock untouched. If it rewrites it, the
+    # Expo fingerprint (which hashes the file) diverges from the committed one, so cached
+    # native builds get invalidated — and the drifted Pods/ is then saved under the exact
+    # cache key, poisoning it so every later exact-key hit reproduces the drift. That went
+    # unnoticed for three weeks; fail loudly here instead, before the cache is written.
+    - name: Verify pod install did not modify Podfile.lock
       shell: bash
       run: |
         echo "Pods cache-hit: '${{ steps.cache-pods.outputs.cache-hit }}'"
+        if git diff --quiet -- ios/Podfile.lock; then
+          echo "✅ ios/Podfile.lock unchanged ($(shasum -a 1 ios/Podfile.lock | cut -d' ' -f1))"
+          exit 0
+        fi
+        echo "::error::pod install modified ios/Podfile.lock. Run 'yarn pod-install' locally and commit the result."
         echo "committed sha1: $(git show HEAD:ios/Podfile.lock | shasum -a 1 | cut -d' ' -f1)"
         echo "on-disk   sha1: $(shasum -a 1 ios/Podfile.lock | cut -d' ' -f1)"
-        if git diff --quiet -- ios/Podfile.lock; then
-          echo "✅ pod install did not modify ios/Podfile.lock"
-        else
-          echo "⚠️ pod install modified ios/Podfile.lock — diff (committed -> after install):"
-          git --no-pager diff -- ios/Podfile.lock
-        fi
-
-    - name: Upload Podfile.lock for comparison
-      shell: bash
-      run: |
-        DEST="s3://mobile-cached-builds/eigen-podfile-lock-debug/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}"
-        git --no-pager diff -- ios/Podfile.lock > podfile-lock.diff || true
-        aws s3 cp ios/Podfile.lock "$DEST/Podfile.lock" || echo "skipped (no aws creds?)"
-        aws s3 cp podfile-lock.diff "$DEST/Podfile.lock.diff" || echo "skipped (no aws creds?)"
-        rm -f podfile-lock.diff
-        echo "Destination: $DEST"
+        echo "diff (committed -> after install):"
+        git --no-pager diff -- ios/Podfile.lock
+        exit 1
 
     - name: Select Xcode version
       run: |

--- a/.github/actions/setup-ios-environment/action.yml
+++ b/.github/actions/setup-ios-environment/action.yml
@@ -7,16 +7,30 @@ runs:
       run: brew bundle
       shell: bash
 
-    - name: Cache cocoapods
+    # Exact-match only: a restored Pods/ that was resolved against a different Podfile.lock
+    # causes `pod install` to reconcile against stale state instead of installing clean, which
+    # can produce a Podfile.lock that differs from a fresh/local install (fingerprint drift).
+    - name: Cache Pods (exact match only)
       id: cache-pods
       uses: actions/cache@v4
       with:
-        path: |
-          ios/Pods
-          ~/Library/Caches/CocoaPods
+        path: ios/Pods
         key: pods-v3-${{ runner.os }}-${{ hashFiles('**/Podfile.lock') }}
+
+    - name: Clean Pods on cache miss
+      if: steps.cache-pods.outputs.cache-hit != 'true'
+      run: rm -rf ios/Pods
+      shell: bash
+
+    # Just downloaded spec files, not resolved install state, so a stale prefix match here is safe
+    # and speeds up cold `pod install` runs without affecting the resulting Podfile.lock.
+    - name: Cache CocoaPods spec repo
+      uses: actions/cache@v4
+      with:
+        path: ~/Library/Caches/CocoaPods
+        key: cocoapods-specs-v1-${{ runner.os }}-${{ hashFiles('**/Podfile.lock') }}
         restore-keys: |
-          pods-v3-${{ runner.os }}-
+          cocoapods-specs-v1-${{ runner.os }}-
 
     - name: Download fonts from s3
       run: ./scripts/setup/download-fonts

--- a/.github/actions/setup-ios-environment/action.yml
+++ b/.github/actions/setup-ios-environment/action.yml
@@ -7,9 +7,11 @@ runs:
       run: brew bundle
       shell: bash
 
-    # Exact-match only: a restored Pods/ that was resolved against a different Podfile.lock
-    # causes `pod install` to reconcile against stale state instead of installing clean, which
-    # can produce a Podfile.lock that differs from a fresh/local install (fingerprint drift).
+    # Exact-match only, no restore-keys. A prefix fallback restores a Pods/ resolved against a
+    # different Podfile.lock, so `pod install` reconciles stale state and rewrites the lockfile
+    # — and that rewritten state then gets saved under the *exact* key, poisoning it so every
+    # later exact-key hit reproduces the drift. Requiring an exact match (and installing clean
+    # otherwise) is what stops a poisoned entry from being created in the first place.
     - name: Cache Pods (exact match only)
       id: cache-pods
       uses: actions/cache@v4

--- a/.github/actions/setup-ios-environment/action.yml
+++ b/.github/actions/setup-ios-environment/action.yml
@@ -44,25 +44,24 @@ runs:
       run: yarn pod-install
       shell: bash
 
-    # `pod install` must leave the committed Podfile.lock untouched. If it rewrites it, the
+    # `pod install` should leave the committed Podfile.lock untouched. If it rewrites it, the
     # Expo fingerprint (which hashes the file) diverges from the committed one, so cached
     # native builds get invalidated — and the drifted Pods/ is then saved under the exact
     # cache key, poisoning it so every later exact-key hit reproduces the drift. That went
-    # unnoticed for three weeks; fail loudly here instead, before the cache is written.
-    - name: Verify pod install did not modify Podfile.lock
+    # unnoticed for three weeks, so surface it in the logs. Reports only, never fails the job.
+    - name: Report Podfile.lock drift
       shell: bash
       run: |
         echo "Pods cache-hit: '${{ steps.cache-pods.outputs.cache-hit }}'"
         if git diff --quiet -- ios/Podfile.lock; then
           echo "✅ ios/Podfile.lock unchanged ($(shasum -a 1 ios/Podfile.lock | cut -d' ' -f1))"
-          exit 0
+        else
+          echo "::warning::pod install modified ios/Podfile.lock — the Expo fingerprint will not match the committed lockfile. Run 'yarn pod-install' locally and commit the result."
+          echo "committed sha1: $(git show HEAD:ios/Podfile.lock | shasum -a 1 | cut -d' ' -f1)"
+          echo "on-disk   sha1: $(shasum -a 1 ios/Podfile.lock | cut -d' ' -f1)"
+          echo "diff (committed -> after install):"
+          git --no-pager diff -- ios/Podfile.lock
         fi
-        echo "::error::pod install modified ios/Podfile.lock. Run 'yarn pod-install' locally and commit the result."
-        echo "committed sha1: $(git show HEAD:ios/Podfile.lock | shasum -a 1 | cut -d' ' -f1)"
-        echo "on-disk   sha1: $(shasum -a 1 ios/Podfile.lock | cut -d' ' -f1)"
-        echo "diff (committed -> after install):"
-        git --no-pager diff -- ios/Podfile.lock
-        exit 1
 
     - name: Select Xcode version
       run: |

--- a/.github/actions/setup-ios-environment/action.yml
+++ b/.github/actions/setup-ios-environment/action.yml
@@ -44,6 +44,34 @@ runs:
       run: yarn pod-install
       shell: bash
 
+    # TEMP (fingerprint drift debugging): `pod install` should leave the committed
+    # Podfile.lock untouched. CI's fingerprint disagrees with the committed file's sha1,
+    # so capture whether pod install rewrote it and exactly how. The cache-hit value tells
+    # us whether drift correlates with a cache miss (stale-Pods reconciliation) or happens
+    # on hits too (environmental). Remove once the drift is understood.
+    - name: Report Podfile.lock drift
+      shell: bash
+      run: |
+        echo "Pods cache-hit: '${{ steps.cache-pods.outputs.cache-hit }}'"
+        echo "committed sha1: $(git show HEAD:ios/Podfile.lock | shasum -a 1 | cut -d' ' -f1)"
+        echo "on-disk   sha1: $(shasum -a 1 ios/Podfile.lock | cut -d' ' -f1)"
+        if git diff --quiet -- ios/Podfile.lock; then
+          echo "✅ pod install did not modify ios/Podfile.lock"
+        else
+          echo "⚠️ pod install modified ios/Podfile.lock — diff (committed -> after install):"
+          git --no-pager diff -- ios/Podfile.lock
+        fi
+
+    - name: Upload Podfile.lock for comparison
+      shell: bash
+      run: |
+        DEST="s3://mobile-cached-builds/eigen-podfile-lock-debug/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}"
+        git --no-pager diff -- ios/Podfile.lock > podfile-lock.diff || true
+        aws s3 cp ios/Podfile.lock "$DEST/Podfile.lock" || echo "skipped (no aws creds?)"
+        aws s3 cp podfile-lock.diff "$DEST/Podfile.lock.diff" || echo "skipped (no aws creds?)"
+        rm -f podfile-lock.diff
+        echo "Destination: $DEST"
+
     - name: Select Xcode version
       run: |
         XCODE_VERSION=$(jq -r '.xcode_version' ios-config.json)

--- a/.github/workflows/android-e2e-maestro.yml
+++ b/.github/workflows/android-e2e-maestro.yml
@@ -22,12 +22,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Set up Java 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: "zulu"
-          java-version: "17"
-
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This PR resolves []

### Description

iOS Expo fingerprints computed in CI didn't match locally computed ones, so cached native
builds were being treated as invalid (and OTA-update eligibility misjudged) on runs where no
native code had changed.

**Narrowing it down.** Diffing a local fingerprint against CI's `--debug` output: all 111
top-level sources matched, and all 849 files hashed under `ios/` matched — except
`ios/Podfile.lock`. The per-file fingerprint hash turns out to be a plain sha1 of file
content, which lets git act as a reference point:

| | `ios/Podfile.lock` sha1 |
|---|---|
| committed in git | `23602a20…` |
| local fingerprint | `23602a20…` |
| CI fingerprint | `829ccae…` |

Local agreed with the committed file; CI didn't. So CI's `pod install` was rewriting the
lockfile during setup, and the fingerprint hashed the rewritten file.

**Root cause: a poisoned cache entry.** Temporary instrumentation on every expo build run
showed the drifting run got `Cache hit for: pods-v3-macOS-ecb4030e…` — an *exact* primary-key
hit, not a `restore-keys` fallback:

| run | pods cache | drift |
|---|---|---|
| `d7e1781c` | HIT — 513MB entry saved July 31 | yes (`829ccae…`) |
| `251cfbc4` (this fix) | MISS → clean install, saved new entry | — |
| `a3c3c5ad` | HIT — new 285MB entry | **no** ✅ |

The July 31 cache held a `Pods/` whose `Manifest.lock` disagreed with the committed
`Podfile.lock`. Every run restored it, `pod install` reconciled, and the same rewritten
lockfile came out — deterministically, for three weeks. How an entry gets into that state:
`restore-keys` restores a stale `Pods/` → `pod install` writes a drifted `Podfile.lock` → the
job saves that state under the *exact* key → every later exact hit inherits the drift.

**The fix**, splitting the single cache along "resolved state" vs. "downloaded artifacts":

- **`ios/Pods` — exact match only.** No `restore-keys`, plus `rm -rf ios/Pods` on a miss. So
  `pod install` only ever sees a `Pods/` resolved against this exact lockfile, or none at all.
  This closes the path that creates poisoned entries.
- **`~/Library/Caches/CocoaPods` — own cache, fallback kept.** Downloaded spec files only;
  reusing an older copy saves network time and can't influence resolution.
- **A drift report** after `pod install`: cache-hit, both sha1s, and the diff, as a
  `::warning::`. Reports only — it does not fail the job.

Changing `path` from two entries to one also changed the cache *version* `actions/cache`
derives from the path list, so the poisoned entry became unreachable under the same key —
which is why run `251cfbc4` saw `Cache not found` despite it existing. That forced one clean
install, which saved a healthy entry, which `a3c3c5ad` then hit with zero drift.

**Verification.** Both paths are covered: the miss path ran for real in `251cfbc4` and the
cache it saved produced no drift downstream (a drifting clean install would have saved another
poisoned entry); the hit path is confirmed directly by `a3c3c5ad`.

Note there is one cold run after merge: the spec cache key is new (`cocoapods-specs-v1-`) and
has nothing to restore yet. Afterwards, a `Podfile.lock` change with no exact-match entry does
a fully clean `pod install` rather than the old incremental shortcut — slower, but that
shortcut was the bug.

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Fix iOS Expo fingerprint drift caused by a stale CocoaPods cache entry rewriting the
  committed `Podfile.lock` during CI setup.

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
