### PR TITLE
chore(release): v9.16.0 RC

### DIFF
--- a/ios/Artsy/View_Controllers/Live_Auctions/LiveAuctionViewController.swift
+++ b/ios/Artsy/View_Controllers/Live_Auctions/LiveAuctionViewController.swift
@@ -175,8 +175,11 @@ class LiveAuctionViewController: UIViewController {
         closeButton.addTarget(self, action: #selector(dismissLiveAuctionsModal), for: .touchUpInside)
 
         offlineView.addSubview(closeButton)
-        closeButton.alignTrailingEdge(withView: offlineView, predicate: "-20")
-        closeButton.alignTopEdge(withView: offlineView, predicate: "20")
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            closeButton.topAnchor.constraint(equalTo: offlineView.safeAreaLayoutGuide.topAnchor, constant: 20),
+            closeButton.trailingAnchor.constraint(equalTo: offlineView.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+        ])
         closeButton.constrainWidth("\(dimension)", height: "\(dimension)")
     }
 

--- a/ios/Artsy/Views/Utilities/AROfflineView.m
+++ b/ios/Artsy/Views/Utilities/AROfflineView.m
@@ -46,7 +46,19 @@
         [stackView addSubview:buttonContainer withTopMargin:@"20" sideMargin:@"0"];
 
         [self addSubview:stackView];
-        [stackView alignCenterWithView:self];
+
+        // FLKAutoLayout sets this for us, native anchors do not. We need native anchors here because
+        // alignCenterWithView: only takes a UIView, and safeAreaLayoutGuide is a UILayoutGuide.
+        stackView.translatesAutoresizingMaskIntoConstraints = NO;
+
+        UILayoutGuide *safeAreaLayoutGuide = self.safeAreaLayoutGuide;
+        [NSLayoutConstraint activateConstraints:@[
+            [stackView.centerXAnchor constraintEqualToAnchor:safeAreaLayoutGuide.centerXAnchor],
+            [stackView.centerYAnchor constraintEqualToAnchor:safeAreaLayoutGuide.centerYAnchor],
+            // Keep the title and subtitle clear of the rounded corners and sensor housing in landscape.
+            [stackView.leadingAnchor constraintGreaterThanOrEqualToAnchor:safeAreaLayoutGuide.leadingAnchor constant:20],
+            [stackView.trailingAnchor constraintLessThanOrEqualToAnchor:safeAreaLayoutGuide.trailingAnchor constant:-20],
+        ]];
     }
     return self;
 }

--- a/src/app/Components/ArtworkCard/ArtworkCardBottomSheet.tsx
+++ b/src/app/Components/ArtworkCard/ArtworkCardBottomSheet.tsx
@@ -8,6 +8,7 @@ import {
   ArtworkCardBottomSheetTabs,
   ArtworkCardBottomSheetTabsSkeleton,
 } from "app/Components/ArtworkCard/ArtworkCardBottomSheetTabs"
+import { useSentryBottomSheetTag } from "app/system/errorReporting/useSentryBottomSheetTag"
 import { FC, useEffect, useState } from "react"
 import { Dimensions } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
@@ -32,6 +33,8 @@ export const ArtworkCardBottomSheet: FC<ArtworkCardBottomSheetProps> = ({
   const [footerVisible, setFooterVisible] = useState(true)
   const color = useColor()
   const { trackEvent } = useTracking()
+
+  useSentryBottomSheetTag("ArtworkCardBottomSheet", isExpanded)
 
   useEffect(() => {
     setFooterVisible(true)

--- a/src/app/Components/BottomSheet/AutomountedBottomSheetModal.tsx
+++ b/src/app/Components/BottomSheet/AutomountedBottomSheetModal.tsx
@@ -6,23 +6,33 @@ import {
 } from "@gorhom/bottom-sheet"
 import { DefaultBottomSheetBackdrop } from "app/Components/BottomSheet/DefaultBottomSheetBackdrop"
 import { defaultIndicatorHandleStyle } from "app/Components/BottomSheet/defaultIndicatorHandleStyle"
+import { useSentryBottomSheetTag } from "app/system/errorReporting/useSentryBottomSheetTag"
 import { FC, useCallback, useEffect, useRef, useState } from "react"
 import { BackHandler } from "react-native"
 
 export interface AutomountedBottomSheetModalProps extends BottomSheetModalProps {
   visible: boolean
   closeOnBackdropClick?: boolean
+  /**
+   * Name reported to Sentry as the `bottom_sheet` tag while this sheet is open, so crashes
+   * inside it can be attributed to a specific sheet rather than just a route.
+   */
+  sentryName?: string
 }
 
 export const AutomountedBottomSheetModal: FC<AutomountedBottomSheetModalProps> = ({
   visible,
   closeOnBackdropClick = true,
+  sentryName,
   ...rest
 }) => {
   const color = useColor()
   const ref = useRef<BottomSheetModal>(null)
   const [modalIsPresented, setModalIsPresented] = useState(false)
   const { height: screenHeight, safeAreaInsets } = useScreenDimensions()
+
+  // gorhom's own `name` prop is a good enough identifier when a caller already passes one.
+  useSentryBottomSheetTag(sentryName ?? rest.name, visible)
 
   // dismiss modal on back button press on Android
   const androidBackHandler = useCallback(() => {

--- a/src/app/Components/GlobalSearchInput/GlobalSearchInput.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInput.tsx
@@ -4,20 +4,30 @@ import { GlobalSearchInputOverlay } from "app/Components/GlobalSearchInput/Globa
 import { useDismissSearchOverlayOnTabBarPress } from "app/Components/GlobalSearchInput/utils/useDismissSearchOverlayOnTabBarPress"
 import { ICON_HIT_SLOP } from "app/Components/constants"
 import { useDebouncedValue } from "app/utils/hooks/useDebouncedValue"
-import { forwardRef, Fragment, useImperativeHandle, useState } from "react"
+import { forwardRef, Fragment, useEffect, useImperativeHandle, useState } from "react"
 import { useTracking } from "react-tracking"
 
 export type GlobalSearchInput = {
   focus: () => void
 }
 
-export const GlobalSearchInput = forwardRef<GlobalSearchInput, { ownerType: OwnerType }>(
-  ({ ownerType }, ref) => {
+interface GlobalSearchInputProps {
+  ownerType: OwnerType
+  onOverlayVisibilityChange?: (isVisible: boolean) => void
+}
+
+export const GlobalSearchInput = forwardRef<GlobalSearchInput, GlobalSearchInputProps>(
+  ({ ownerType, onOverlayVisibilityChange }, ref) => {
     const [isVisible, setIsVisible] = useState(false)
 
     const debouncedIsVisible = useDebouncedValue({ value: isVisible })
 
     const tracking = useTracking()
+
+    useEffect(() => {
+      onOverlayVisibilityChange?.(isVisible)
+      return () => onOverlayVisibilityChange?.(false)
+    }, [isVisible, onOverlayVisibilityChange])
 
     useDismissSearchOverlayOnTabBarPress({ isVisible, ownerType, setIsVisible })
 

--- a/src/app/Components/GlobalSearchInput/__tests__/GlobalSearchInput.tests.tsx
+++ b/src/app/Components/GlobalSearchInput/__tests__/GlobalSearchInput.tests.tsx
@@ -38,4 +38,24 @@ describe("GlobalSearchInput", () => {
       })
     )
   })
+
+  it("reports overlay visibility changes", () => {
+    const onOverlayVisibilityChange = jest.fn()
+    const { unmount } = renderWithWrappers(
+      <GlobalSearchInput
+        ownerType={OwnerType.home}
+        onOverlayVisibilityChange={onOverlayVisibilityChange}
+      />
+    )
+
+    expect(onOverlayVisibilityChange).toHaveBeenLastCalledWith(false)
+
+    fireEvent.press(screen.getByTestId("search-button"))
+
+    expect(onOverlayVisibilityChange).toHaveBeenLastCalledWith(true)
+
+    unmount()
+
+    expect(onOverlayVisibilityChange).toHaveBeenLastCalledWith(false)
+  })
 })

--- a/src/app/Components/SortByModal/SortByModal.tsx
+++ b/src/app/Components/SortByModal/SortByModal.tsx
@@ -1,7 +1,6 @@
 import { Flex, Join, RadioButton, Spacer, Text } from "@artsy/palette-mobile"
 import { BottomSheetScrollView } from "@gorhom/bottom-sheet"
 import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
-import { SNAP_POINTS } from "app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalArtistsPrompt"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 export interface SortOption {
@@ -24,7 +23,6 @@ export const SortByModal: React.FC<SortByModalProps> = (props) => {
   return (
     <AutomountedBottomSheetModal
       visible={visible}
-      snapPoints={SNAP_POINTS}
       enableDynamicSizing
       onDismiss={() => {
         onModalFinishedClosing()

--- a/src/app/Components/SortByModal/SortByModal.tsx
+++ b/src/app/Components/SortByModal/SortByModal.tsx
@@ -22,6 +22,7 @@ export const SortByModal: React.FC<SortByModalProps> = (props) => {
 
   return (
     <AutomountedBottomSheetModal
+      sentryName="SortByModal"
       visible={visible}
       enableDynamicSizing
       onDismiss={() => {

--- a/src/app/Navigation/Navigation.tsx
+++ b/src/app/Navigation/Navigation.tsx
@@ -13,6 +13,7 @@ import {
 import { useNavigationTheme } from "app/Navigation/useNavigationTheme"
 import { OnboardingWelcomeScreens } from "app/Scenes/Onboarding/Screens/Onboarding"
 import { GlobalStore } from "app/store/GlobalStore"
+import { setSentryRouteTag } from "app/system/errorReporting/sentryTags"
 import { navigationInstrumentation } from "app/system/errorReporting/setupSentry"
 import { useReloadedDevNavigationState } from "app/system/navigation/useReloadedDevNavigationState"
 import { conversationIDFromRoute } from "app/system/notifications/visibleConversation"
@@ -75,8 +76,11 @@ export const Navigation = () => {
           setNavigationReady({ isNavigationReady: true })
           LegacyNativeModules.ARNotificationsManager.didFinishBootstrapping()
 
+          const initialRouteName = internal_navigationRef?.current?.getCurrentRoute()?.name
+
+          setSentryRouteTag(initialRouteName)
+
           if (trackSiftAndroid) {
-            const initialRouteName = internal_navigationRef?.current?.getCurrentRoute()?.name
             SiftReactNative.setPageName(`screen_${initialRouteName}`)
             SiftReactNative.upload()
           }
@@ -105,6 +109,10 @@ export const Navigation = () => {
           LegacyNativeModules.ARNotificationsManager.reactStateUpdated({
             visibleConversationID: conversationIDFromRoute(currentRoute),
           })
+
+          // Breadcrumbs aren't searchable, so also tag the route: this is what lets us
+          // group a crash by screen in Sentry, including native crashes.
+          setSentryRouteTag(currentRoute?.name)
 
           addBreadcrumb({
             message: `navigated to ${currentRoute?.name}`,

--- a/src/app/Scenes/ArtworkList/ArtworkList.tsx
+++ b/src/app/Scenes/ArtworkList/ArtworkList.tsx
@@ -24,9 +24,8 @@ import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import { useRefreshControl } from "app/utils/refreshHelpers"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
-import { FC, Suspense, useState } from "react"
+import { FC, Suspense, useRef, useState } from "react"
 import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
-import usePrevious from "react-use/lib/usePrevious"
 
 interface ArtworkListScreenProps {
   listID: string
@@ -44,7 +43,12 @@ export const artworkListVariables = { count: PAGE_SIZE, sort: DEFAULT_SORT_OPTIO
 export const ArtworkList: FC<ArtworkListScreenProps> = ({ listID }) => {
   const [sortModalVisible, setSortModalVisible] = useState(false)
   const [selectedSortValue, setSelectedSortValue] = useState(DEFAULT_SORT_OPTION)
-  const prevSelectedSortValue = usePrevious(selectedSortValue)
+  // The sort modal reports its dismissal asynchronously, once its closing animation has finished,
+  // so `handleSortByModalClosed` cannot rely on the `selectedSortValue` state closure: by then it
+  // may be reading a value from a stale render. These refs track the sort the user actually picked
+  // and the one we last fetched, so we always compare and refetch the current values.
+  const selectedSortValueRef = useRef(DEFAULT_SORT_OPTION)
+  const lastFetchedSortValueRef = useRef(DEFAULT_SORT_OPTION)
 
   const queryData = useLazyLoadQuery<ArtworkListQuery>(
     ArtworkListScreenQuery,
@@ -65,11 +69,16 @@ export const ArtworkList: FC<ArtworkListScreenProps> = ({ listID }) => {
   const handleSortByModalClosed = () => {
     setSortModalVisible(false)
 
-    if (selectedSortValue === prevSelectedSortValue) {
+    const newSortValue = selectedSortValueRef.current
+
+    if (newSortValue === lastFetchedSortValueRef.current) {
       return
     }
+
+    lastFetchedSortValueRef.current = newSortValue
+
     refetch(
-      { sort: selectedSortValue },
+      { sort: newSortValue },
       {
         fetchPolicy: "store-and-network",
       }
@@ -81,6 +90,7 @@ export const ArtworkList: FC<ArtworkListScreenProps> = ({ listID }) => {
   }
 
   const handleSelectOption = (option: SortOption) => {
+    selectedSortValueRef.current = option.value as CollectionArtworkSorts
     setSelectedSortValue(option.value as CollectionArtworkSorts)
     closeSortModal()
   }

--- a/src/app/Scenes/ArtworkList/__tests__/ArtworkList.tests.tsx
+++ b/src/app/Scenes/ArtworkList/__tests__/ArtworkList.tests.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@artsy/palette-mobile"
-import { fireEvent, screen } from "@testing-library/react-native"
+import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { ArtworkList_Test_Query } from "__generated__/ArtworkList_Test_Query.graphql"
 import { ArtworkListScreen } from "app/Scenes/ArtworkList/ArtworkList"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
@@ -43,6 +43,78 @@ describe("ArtworkList", () => {
 
     expect(screen.getByText("Artwork Title 1")).toBeOnTheScreen()
     expect(screen.getByText("Artwork Title 2")).toBeOnTheScreen()
+  })
+
+  /**
+   * These cover the wiring only: picking an option dismisses the sheet, and the dismissal
+   * refetches with the picked sort (or doesn't, when nothing changed).
+   *
+   * They deliberately do NOT guard against the stale-closure bug this wiring once had, and they
+   * pass against that buggy implementation. Reproducing it needs a parent re-render to land
+   * between the selection and the sheet's dismissal — production gets that for free during the
+   * close animation, but a test would have to force it, which the current mock can't do with a
+   * microtask. Don't mistake these for that regression guard.
+   */
+  describe("changing the sort option", () => {
+    /**
+     * Opens the sort sheet and picks an option. The sheet reports its dismissal asynchronously
+     * (see the `@gorhom/bottom-sheet` mock in `setupJest`), which is what triggers the refetch,
+     * so callers need to await the resulting operation.
+     */
+    const selectSortOption = (optionText: string) => {
+      fireEvent.press(screen.getByText("Sort"))
+      fireEvent.press(screen.getByText(optionText))
+    }
+
+    it("refetches with the picked sort value when the sheet is dismissed", async () => {
+      const { env, mockResolveLastOperation } = renderWithRelay()
+
+      mockResolveLastOperation({ Me: () => me })
+
+      selectSortOption("First Added")
+
+      await waitFor(() => {
+        expect(env.mock.getMostRecentOperation().request.variables.sort).toBe("SAVED_AT_ASC")
+      })
+    })
+
+    it("refetches again when the sort value is changed a second time", async () => {
+      const { env, mockResolveLastOperation } = renderWithRelay()
+
+      mockResolveLastOperation({ Me: () => me })
+
+      selectSortOption("First Added")
+
+      await waitFor(() => {
+        expect(env.mock.getMostRecentOperation().request.variables.sort).toBe("SAVED_AT_ASC")
+      })
+
+      mockResolveLastOperation({ Me: () => me })
+
+      selectSortOption("Recently Added")
+
+      await waitFor(() => {
+        expect(env.mock.getMostRecentOperation().request.variables.sort).toBe("SAVED_AT_DESC")
+      })
+    })
+
+    it("does not refetch when re-selecting the already-selected sort value", async () => {
+      const { env, mockResolveLastOperation } = renderWithRelay()
+
+      mockResolveLastOperation({ Me: () => me })
+
+      const operationCountBefore = env.mock.getAllOperations().length
+
+      // "Recently Added" (SAVED_AT_DESC) is already the selected value
+      selectSortOption("Recently Added")
+
+      // Give the sheet's asynchronous dismissal a chance to trigger a refetch it shouldn't
+      await waitFor(() => {
+        expect(screen.getByText("Recently Added")).toBeOnTheScreen()
+      })
+
+      expect(env.mock.getAllOperations()).toHaveLength(operationCountBefore)
+    })
   })
 
   describe("Contextual menu button", () => {

--- a/src/app/Scenes/Favorites/Components/FavoritesLearnMore.tsx
+++ b/src/app/Scenes/Favorites/Components/FavoritesLearnMore.tsx
@@ -120,6 +120,7 @@ export const FavoritesLearnMore = () => {
       </Touchable>
 
       <AutomountedBottomSheetModal
+        sentryName="FavoritesLearnMore"
         visible={showBottomSheet}
         snapPoints={SNAP_POINTS}
         enableDynamicSizing

--- a/src/app/Scenes/Favorites/FollowsTab.tsx
+++ b/src/app/Scenes/Favorites/FollowsTab.tsx
@@ -87,6 +87,7 @@ export const FollowsTab = () => {
       {followOption === "galleries" && <FollowedGalleriesQueryRenderer />}
 
       <AutomountedBottomSheetModal
+        sentryName="FollowsTab"
         visible={showFollowsBottomSheet}
         snapPoints={SNAP_POINTS}
         enableDynamicSizing

--- a/src/app/Scenes/HomeView/Components/HomeHeader.tsx
+++ b/src/app/Scenes/HomeView/Components/HomeHeader.tsx
@@ -7,7 +7,9 @@ import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { memo } from "react"
 import { ActivityIndicator } from "./ActivityIndicator"
 
-export const HomeHeader: React.FC = memo(() => {
+export const HomeHeader: React.FC<{
+  onSearchOverlayVisibilityChange?: (isVisible: boolean) => void
+}> = memo(({ onSearchOverlayVisibilityChange }) => {
   const showPaymentFailureBanner = useFeatureFlag("AREnablePaymentFailureBanner")
   const hasUnseenNotifications = GlobalStore.useAppState(
     (state) => state.bottomTabs.hasUnseenNotifications
@@ -19,7 +21,10 @@ export const HomeHeader: React.FC = memo(() => {
       <Flex pb={1} pt={2}>
         <Flex flexDirection="row" px={2} gap={1} justifyContent="space-around" alignItems="center">
           <Flex flex={1}>
-            <GlobalSearchInput ownerType={OwnerType.home} />
+            <GlobalSearchInput
+              ownerType={OwnerType.home}
+              onOverlayVisibilityChange={onSearchOverlayVisibilityChange}
+            />
           </Flex>
           <Flex alignItems="flex-end">
             <ActivityIndicator hasUnseenNotifications={hasUnseenNotifications} />

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -21,6 +21,7 @@ import { Section } from "app/Scenes/HomeView/Sections/Section"
 import { useHomeViewExperimentTracking } from "app/Scenes/HomeView/hooks/useHomeViewExperimentTracking"
 import { useHomeViewTracking } from "app/Scenes/HomeView/hooks/useHomeViewTracking"
 import { useLiveHomeViewSectionIDs } from "app/Scenes/HomeView/hooks/useLiveHomeViewSectionIDs"
+import { useRefreshLiveHomeViewSections } from "app/Scenes/HomeView/hooks/useRefreshLiveHomeViewSections"
 import { Playground } from "app/Scenes/Playground/Playground"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useExperimentVariant } from "app/system/flags/hooks/useExperimentVariant"
@@ -155,23 +156,10 @@ export const HomeView: React.FC = memo(() => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Refresh all live rails when returning to home (skipping the initial mount focus).
-  // useFocusEffect is used because inactive screens are frozen and wouldn't observe the transition.
-  const hasFocusedHomeOnce = useRef(false)
-  useFocusEffect(
-    useCallback(() => {
-      if (!hasLiveSections) {
-        return
-      }
-
-      if (!hasFocusedHomeOnce.current) {
-        hasFocusedHomeOnce.current = true
-        return
-      }
-
-      bumpLiveRefetchKey()
-    }, [hasLiveSections, bumpLiveRefetchKey])
-  )
+  const { onSearchOverlayVisibilityChange } = useRefreshLiveHomeViewSections({
+    hasLiveSections,
+    refresh: bumpLiveRefetchKey,
+  })
 
   const fetchSavedArtworksCount = async () => {
     fetchQuery<HomeViewFetchMeQuery>(
@@ -231,6 +219,11 @@ export const HomeView: React.FC = memo(() => {
     [refetchKey]
   )
 
+  const renderHomeHeader = useCallback(
+    () => <HomeHeader onSearchOverlayVisibilityChange={onSearchOverlayVisibilityChange} />,
+    [onSearchOverlayVisibilityChange]
+  )
+
   return (
     <Screen safeArea={true}>
       <Screen.Body fullwidth>
@@ -244,7 +237,7 @@ export const HomeView: React.FC = memo(() => {
           keyExtractor={(item) => item.internalID}
           renderItem={renderItem}
           onEndReached={() => loadNext(NUMBER_OF_SECTIONS_TO_LOAD)}
-          ListHeaderComponent={HomeHeader}
+          ListHeaderComponent={renderHomeHeader}
           ListFooterComponent={() =>
             hasNext ? (
               <Flex width="100%" justifyContent="center" alignItems="center" height={200}>

--- a/src/app/Scenes/HomeView/hooks/__tests__/useRefreshLiveHomeViewSections.tests.ts
+++ b/src/app/Scenes/HomeView/hooks/__tests__/useRefreshLiveHomeViewSections.tests.ts
@@ -1,0 +1,97 @@
+import { act, renderHook } from "@testing-library/react-native"
+import { useRefreshLiveHomeViewSections } from "app/Scenes/HomeView/hooks/useRefreshLiveHomeViewSections"
+
+type FocusEffect = () => void | (() => void)
+
+let mockFocusEffect: FocusEffect
+
+jest.mock("@react-navigation/native", () => ({
+  useFocusEffect: (effect: FocusEffect) => {
+    mockFocusEffect = effect
+  },
+}))
+
+describe("useRefreshLiveHomeViewSections", () => {
+  let cleanupFocusEffect: void | (() => void)
+
+  const focusHome = () => {
+    act(() => {
+      cleanupFocusEffect = mockFocusEffect()
+    })
+  }
+
+  const blurHome = () => {
+    act(() => {
+      cleanupFocusEffect?.()
+      cleanupFocusEffect = undefined
+    })
+  }
+
+  beforeEach(() => {
+    cleanupFocusEffect = undefined
+  })
+
+  it("refreshes when Home regains focus without an overlay", () => {
+    const refresh = jest.fn()
+
+    renderHook(() => useRefreshLiveHomeViewSections({ hasLiveSections: true, refresh }))
+
+    focusHome()
+    blurHome()
+    focusHome()
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it("defers a focus refresh until the Home overlay closes", () => {
+    const refresh = jest.fn()
+    const { result } = renderHook(() =>
+      useRefreshLiveHomeViewSections({ hasLiveSections: true, refresh })
+    )
+
+    focusHome()
+    act(() => result.current.onSearchOverlayVisibilityChange(true))
+    blurHome()
+    focusHome()
+
+    expect(refresh).not.toHaveBeenCalled()
+
+    act(() => result.current.onSearchOverlayVisibilityChange(false))
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not refresh when the overlay opens and closes without a focus change", () => {
+    const refresh = jest.fn()
+    const { result } = renderHook(() =>
+      useRefreshLiveHomeViewSections({ hasLiveSections: true, refresh })
+    )
+
+    focusHome()
+    act(() => result.current.onSearchOverlayVisibilityChange(true))
+    act(() => result.current.onSearchOverlayVisibilityChange(false))
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it("waits for the next focus if the overlay closes while Home is blurred", () => {
+    const refresh = jest.fn()
+    const { result } = renderHook(() =>
+      useRefreshLiveHomeViewSections({ hasLiveSections: true, refresh })
+    )
+
+    focusHome()
+    act(() => result.current.onSearchOverlayVisibilityChange(true))
+    blurHome()
+    focusHome()
+    blurHome()
+
+    act(() => result.current.onSearchOverlayVisibilityChange(false))
+
+    expect(refresh).not.toHaveBeenCalled()
+
+    focusHome()
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/Scenes/HomeView/hooks/useRefreshLiveHomeViewSections.ts
+++ b/src/app/Scenes/HomeView/hooks/useRefreshLiveHomeViewSections.ts
@@ -1,0 +1,79 @@
+import { useFocusEffect } from "@react-navigation/native"
+import { useCallback, useRef } from "react"
+
+interface UseRefreshLiveHomeViewSectionsProps {
+  hasLiveSections: boolean
+  refresh: () => void
+}
+
+/**
+ * Refreshes Home's live rails when the user actually sees Home — not just when
+ * Home regains navigation focus. If the search overlay is on top, focus alone
+ * would trigger a refetch that re-fires `railViewed` / `itemViewed` for a Home
+ * the user isn't looking at. This hook defers the refresh until the overlay
+ * closes with Home still focused.
+ *
+ * Wire the returned `onSearchOverlayVisibilityChange` into GlobalSearchInput.
+ */
+export const useRefreshLiveHomeViewSections = ({
+  hasLiveSections,
+  refresh,
+}: UseRefreshLiveHomeViewSectionsProps) => {
+  // Refs (not state) so overlay toggles don't re-render HomeView, and so the
+  // close handler below can stay `useCallback([])` — a stable identity matters
+  // because GlobalSearchInput's cleanup effect would emit a spurious `false`
+  // if the callback prop changed.
+  const hasFocusedHomeOnceRef = useRef(false)
+  const isHomeFocusedRef = useRef(false)
+  const isSearchOverlayVisibleRef = useRef(false)
+  const hasPendingRefreshRef = useRef(false)
+  // Mirrored so the close handler (empty deps) can read the latest values.
+  const hasLiveSectionsRef = useRef(hasLiveSections)
+  const refreshRef = useRef(refresh)
+
+  hasLiveSectionsRef.current = hasLiveSections
+  refreshRef.current = refresh
+
+  // Inactive screens may be frozen, so focus remains the source of truth for returning to Home.
+  useFocusEffect(
+    useCallback(() => {
+      isHomeFocusedRef.current = true
+
+      if (hasLiveSections) {
+        if (!hasFocusedHomeOnceRef.current) {
+          // First focus: initial query already delivered fresh data, skip refetch.
+          hasFocusedHomeOnceRef.current = true
+        } else if (isSearchOverlayVisibleRef.current) {
+          // Overlay covers Home — defer the refresh until it closes.
+          hasPendingRefreshRef.current = true
+        } else {
+          hasPendingRefreshRef.current = false
+          refreshRef.current()
+        }
+      }
+
+      return () => {
+        isHomeFocusedRef.current = false
+      }
+    }, [hasLiveSections])
+  )
+
+  // Fires the deferred refresh at the moment Home becomes visible again — i.e.
+  // overlay just closed, a refresh was actually pending, and Home is focused.
+  const onSearchOverlayVisibilityChange = useCallback((isVisible: boolean) => {
+    const justClosed = isSearchOverlayVisibleRef.current && !isVisible
+    isSearchOverlayVisibleRef.current = isVisible
+
+    if (
+      justClosed &&
+      hasPendingRefreshRef.current &&
+      isHomeFocusedRef.current &&
+      hasLiveSectionsRef.current
+    ) {
+      hasPendingRefreshRef.current = false
+      refreshRef.current()
+    }
+  }, [])
+
+  return { onSearchOverlayVisibilityChange }
+}

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryAboutTheWorkTab.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryAboutTheWorkTab.tsx
@@ -11,7 +11,7 @@ import {
   Tabs,
   Text,
 } from "@artsy/palette-mobile"
-import { BottomSheetScrollView, useBottomSheet } from "@gorhom/bottom-sheet"
+import { useBottomSheet } from "@gorhom/bottom-sheet"
 import { InfiniteDiscoveryAboutTheWorkTabQuery } from "__generated__/InfiniteDiscoveryAboutTheWorkTabQuery.graphql"
 import { InfiniteDiscoveryAboutTheWorkTab_artwork$key } from "__generated__/InfiniteDiscoveryAboutTheWorkTab_artwork.graphql"
 import { MyProfileEditModal_me$key } from "__generated__/MyProfileEditModal_me.graphql"
@@ -62,7 +62,7 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
   }
 
   return (
-    <BottomSheetScrollView>
+    <Tabs.ScrollView contentContainerStyle={{ marginHorizontal: 0 }}>
       <AnalyticsContextProvider
         contextModule={ContextModule.infiniteDiscoveryDrawer}
         contextScreenOwnerType={OwnerType.infiniteDiscoveryArtwork}
@@ -70,7 +70,6 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
         contextScreenOwnerSlug={data.slug}
       >
         <Flex flex={1} px={2} gap={2}>
-          <Spacer y={4} />
           <Flex gap={1} pt={1}>
             <InfiniteDiscoveryCollectorSignal artwork={data} />
 
@@ -180,7 +179,7 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
         <Spacer y={12} />
         <Spacer y={6} />
       </AnalyticsContextProvider>
-    </BottomSheetScrollView>
+    </Tabs.ScrollView>
   )
 }
 
@@ -260,10 +259,9 @@ export const InfiniteDiscoveryAboutTheWorkTab: FC<InfiniteDiscoveryAboutTheWorkT
 
 export const InfiniteDiscoveryAboutTheWorkTabSkeleton: FC = () => {
   return (
-    <BottomSheetScrollView scrollEnabled={false}>
+    <Tabs.ScrollView scrollEnabled={false} contentContainerStyle={{ marginHorizontal: 0 }}>
       <Skeleton>
         <Flex gap={2} px={2} flex={1}>
-          <Spacer y={4} />
           <Flex gap={1} pt={1}>
             <Flex flexDirection="row" gap={0.5} alignItems="center">
               <SkeletonBox size={18} />
@@ -319,6 +317,6 @@ export const InfiniteDiscoveryAboutTheWorkTabSkeleton: FC = () => {
           </Flex>
         </Flex>
       </Skeleton>
-    </BottomSheetScrollView>
+    </Tabs.ScrollView>
   )
 }

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet.tsx
@@ -63,10 +63,15 @@ export const NewUserOnboardingArtworkCardBottomSheet: FC<
   return (
     <BottomSheet
       ref={bottomSheetRef}
-      enableDynamicSizing={true}
+      // Fixed detents rather than dynamic sizing, matching ArtworkCardBottomSheet. This sheet is
+      // not remounted between artworks, so with `enableDynamicSizing` the content-sized detent was
+      // recomputed on every swipe while the sheet stayed put. Once the sheet's position no longer
+      // matched the recomputed one, gorhom stopped considering it EXTENDED and locked its
+      // scrollable, which fires a corrective scrollTo on every scroll event and can recurse until
+      // the native stack overflows (EIGEN-AZKQ).
+      enableDynamicSizing={false}
       enablePanDownToClose={false}
-      snapPoints={[bottom + 60]}
-      maxDynamicContentSize={height * 0.88}
+      snapPoints={[bottom + 60, height * 0.88]}
       index={0}
       backdropComponent={renderBackdrop}
       backgroundStyle={{ backgroundColor: color("mono0") }}

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet.tsx
@@ -3,8 +3,9 @@ import BottomSheet, { BottomSheetBackdrop, BottomSheetBackdropProps } from "@gor
 import { ArtworkCardBottomSheetHandle } from "app/Components/ArtworkCard/ArtworkCardBottomSheetHandle"
 import { ArtsyNativeModule } from "app/NativeModules/ArtsyNativeModule"
 import { NewUserOnboardingAboutTheWorkTab } from "app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingAboutTheWorkTab" // pragma: allowlist secret
+import { SENTRY_TAG_NONE, setSentryBottomSheetTag } from "app/system/errorReporting/sentryTags"
 import { useBackHandler } from "app/utils/hooks/useBackHandler"
-import { FC, useCallback, useRef } from "react"
+import { FC, useCallback, useEffect, useRef } from "react"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 interface NewUserOnboardingArtworkCardBottomSheetProps {
@@ -32,6 +33,12 @@ export const NewUserOnboardingArtworkCardBottomSheet: FC<
   const color = useColor()
   const bottomSheetRef = useRef<BottomSheet>(null)
   const isExpandedRef = useRef(false)
+
+  // Expansion is tracked in a ref to avoid re-rendering the card on every swipe, so the
+  // Sentry tag is set imperatively from `onChange` rather than with useSentryBottomSheetTag.
+  useEffect(() => {
+    return () => setSentryBottomSheetTag(SENTRY_TAG_NONE)
+  }, [])
 
   // InfiniteDiscovery is a dead-end in onboarding, so always handle hardware back
   // ourselves to keep it from popping back to the previous step.
@@ -76,7 +83,12 @@ export const NewUserOnboardingArtworkCardBottomSheet: FC<
       backdropComponent={renderBackdrop}
       backgroundStyle={{ backgroundColor: color("mono0") }}
       handleComponent={ArtworkCardBottomSheetHandle}
-      onChange={(index) => (isExpandedRef.current = index > 0)}
+      onChange={(index) => {
+        isExpandedRef.current = index > 0
+        setSentryBottomSheetTag(
+          isExpandedRef.current ? "NewUserOnboardingArtworkCardBottomSheet" : SENTRY_TAG_NONE
+        )
+      }}
     >
       <NewUserOnboardingAboutTheWorkTab artworkID={artworkID} />
     </BottomSheet>

--- a/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalProfile.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalProfile.tsx
@@ -17,6 +17,7 @@ export const MyCollectionBottomSheetModalProfile: React.FC<{
 
   return (
     <AutomountedBottomSheetModal
+      sentryName="MyCollectionBottomSheetModalProfile"
       visible={isVisible}
       snapPoints={SNAP_POINTS}
       enableDynamicSizing

--- a/src/app/Scenes/MyCollection/Screens/Insights/CareerHighlightBottomSheet.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/CareerHighlightBottomSheet.tsx
@@ -2,6 +2,7 @@ import { BoxProps, Flex } from "@artsy/palette-mobile"
 import BottomSheet, { BottomSheetBackdrop } from "@gorhom/bottom-sheet"
 import { BottomSheetDefaultBackdropProps } from "@gorhom/bottom-sheet/lib/typescript/components/bottomSheetBackdrop/types"
 import { CareerHighlightBottomSheet_query$key } from "__generated__/CareerHighlightBottomSheet_query.graphql"
+import { useSentryBottomSheetTag } from "app/system/errorReporting/useSentryBottomSheetTag"
 import { delay } from "app/utils/delay"
 import { useScreenDimensions } from "app/utils/hooks"
 import { compact } from "lodash"
@@ -110,6 +111,12 @@ export const CareerHighlightBottomSheet: React.FC<CareerHighlightBottomSheetProp
   const flatListData = useMemo(
     () => dataForFlatlist(),
     [JSON.stringify(data.analyticsArtistSparklines)]
+  )
+
+  // This sheet only renders while a highlight is selected, so being mounted means being open.
+  useSentryBottomSheetTag(
+    "CareerHighlightBottomSheet",
+    !!flatListData.length && selectedXAxisHighlight !== null
   )
 
   if (!flatListData.length || selectedXAxisHighlight === null) {

--- a/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
@@ -114,7 +114,12 @@ export const MyProfileEditModal: React.FC<MyProfileEditModalProps> = ({
   }
 
   return (
-    <AutomountedBottomSheetModal visible={visible} onDismiss={handleDismiss} enableDynamicSizing>
+    <AutomountedBottomSheetModal
+      sentryName="MyProfileEditModal"
+      visible={visible}
+      onDismiss={handleDismiss}
+      enableDynamicSizing
+    >
       <BottomSheetKeyboardAwareScrollView keyboardShouldPersistTaps="always">
         <Box p={2}>
           <Text>{message}</Text>

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
@@ -9,6 +9,7 @@ import {
   Spacer,
   Text,
   Touchable,
+  useSpace,
 } from "@artsy/palette-mobile"
 import { ArtistListItemNew_artist$key } from "__generated__/ArtistListItemNew_artist.graphql"
 import { OnboardingProgressBadge } from "app/Components/OnboardingProgressBadge/OnboardingProgressBadge"
@@ -26,12 +27,15 @@ import { OnboardingFollowedArtist } from "app/store/OnboardingModel"
 import { useDebouncedValue } from "app/utils/hooks/useDebouncedValue"
 import { useState } from "react"
 import { KeyboardController, KeyboardStickyView } from "react-native-keyboard-controller"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 const MIN_FOLLOWED = 3
 const SET_ID = "onboarding:suggested-artists"
 
 export const FollowArtists: React.FC = () => {
   const { trackCompletedOnboarding, trackTappedSkip } = useOnboardingTracking()
+  const { bottom } = useSafeAreaInsets()
+  const space = useSpace()
   const [query, setQuery] = useState("")
   const [followedArtistRefs, setFollowedArtistRefs] = useState<ArtistRef[]>([])
 
@@ -139,8 +143,8 @@ export const FollowArtists: React.FC = () => {
             />
           )}
         </Flex>
-        <KeyboardStickyView>
-          <Flex p={2} backgroundColor="mono0">
+        <KeyboardStickyView offset={{ opened: bottom - space(2) }}>
+          <Flex p={2} pb={`${bottom}px`} backgroundColor="mono0">
             <FollowArtistsContinueButton
               testID="continue-button"
               disabled={count < MIN_FOLLOWED}

--- a/src/app/Scenes/Search/TrendingSearches/TrendingSearches.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/TrendingSearches.tsx
@@ -67,8 +67,8 @@ const TrendingContent: React.FC<{ period: TrendingPeriod }> = ({ period }) => {
   return (
     <Flex>
       <Join separator={<Spacer y={2} />}>
-        <TrendingArtistsAvatarsRail artists={artists} />
-        <TrendingArtworksRail artworks={artworks} />
+        <TrendingArtistsAvatarsRail artists={artists} resetKey={period} />
+        <TrendingArtworksRail artworks={artworks} resetKey={period} />
       </Join>
     </Flex>
   )

--- a/src/app/Scenes/Search/TrendingSearches/components/TrendingArtistsAvatarsRail.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/TrendingArtistsAvatarsRail.tsx
@@ -5,20 +5,28 @@ import { TrendingSectionHeader } from "app/Scenes/Search/TrendingSearches/compon
 import { AVATAR_ITEM_WIDTH, AVATAR_SIZE } from "app/Scenes/Search/TrendingSearches/constants"
 import { TrendingArtist } from "app/Scenes/Search/TrendingSearches/useTrendingSearches"
 import { RouterLink } from "app/system/navigation/RouterLink"
+import { useEffect, useRef } from "react"
 import { FlatList } from "react-native"
 import { useTracking } from "react-tracking"
 
 interface TrendingArtistsAvatarsRailProps {
   artists: TrendingArtist[]
+  resetKey?: string
   title?: string
 }
 
 export const TrendingArtistsAvatarsRail: React.FC<TrendingArtistsAvatarsRailProps> = ({
   artists,
+  resetKey,
   title = "Trending Artists",
 }) => {
   const space = useSpace()
   const { trackEvent } = useTracking()
+  const listRef = useRef<FlatList<TrendingArtist>>(null)
+
+  useEffect(() => {
+    listRef.current?.scrollToOffset({ offset: 0, animated: false })
+  }, [resetKey])
 
   if (!artists.length) {
     return null
@@ -43,6 +51,7 @@ export const TrendingArtistsAvatarsRail: React.FC<TrendingArtistsAvatarsRailProp
       <TrendingSectionHeader title={title} />
 
       <FlatList
+        ref={listRef}
         horizontal
         data={artists}
         keyboardShouldPersistTaps="handled"

--- a/src/app/Scenes/Search/TrendingSearches/components/TrendingArtworksRail.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/TrendingArtworksRail.tsx
@@ -3,16 +3,26 @@ import { Flex } from "@artsy/palette-mobile"
 import { ArtworkRail_artworks$key } from "__generated__/ArtworkRail_artworks.graphql"
 import { ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
 import { TrendingSectionHeader } from "app/Scenes/Search/TrendingSearches/components/TrendingSectionHeader"
+import { useEffect, useRef } from "react"
+import { FlatList } from "react-native"
 
 interface TrendingArtworksRailProps {
   artworks: ArtworkRail_artworks$key
+  resetKey?: string
   title?: string
 }
 
 export const TrendingArtworksRail: React.FC<TrendingArtworksRailProps> = ({
   artworks,
+  resetKey,
   title = "Trending Artworks",
 }) => {
+  const listRef = useRef<FlatList<any>>(null)
+
+  useEffect(() => {
+    listRef.current?.scrollToOffset({ offset: 0, animated: false })
+  }, [resetKey])
+
   if (!artworks.length) {
     return null
   }
@@ -22,6 +32,7 @@ export const TrendingArtworksRail: React.FC<TrendingArtworksRailProps> = ({
       <TrendingSectionHeader title={title} />
       <ArtworkRail
         artworks={artworks}
+        listRef={listRef}
         showSaveIcon
         contextModule={ContextModule.trendingArtworksRail}
         contextScreenOwnerType={OwnerType.search}

--- a/src/app/system/errorReporting/__tests__/useSentryBottomSheetTag.tests.ts
+++ b/src/app/system/errorReporting/__tests__/useSentryBottomSheetTag.tests.ts
@@ -1,0 +1,52 @@
+import { setTag } from "@sentry/react-native"
+import { renderHook } from "@testing-library/react-native"
+import { useSentryBottomSheetTag } from "app/system/errorReporting/useSentryBottomSheetTag"
+
+jest.mock("@sentry/react-native", () => ({
+  setTag: jest.fn(),
+}))
+
+describe("useSentryBottomSheetTag", () => {
+  const setTagMock = setTag as jest.Mock
+
+  beforeEach(() => {
+    setTagMock.mockClear()
+  })
+
+  it("tags the open sheet", () => {
+    renderHook(() => useSentryBottomSheetTag("SortByModal", true))
+
+    expect(setTagMock).toHaveBeenCalledWith("bottom_sheet", "SortByModal")
+  })
+
+  it("does not tag a closed sheet", () => {
+    renderHook(() => useSentryBottomSheetTag("SortByModal", false))
+
+    expect(setTagMock).not.toHaveBeenCalled()
+  })
+
+  it("does not tag when no name is given", () => {
+    renderHook(() => useSentryBottomSheetTag(undefined, true))
+
+    expect(setTagMock).not.toHaveBeenCalled()
+  })
+
+  it("clears the tag when the sheet closes, so it isn't attached to later events", () => {
+    const { rerender } = renderHook<void, { isOpen: boolean }>(
+      ({ isOpen }) => useSentryBottomSheetTag("SortByModal", isOpen),
+      { initialProps: { isOpen: true } }
+    )
+
+    rerender({ isOpen: false })
+
+    expect(setTagMock).toHaveBeenLastCalledWith("bottom_sheet", "none")
+  })
+
+  it("clears the tag on unmount", () => {
+    const { unmount } = renderHook(() => useSentryBottomSheetTag("SortByModal", true))
+
+    unmount()
+
+    expect(setTagMock).toHaveBeenLastCalledWith("bottom_sheet", "none")
+  })
+})

--- a/src/app/system/errorReporting/sentryTags.ts
+++ b/src/app/system/errorReporting/sentryTags.ts
@@ -1,0 +1,33 @@
+import { setTag } from "@sentry/react-native"
+
+/**
+ * Tags we attach to the Sentry scope ourselves, so crashes can be attributed to a
+ * screen or an open bottom sheet without reading breadcrumbs event by event.
+ *
+ * Why tags and not `transaction`: our worst scroll/animation crashes (e.g. EIGEN-AZKQ)
+ * are native `cpp_exception` events captured by sentry-cocoa. The JS `beforeSend` hook
+ * never runs for those, and the RN SDK doesn't sync the scope's transaction name to the
+ * native layer — it only syncs user, tags, contexts and breadcrumbs (see
+ * `@sentry/react-native/dist/js/scopeSync.js`). Tags are therefore the only searchable
+ * scope data that survives into a native crash report.
+ */
+export const SENTRY_TAGS = {
+  route: "route",
+  bottomSheet: "bottom_sheet",
+} as const
+
+/**
+ * Tag values must be <= 200 chars and free of newlines, so keep them to plain names.
+ * We clear with an explicit value rather than `undefined`: the native bridge types
+ * `setTag(key, value: string)` as non-nullable, and an empty tag is indistinguishable
+ * from "we never set it" when searching in Sentry.
+ */
+export const SENTRY_TAG_NONE = "none"
+
+export const setSentryRouteTag = (routeName: string | undefined) => {
+  setTag(SENTRY_TAGS.route, routeName ?? "unknown")
+}
+
+export const setSentryBottomSheetTag = (name: string) => {
+  setTag(SENTRY_TAGS.bottomSheet, name)
+}

--- a/src/app/system/errorReporting/useSentryBottomSheetTag.ts
+++ b/src/app/system/errorReporting/useSentryBottomSheetTag.ts
@@ -1,0 +1,30 @@
+import { SENTRY_TAG_NONE, setSentryBottomSheetTag } from "app/system/errorReporting/sentryTags"
+import { useEffect } from "react"
+
+/**
+ * Tags Sentry events with the bottom sheet that is currently open.
+ *
+ * Bottom sheets are overlays, so the navigation route stays the same whichever sheet is
+ * up — the `route` tag alone can't tell us which sheet a crash came from. Several of our
+ * crashes live specifically in sheet scrollables (gorhom's scroll correction fighting
+ * another animated scroll handler, EIGEN-AZKQ), so sheet identity is the attribution we
+ * actually need.
+ *
+ * @param name Stable, human-readable sheet name. Keep it aligned with the component name.
+ * @param isOpen Whether the sheet is currently presented (or expanded, for sheets that
+ *   stay mounted at a collapsed detent).
+ */
+export const useSentryBottomSheetTag = (name: string | undefined, isOpen: boolean) => {
+  useEffect(() => {
+    if (!name || !isOpen) {
+      return
+    }
+
+    setSentryBottomSheetTag(name)
+
+    // Tags live on the isolation scope, which in React Native is global for the whole
+    // app lifetime — there's no per-request isolation to fall out of. Without this
+    // cleanup a closed sheet's name stays attached to every later event.
+    return () => setSentryBottomSheetTag(SENTRY_TAG_NONE)
+  }, [name, isOpen])
+}

--- a/src/setupJest.tsx
+++ b/src/setupJest.tsx
@@ -275,6 +275,8 @@ jest.mock("@sentry/react-native", () => ({
   captureException: jest.fn(),
   init() {},
   setUser() {},
+  setTag: jest.fn(),
+  setContext: jest.fn(),
   addBreadcrumb() {},
   withScope() {},
   Severity: "info",

--- a/src/setupJest.tsx
+++ b/src/setupJest.tsx
@@ -659,11 +659,57 @@ jest.mock("app/system/navigation/useReloadedDevNavigationState", () => ({
 
 jest.mock("@gorhom/bottom-sheet", () => {
   const { View } = require("react-native")
+  const bottomSheetMock = require("@gorhom/bottom-sheet/mock")
+
+  /**
+   * The bundled mock's `BottomSheetModal` stubs out `present`/`dismiss` entirely, so it never
+   * invokes the `onAnimate`/`onDismiss` callbacks that the real component fires. That makes any
+   * logic hanging off those props unreachable from tests. Mirror the real component instead:
+   *
+   * - `present()` reports the presentation through `onAnimate`.
+   * - dismissing reports it through `onDismiss`, but only *once* and only if the sheet was
+   *   actually presented (the real one early-exits when it is already closed).
+   * - `onDismiss` fires asynchronously, because the real sheet only reports a dismissal once its
+   *   closing animation has finished — i.e. a tick after whatever triggered the close. Callbacks
+   *   that read component state therefore see it already committed, and tests that depend on
+   *   this ordering stay honest.
+   */
+  class BottomSheetModal extends bottomSheetMock.BottomSheetModal {
+    isPresented = false
+
+    present(data: unknown) {
+      if (this.isPresented) {
+        return
+      }
+      this.isPresented = true
+      super.present(data)
+      this.props.onAnimate?.(-1, 0)
+    }
+
+    dismiss() {
+      if (!this.isPresented) {
+        return
+      }
+      this.isPresented = false
+      super.dismiss()
+      Promise.resolve().then(() => this.props.onDismiss?.())
+    }
+
+    close() {
+      this.dismiss()
+    }
+
+    forceClose() {
+      this.dismiss()
+    }
+  }
+
   return {
     __esModule: true,
     SCROLLABLE_TYPE: {},
     createBottomSheetScrollableComponent: jest.fn().mockReturnValue(View),
-    ...require("@gorhom/bottom-sheet/mock"),
+    ...bottomSheetMock,
+    BottomSheetModal,
   }
 })
 


### PR DESCRIPTION
## Release Candidate 9.16.0

This branch was automatically created as the release candidate for version 9.16.0.

> ⚠️ Do not merge this PR. It is used for tracking the release and 🍒 cherry-picking fixes only.

## Changelog

### Cross-platform user-facing changes
- passthrough keyboard taps on follow artists screen - brian — brainbicycle (#13901)
- Improve rendering of artist bios on artwork pages. — anandaroop (#13851)
- make experienced onboarding non-root to fix back behavior - brian — brainbicycle (#13902)
- fix crash on expo-update channel switch — MrSltun (#13926)
- add trending artists and artworks to the global search overlay's idle state - @nickskalkin — nickskalkin (#13941)

### iOS user-facing changes
- Fix a crash on app launch caused by async blurhash decoding — gkartalis (#13943)

### Dev changes
- Add real-time conversation updates via websockets with `useConversationsWebsocket` hook — MounirDhahri (#13833)
- fix gity guide warning - mounir — MounirDhahri (#13907)
- fix CascadingEndTimesBanner use correct Text component & disable prefetching for external link — gkartalis (#13909)
- remove ninja from CI — gkartalis (#13911)
- fix(e2e): update signup flow assertions — gkartalis (#13912)
- Updated the variant on the Continue button to better match the figma design — JanaeHijaz (#13914)
- creates more space in the scrollable viewport when typing in an artist's name by decreasing font size and margin space a bit — JanaeHijaz (#13915)
- refactor nwfy hw section grid, fix the render of View More button - daria — dariakoko (#13916)
- guard beta deploys against same-hour build number — gkartalis (#13917)
- bring back ninja for circle ci — gkartalis (#13923)
- modernize android image — gkartalis (#13924)
- The QA-document Slack thread now lists the GitHub handles of everyone with a changelog entry, so the release captain can see at a glance who to pull into Recent Changes QA. — gkartalis (#13927)
- bump rozenite to latest — gkartalis (#13929)
- post QA launch blockers via the release-lookout Slack bot — gkartalis (#13928)
- remove idb — gkartalis (#13932)
- Update expo-updates runtimeVerison to use app version + native code fingerprint gate — MrSltun (#13904)
- remove no op setLayoutAnimationEnabledExperimental — gkartalis (#13933)
- bump nanoid dep — gkartalis (#13936)
- add latest-remote-fingerprint script for debugging — gkartalis (#13935)
- Add expoUpdateId in segment events if the app is using an expo-update bundle — MrSltun (#13938)
- fix Expo fingerprint in GH tags' message — MrSltun (#13939)
- exclude echo file from fingerprint — gkartalis (#13946)
- ignore sentry expo-handler build artifacts — gkartalis (#13949)
- include cacheable flag for non persisted queries - mounir — MounirDhahri (#13953)
- remove redundant dependency installation steps from gh actions — gkartalis (#13954)
- Fix iOS Expo fingerprint drift caused by a stale CocoaPods cache entry rewriting the
committed `Podfile.lock` during CI setup. — gkartalis (#13950)

#nochangelog