### PR TITLE
chore: make sure that cacheable is also sent

### DIFF
--- a/src/app/system/relay/middlewares/metaphysicsMiddleware.ts
+++ b/src/app/system/relay/middlewares/metaphysicsMiddleware.ts
@@ -128,13 +128,15 @@ export function persistedQueryMiddleware(): Middleware {
     const queryID = request.getID()
     const variables = request.getVariables()
 
+    const cacheable = CACHEABLE_DIRECTIVE_REGEX.test(
+      require("../../../../../data/complete.queryMap.json")[queryID]
+    )
+
     body = {
       documentID: queryID,
       variables,
       query: request.operation.name,
-      cacheable: CACHEABLE_DIRECTIVE_REGEX.test(
-        require("../../../../../data/complete.queryMap.json")[queryID]
-      ),
+      cacheable,
     }
 
     if (body && (body.query || body.documentID)) {
@@ -148,7 +150,11 @@ export function persistedQueryMiddleware(): Middleware {
       if (e.toString().includes("Unable to serve persisted query with ID")) {
         // this should not happen normally, but let's try again with full query text to avoid ruining the user's day?
         captureMessage(e.stack)
-        body = { query: require("../../../../../data/complete.queryMap.json")[queryID], variables }
+        body = {
+          query: require("../../../../../data/complete.queryMap.json")[queryID],
+          variables,
+          cacheable,
+        }
         request.fetchOpts.body = JSON.stringify(body)
         return await next(req)
       } else {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes an issue where subsequent queries made didn't include the cacheable flag.


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- include cacheable flag for non persisted queries - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
