### PR TITLE
chore: support expired state in verification overrides

### DIFF
--- a/src/app/Scenes/MyProfile/useHandleVerification.tsx
+++ b/src/app/Scenes/MyProfile/useHandleVerification.tsx
@@ -5,7 +5,7 @@ import { verifyID } from "app/utils/verifyID"
 import { useCallback, useState } from "react"
 
 const VERIFICATION_BANNER_TIMEOUT = 6000
-const ID_VERIFICATION_BLOCKING_STATES = ["passed", "failed", "watchlist_hit"]
+const ID_VERIFICATION_BLOCKING_STATES = ["passed", "failed", "watchlist_hit", "expired"]
 
 export const useHandleEmailVerification = () => {
   const [showVerificationBanner, setShowVerificationBanner] = useState(false)


### PR DESCRIPTION
Like https://github.com/artsy/forque/pull/2157, this just catches Eigen up to the core API's new `expired` verification state. No verifications have entered this state yet, but when they do in the future, they should be treated like the other states that block further verification progress.

I have _not_ validated this change locally or remotely and will probably struggle to do that, but am open to guidance.

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

