### PR TITLE
refactor: attempt to fix some crashes of bottomsheets

### DIFF
--- a/src/app/Components/SortByModal/SortByModal.tsx
+++ b/src/app/Components/SortByModal/SortByModal.tsx
@@ -1,7 +1,6 @@
 import { Flex, Join, RadioButton, Spacer, Text } from "@artsy/palette-mobile"
 import { BottomSheetScrollView } from "@gorhom/bottom-sheet"
 import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
-import { SNAP_POINTS } from "app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalArtistsPrompt"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 export interface SortOption {
@@ -24,7 +23,6 @@ export const SortByModal: React.FC<SortByModalProps> = (props) => {
   return (
     <AutomountedBottomSheetModal
       visible={visible}
-      snapPoints={SNAP_POINTS}
       enableDynamicSizing
       onDismiss={() => {
         onModalFinishedClosing()

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryAboutTheWorkTab.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryAboutTheWorkTab.tsx
@@ -11,7 +11,7 @@ import {
   Tabs,
   Text,
 } from "@artsy/palette-mobile"
-import { BottomSheetScrollView, useBottomSheet } from "@gorhom/bottom-sheet"
+import { useBottomSheet } from "@gorhom/bottom-sheet"
 import { InfiniteDiscoveryAboutTheWorkTabQuery } from "__generated__/InfiniteDiscoveryAboutTheWorkTabQuery.graphql"
 import { InfiniteDiscoveryAboutTheWorkTab_artwork$key } from "__generated__/InfiniteDiscoveryAboutTheWorkTab_artwork.graphql"
 import { MyProfileEditModal_me$key } from "__generated__/MyProfileEditModal_me.graphql"
@@ -62,7 +62,7 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
   }
 
   return (
-    <BottomSheetScrollView>
+    <Tabs.ScrollView contentContainerStyle={{ marginHorizontal: 0 }}>
       <AnalyticsContextProvider
         contextModule={ContextModule.infiniteDiscoveryDrawer}
         contextScreenOwnerType={OwnerType.infiniteDiscoveryArtwork}
@@ -70,7 +70,6 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
         contextScreenOwnerSlug={data.slug}
       >
         <Flex flex={1} px={2} gap={2}>
-          <Spacer y={4} />
           <Flex gap={1} pt={1}>
             <InfiniteDiscoveryCollectorSignal artwork={data} />
 
@@ -180,7 +179,7 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
         <Spacer y={12} />
         <Spacer y={6} />
       </AnalyticsContextProvider>
-    </BottomSheetScrollView>
+    </Tabs.ScrollView>
   )
 }
 
@@ -260,10 +259,9 @@ export const InfiniteDiscoveryAboutTheWorkTab: FC<InfiniteDiscoveryAboutTheWorkT
 
 export const InfiniteDiscoveryAboutTheWorkTabSkeleton: FC = () => {
   return (
-    <BottomSheetScrollView scrollEnabled={false}>
+    <Tabs.ScrollView scrollEnabled={false} contentContainerStyle={{ marginHorizontal: 0 }}>
       <Skeleton>
         <Flex gap={2} px={2} flex={1}>
-          <Spacer y={4} />
           <Flex gap={1} pt={1}>
             <Flex flexDirection="row" gap={0.5} alignItems="center">
               <SkeletonBox size={18} />
@@ -319,6 +317,6 @@ export const InfiniteDiscoveryAboutTheWorkTabSkeleton: FC = () => {
           </Flex>
         </Flex>
       </Skeleton>
-    </BottomSheetScrollView>
+    </Tabs.ScrollView>
   )
 }

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet.tsx
@@ -63,10 +63,15 @@ export const NewUserOnboardingArtworkCardBottomSheet: FC<
   return (
     <BottomSheet
       ref={bottomSheetRef}
-      enableDynamicSizing={true}
+      // Fixed detents rather than dynamic sizing, matching ArtworkCardBottomSheet. This sheet is
+      // not remounted between artworks, so with `enableDynamicSizing` the content-sized detent was
+      // recomputed on every swipe while the sheet stayed put. Once the sheet's position no longer
+      // matched the recomputed one, gorhom stopped considering it EXTENDED and locked its
+      // scrollable, which fires a corrective scrollTo on every scroll event and can recurse until
+      // the native stack overflows (EIGEN-AZKQ).
+      enableDynamicSizing={false}
       enablePanDownToClose={false}
-      snapPoints={[bottom + 60]}
-      maxDynamicContentSize={height * 0.88}
+      snapPoints={[bottom + 60, height * 0.88]}
       index={0}
       backdropComponent={renderBackdrop}
       backgroundStyle={{ backgroundColor: color("mono0") }}


### PR DESCRIPTION
This PR resolves [PHIRE-3402] <!-- eg [PROJECT-XXXX] -->

### Description

We still have some crashes coming from the bottom sheets library, this pr attempts to fix some of the surfaces:

Slightly adjusts the behaviour but only in the Sort&Filter, would appreciate some 👀 from @artsy/diamond-devs.

I opened another PR to add Sentry Tags https://github.com/artsy/eigen/pull/13958 for the rest of the surfaces to collect more data on the crashes.

Note that the crashes only appear in iOS and i was not able to reproduce.

[Sentry stacktrace](https://artsynet.sentry.io/issues/7440783053/?project=5867225&referrer=jira_integration)

| Platform | Before | After |
|---|---|---|
| iOS | <video src="https://github.com/user-attachments/assets/74283b17-fdf6-4dfa-b2f5-2c09c6b10188" width="400" /> | <video src="https://github.com/user-attachments/assets/fa8cba94-4074-47ff-9756-8393f76419cb" width="400" /> |
| iOS | <video src="https://github.com/user-attachments/assets/c3b5c4e8-5f0f-4d7f-bca9-d0ac853090a8" width="400" /> | <video src="https://github.com/user-attachments/assets/9c4f96b2-0f77-4e53-977a-392036d78345" width="400" /> |
| iOS | <video src="https://github.com/user-attachments/assets/433cd698-1cff-4620-916b-70376009d5bd" width="400" /> | <video src="https://github.com/user-attachments/assets/934a93f5-511a-4f3a-b221-c38286ddd03b" width="400" /> | 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- attempt to fix some crashes of bottomsheets

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3402]: https://artsyproduct.atlassian.net/browse/PHIRE-3402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ