### PR TITLE
feat(PHIRE-3402): tag Sentry events with the current route and open bottom sheet

### DIFF
--- a/src/app/Components/ArtworkCard/ArtworkCardBottomSheet.tsx
+++ b/src/app/Components/ArtworkCard/ArtworkCardBottomSheet.tsx
@@ -8,6 +8,7 @@ import {
   ArtworkCardBottomSheetTabs,
   ArtworkCardBottomSheetTabsSkeleton,
 } from "app/Components/ArtworkCard/ArtworkCardBottomSheetTabs"
+import { useSentryBottomSheetTag } from "app/system/errorReporting/useSentryBottomSheetTag"
 import { FC, useEffect, useState } from "react"
 import { Dimensions } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
@@ -32,6 +33,8 @@ export const ArtworkCardBottomSheet: FC<ArtworkCardBottomSheetProps> = ({
   const [footerVisible, setFooterVisible] = useState(true)
   const color = useColor()
   const { trackEvent } = useTracking()
+
+  useSentryBottomSheetTag("ArtworkCardBottomSheet", isExpanded)
 
   useEffect(() => {
     setFooterVisible(true)

--- a/src/app/Components/BottomSheet/AutomountedBottomSheetModal.tsx
+++ b/src/app/Components/BottomSheet/AutomountedBottomSheetModal.tsx
@@ -6,23 +6,33 @@ import {
 } from "@gorhom/bottom-sheet"
 import { DefaultBottomSheetBackdrop } from "app/Components/BottomSheet/DefaultBottomSheetBackdrop"
 import { defaultIndicatorHandleStyle } from "app/Components/BottomSheet/defaultIndicatorHandleStyle"
+import { useSentryBottomSheetTag } from "app/system/errorReporting/useSentryBottomSheetTag"
 import { FC, useCallback, useEffect, useRef, useState } from "react"
 import { BackHandler } from "react-native"
 
 export interface AutomountedBottomSheetModalProps extends BottomSheetModalProps {
   visible: boolean
   closeOnBackdropClick?: boolean
+  /**
+   * Name reported to Sentry as the `bottom_sheet` tag while this sheet is open, so crashes
+   * inside it can be attributed to a specific sheet rather than just a route.
+   */
+  sentryName?: string
 }
 
 export const AutomountedBottomSheetModal: FC<AutomountedBottomSheetModalProps> = ({
   visible,
   closeOnBackdropClick = true,
+  sentryName,
   ...rest
 }) => {
   const color = useColor()
   const ref = useRef<BottomSheetModal>(null)
   const [modalIsPresented, setModalIsPresented] = useState(false)
   const { height: screenHeight, safeAreaInsets } = useScreenDimensions()
+
+  // gorhom's own `name` prop is a good enough identifier when a caller already passes one.
+  useSentryBottomSheetTag(sentryName ?? rest.name, visible)
 
   // dismiss modal on back button press on Android
   const androidBackHandler = useCallback(() => {

--- a/src/app/Components/SortByModal/SortByModal.tsx
+++ b/src/app/Components/SortByModal/SortByModal.tsx
@@ -23,6 +23,7 @@ export const SortByModal: React.FC<SortByModalProps> = (props) => {
 
   return (
     <AutomountedBottomSheetModal
+      sentryName="SortByModal"
       visible={visible}
       snapPoints={SNAP_POINTS}
       enableDynamicSizing

--- a/src/app/Navigation/Navigation.tsx
+++ b/src/app/Navigation/Navigation.tsx
@@ -13,6 +13,7 @@ import {
 import { useNavigationTheme } from "app/Navigation/useNavigationTheme"
 import { OnboardingWelcomeScreens } from "app/Scenes/Onboarding/Screens/Onboarding"
 import { GlobalStore } from "app/store/GlobalStore"
+import { setSentryRouteTag } from "app/system/errorReporting/sentryTags"
 import { navigationInstrumentation } from "app/system/errorReporting/setupSentry"
 import { useReloadedDevNavigationState } from "app/system/navigation/useReloadedDevNavigationState"
 import { conversationIDFromRoute } from "app/system/notifications/visibleConversation"
@@ -75,8 +76,11 @@ export const Navigation = () => {
           setNavigationReady({ isNavigationReady: true })
           LegacyNativeModules.ARNotificationsManager.didFinishBootstrapping()
 
+          const initialRouteName = internal_navigationRef?.current?.getCurrentRoute()?.name
+
+          setSentryRouteTag(initialRouteName)
+
           if (trackSiftAndroid) {
-            const initialRouteName = internal_navigationRef?.current?.getCurrentRoute()?.name
             SiftReactNative.setPageName(`screen_${initialRouteName}`)
             SiftReactNative.upload()
           }
@@ -105,6 +109,10 @@ export const Navigation = () => {
           LegacyNativeModules.ARNotificationsManager.reactStateUpdated({
             visibleConversationID: conversationIDFromRoute(currentRoute),
           })
+
+          // Breadcrumbs aren't searchable, so also tag the route: this is what lets us
+          // group a crash by screen in Sentry, including native crashes.
+          setSentryRouteTag(currentRoute?.name)
 
           addBreadcrumb({
             message: `navigated to ${currentRoute?.name}`,

--- a/src/app/Scenes/Favorites/Components/FavoritesLearnMore.tsx
+++ b/src/app/Scenes/Favorites/Components/FavoritesLearnMore.tsx
@@ -120,6 +120,7 @@ export const FavoritesLearnMore = () => {
       </Touchable>
 
       <AutomountedBottomSheetModal
+        sentryName="FavoritesLearnMore"
         visible={showBottomSheet}
         snapPoints={SNAP_POINTS}
         enableDynamicSizing

--- a/src/app/Scenes/Favorites/FollowsTab.tsx
+++ b/src/app/Scenes/Favorites/FollowsTab.tsx
@@ -87,6 +87,7 @@ export const FollowsTab = () => {
       {followOption === "galleries" && <FollowedGalleriesQueryRenderer />}
 
       <AutomountedBottomSheetModal
+        sentryName="FollowsTab"
         visible={showFollowsBottomSheet}
         snapPoints={SNAP_POINTS}
         enableDynamicSizing

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet.tsx
@@ -3,8 +3,9 @@ import BottomSheet, { BottomSheetBackdrop, BottomSheetBackdropProps } from "@gor
 import { ArtworkCardBottomSheetHandle } from "app/Components/ArtworkCard/ArtworkCardBottomSheetHandle"
 import { ArtsyNativeModule } from "app/NativeModules/ArtsyNativeModule"
 import { NewUserOnboardingAboutTheWorkTab } from "app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingAboutTheWorkTab" // pragma: allowlist secret
+import { SENTRY_TAG_NONE, setSentryBottomSheetTag } from "app/system/errorReporting/sentryTags"
 import { useBackHandler } from "app/utils/hooks/useBackHandler"
-import { FC, useCallback, useRef } from "react"
+import { FC, useCallback, useEffect, useRef } from "react"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 interface NewUserOnboardingArtworkCardBottomSheetProps {
@@ -32,6 +33,12 @@ export const NewUserOnboardingArtworkCardBottomSheet: FC<
   const color = useColor()
   const bottomSheetRef = useRef<BottomSheet>(null)
   const isExpandedRef = useRef(false)
+
+  // Expansion is tracked in a ref to avoid re-rendering the card on every swipe, so the
+  // Sentry tag is set imperatively from `onChange` rather than with useSentryBottomSheetTag.
+  useEffect(() => {
+    return () => setSentryBottomSheetTag(SENTRY_TAG_NONE)
+  }, [])
 
   // InfiniteDiscovery is a dead-end in onboarding, so always handle hardware back
   // ourselves to keep it from popping back to the previous step.
@@ -71,7 +78,12 @@ export const NewUserOnboardingArtworkCardBottomSheet: FC<
       backdropComponent={renderBackdrop}
       backgroundStyle={{ backgroundColor: color("mono0") }}
       handleComponent={ArtworkCardBottomSheetHandle}
-      onChange={(index) => (isExpandedRef.current = index > 0)}
+      onChange={(index) => {
+        isExpandedRef.current = index > 0
+        setSentryBottomSheetTag(
+          isExpandedRef.current ? "NewUserOnboardingArtworkCardBottomSheet" : SENTRY_TAG_NONE
+        )
+      }}
     >
       <NewUserOnboardingAboutTheWorkTab artworkID={artworkID} />
     </BottomSheet>

--- a/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalProfile.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalProfile.tsx
@@ -17,6 +17,7 @@ export const MyCollectionBottomSheetModalProfile: React.FC<{
 
   return (
     <AutomountedBottomSheetModal
+      sentryName="MyCollectionBottomSheetModalProfile"
       visible={isVisible}
       snapPoints={SNAP_POINTS}
       enableDynamicSizing

--- a/src/app/Scenes/MyCollection/Screens/Insights/CareerHighlightBottomSheet.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/CareerHighlightBottomSheet.tsx
@@ -2,6 +2,7 @@ import { BoxProps, Flex } from "@artsy/palette-mobile"
 import BottomSheet, { BottomSheetBackdrop } from "@gorhom/bottom-sheet"
 import { BottomSheetDefaultBackdropProps } from "@gorhom/bottom-sheet/lib/typescript/components/bottomSheetBackdrop/types"
 import { CareerHighlightBottomSheet_query$key } from "__generated__/CareerHighlightBottomSheet_query.graphql"
+import { useSentryBottomSheetTag } from "app/system/errorReporting/useSentryBottomSheetTag"
 import { delay } from "app/utils/delay"
 import { useScreenDimensions } from "app/utils/hooks"
 import { compact } from "lodash"
@@ -110,6 +111,12 @@ export const CareerHighlightBottomSheet: React.FC<CareerHighlightBottomSheetProp
   const flatListData = useMemo(
     () => dataForFlatlist(),
     [JSON.stringify(data.analyticsArtistSparklines)]
+  )
+
+  // This sheet only renders while a highlight is selected, so being mounted means being open.
+  useSentryBottomSheetTag(
+    "CareerHighlightBottomSheet",
+    !!flatListData.length && selectedXAxisHighlight !== null
   )
 
   if (!flatListData.length || selectedXAxisHighlight === null) {

--- a/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
@@ -114,7 +114,12 @@ export const MyProfileEditModal: React.FC<MyProfileEditModalProps> = ({
   }
 
   return (
-    <AutomountedBottomSheetModal visible={visible} onDismiss={handleDismiss} enableDynamicSizing>
+    <AutomountedBottomSheetModal
+      sentryName="MyProfileEditModal"
+      visible={visible}
+      onDismiss={handleDismiss}
+      enableDynamicSizing
+    >
       <BottomSheetKeyboardAwareScrollView keyboardShouldPersistTaps="always">
         <Box p={2}>
           <Text>{message}</Text>

--- a/src/app/system/errorReporting/__tests__/useSentryBottomSheetTag.tests.ts
+++ b/src/app/system/errorReporting/__tests__/useSentryBottomSheetTag.tests.ts
@@ -1,0 +1,52 @@
+import { setTag } from "@sentry/react-native"
+import { renderHook } from "@testing-library/react-native"
+import { useSentryBottomSheetTag } from "app/system/errorReporting/useSentryBottomSheetTag"
+
+jest.mock("@sentry/react-native", () => ({
+  setTag: jest.fn(),
+}))
+
+describe("useSentryBottomSheetTag", () => {
+  const setTagMock = setTag as jest.Mock
+
+  beforeEach(() => {
+    setTagMock.mockClear()
+  })
+
+  it("tags the open sheet", () => {
+    renderHook(() => useSentryBottomSheetTag("SortByModal", true))
+
+    expect(setTagMock).toHaveBeenCalledWith("bottom_sheet", "SortByModal")
+  })
+
+  it("does not tag a closed sheet", () => {
+    renderHook(() => useSentryBottomSheetTag("SortByModal", false))
+
+    expect(setTagMock).not.toHaveBeenCalled()
+  })
+
+  it("does not tag when no name is given", () => {
+    renderHook(() => useSentryBottomSheetTag(undefined, true))
+
+    expect(setTagMock).not.toHaveBeenCalled()
+  })
+
+  it("clears the tag when the sheet closes, so it isn't attached to later events", () => {
+    const { rerender } = renderHook<void, { isOpen: boolean }>(
+      ({ isOpen }) => useSentryBottomSheetTag("SortByModal", isOpen),
+      { initialProps: { isOpen: true } }
+    )
+
+    rerender({ isOpen: false })
+
+    expect(setTagMock).toHaveBeenLastCalledWith("bottom_sheet", "none")
+  })
+
+  it("clears the tag on unmount", () => {
+    const { unmount } = renderHook(() => useSentryBottomSheetTag("SortByModal", true))
+
+    unmount()
+
+    expect(setTagMock).toHaveBeenLastCalledWith("bottom_sheet", "none")
+  })
+})

--- a/src/app/system/errorReporting/sentryTags.ts
+++ b/src/app/system/errorReporting/sentryTags.ts
@@ -1,0 +1,33 @@
+import { setTag } from "@sentry/react-native"
+
+/**
+ * Tags we attach to the Sentry scope ourselves, so crashes can be attributed to a
+ * screen or an open bottom sheet without reading breadcrumbs event by event.
+ *
+ * Why tags and not `transaction`: our worst scroll/animation crashes (e.g. EIGEN-AZKQ)
+ * are native `cpp_exception` events captured by sentry-cocoa. The JS `beforeSend` hook
+ * never runs for those, and the RN SDK doesn't sync the scope's transaction name to the
+ * native layer — it only syncs user, tags, contexts and breadcrumbs (see
+ * `@sentry/react-native/dist/js/scopeSync.js`). Tags are therefore the only searchable
+ * scope data that survives into a native crash report.
+ */
+export const SENTRY_TAGS = {
+  route: "route",
+  bottomSheet: "bottom_sheet",
+} as const
+
+/**
+ * Tag values must be <= 200 chars and free of newlines, so keep them to plain names.
+ * We clear with an explicit value rather than `undefined`: the native bridge types
+ * `setTag(key, value: string)` as non-nullable, and an empty tag is indistinguishable
+ * from "we never set it" when searching in Sentry.
+ */
+export const SENTRY_TAG_NONE = "none"
+
+export const setSentryRouteTag = (routeName: string | undefined) => {
+  setTag(SENTRY_TAGS.route, routeName ?? "unknown")
+}
+
+export const setSentryBottomSheetTag = (name: string) => {
+  setTag(SENTRY_TAGS.bottomSheet, name)
+}

--- a/src/app/system/errorReporting/useSentryBottomSheetTag.ts
+++ b/src/app/system/errorReporting/useSentryBottomSheetTag.ts
@@ -1,0 +1,30 @@
+import { SENTRY_TAG_NONE, setSentryBottomSheetTag } from "app/system/errorReporting/sentryTags"
+import { useEffect } from "react"
+
+/**
+ * Tags Sentry events with the bottom sheet that is currently open.
+ *
+ * Bottom sheets are overlays, so the navigation route stays the same whichever sheet is
+ * up — the `route` tag alone can't tell us which sheet a crash came from. Several of our
+ * crashes live specifically in sheet scrollables (gorhom's scroll correction fighting
+ * another animated scroll handler, EIGEN-AZKQ), so sheet identity is the attribution we
+ * actually need.
+ *
+ * @param name Stable, human-readable sheet name. Keep it aligned with the component name.
+ * @param isOpen Whether the sheet is currently presented (or expanded, for sheets that
+ *   stay mounted at a collapsed detent).
+ */
+export const useSentryBottomSheetTag = (name: string | undefined, isOpen: boolean) => {
+  useEffect(() => {
+    if (!name || !isOpen) {
+      return
+    }
+
+    setSentryBottomSheetTag(name)
+
+    // Tags live on the isolation scope, which in React Native is global for the whole
+    // app lifetime — there's no per-request isolation to fall out of. Without this
+    // cleanup a closed sheet's name stays attached to every later event.
+    return () => setSentryBottomSheetTag(SENTRY_TAG_NONE)
+  }, [name, isOpen])
+}

--- a/src/setupJest.tsx
+++ b/src/setupJest.tsx
@@ -275,6 +275,8 @@ jest.mock("@sentry/react-native", () => ({
   captureException: jest.fn(),
   init() {},
   setUser() {},
+  setTag: jest.fn(),
+  setContext: jest.fn(),
   addBreadcrumb() {},
   withScope() {},
   Severity: "info",


### PR DESCRIPTION
This PR resolves [PHIRE-3402](https://artsyproduct.atlassian.net/browse/PHIRE-3402)

Instrumentation for [EIGEN-AZKQ](https://artsynet.sentry.io/issues/EIGEN-AZKQ) — not the fix itself.

### Description

Attributing our scroll/animation crashes to a screen currently means opening Sentry events
one at a time and reading breadcrumbs. This adds two indexed tags so it's a filter instead.

**Why tags, and not `transaction`.** Our worst offender here ([EIGEN-AZKQ](https://artsynet.sentry.io/issues/EIGEN-AZKQ),
84 events / 57 users, iOS only) is a native `cpp_exception` captured by sentry-cocoa —
`platform: cocoa`, `event.environment: native`, no JS stacktrace. Two consequences:

- JS `beforeSend` never runs for native events ([docs](https://docs.sentry.io/platforms/react-native/configuration/filtering/)),
  so we can't populate anything at send time.
- The RN SDK syncs only user, tags, contexts and breadcrumbs to the native layer
  (`@sentry/react-native/dist/js/scopeSync.js`) — *not* the scope's transaction name.

So tags are the only searchable scope data that survives into a native crash report. Worth
knowing separately: `transaction` is blank on **every** eigen error event, native or JS —
`@sentry/core` only fills it from `scopeData.transactionName` (`utils/scopeData.js:135`),
and nothing in the RN SDK ever sets it. That's a bigger change and out of scope here.

**What's added**

- `route` — set from the existing `onStateChange` handler in `Navigation.tsx`, next to the
  navigation breadcrumb that's already there, plus once on `onReady` for the initial screen.
- `bottom_sheet` — set while a sheet is open, cleared on close and unmount. Sheets are
  overlays, so the route alone can't tell us which sheet a crash came from, and several of
  these crashes live specifically in sheet scrollables.

`AutomountedBottomSheetModal` takes a new optional `sentryName` (falling back to gorhom's
own `name` prop when a caller already passes one), so any sheet using the shared wrapper
opts in with one prop. Sheets built on raw gorhom `BottomSheet` call
`useSentryBottomSheetTag` directly. Tagged here: the surfaces that showed up in EIGEN-AZKQ
breadcrumbs (SortByModal, both InfiniteDiscovery card sheets, CareerHighlightBottomSheet)
plus the ones rendering a gorhom scrollable (FollowsTab, FavoritesLearnMore,
MyCollectionBottomSheetModalProfile, MyProfileEditModal). Untagged sheets simply don't set
the tag.

**Performance:** nothing measurable. One `setTag` per navigation (alongside the native
calls that handler already makes) and one per sheet open/close — gorhom's `onChange` fires
only on a settled detent change, never per frame (`BottomSheet.js:379`). No new renders:
`ArtworkCardBottomSheet` reuses its existing `isExpanded` state, and the onboarding sheet
keeps its ref-based tracking and sets the tag imperatively so its swipe path is untouched.
On the native side `setTag` is a `free` + `strdup` of a small JSON string in memory
(`SentryScopeSyncC.c`), no disk I/O.

**Implementation notes**

- Cleared with an explicit `"none"` rather than `undefined`: the native bridge types the
  value as non-nullable `string`, and `bottom_sheet:none` is searchable in a way an absent
  tag isn't.
- Tags live on the isolation scope, which in RN is global for the app's lifetime — hence
  the explicit cleanup, or a closed sheet's name would ride along on every later event.
- Nested sheets are last-writer-wins: closing a modal over an already-expanded sheet sets
  `none` even though the sheet underneath is still up. Acceptable for a diagnostic; a stack
  would be the fix if it ever matters.
- `route` only tracks react-navigation, so natively-presented screens won't update it.
- `setupJest.tsx` needed `setTag`/`setContext` added to the global Sentry mock.

**Follow-up work**

- Verify on a device with `Sentry.nativeCrash()` from the dev menu (the `debugSentry` path
  only exercises the JS pipeline, which proves nothing for native crashes). Not yet done.
- Once this ships, EIGEN-AZKQ residue can be grouped by surface — which is what tells us
  whether the sheet fixes on `gkartalis/EIGEN-AZKQ` were sufficient.

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Tag Sentry events with the current route and the open bottom sheet, so native crashes can be attributed to a screen

<!-- end_changelog_updates -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PHIRE-3402]: https://artsyproduct.atlassian.net/browse/PHIRE-3402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ