### PR TITLE
fix(artwork-list): refetch when the sort option changes

### DIFF
--- a/src/app/Scenes/ArtworkList/ArtworkList.tsx
+++ b/src/app/Scenes/ArtworkList/ArtworkList.tsx
@@ -24,9 +24,8 @@ import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import { useRefreshControl } from "app/utils/refreshHelpers"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
-import { FC, Suspense, useState } from "react"
+import { FC, Suspense, useRef, useState } from "react"
 import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
-import usePrevious from "react-use/lib/usePrevious"
 
 interface ArtworkListScreenProps {
   listID: string
@@ -44,7 +43,12 @@ export const artworkListVariables = { count: PAGE_SIZE, sort: DEFAULT_SORT_OPTIO
 export const ArtworkList: FC<ArtworkListScreenProps> = ({ listID }) => {
   const [sortModalVisible, setSortModalVisible] = useState(false)
   const [selectedSortValue, setSelectedSortValue] = useState(DEFAULT_SORT_OPTION)
-  const prevSelectedSortValue = usePrevious(selectedSortValue)
+  // The sort modal reports its dismissal asynchronously, once its closing animation has finished,
+  // so `handleSortByModalClosed` cannot rely on the `selectedSortValue` state closure: by then it
+  // may be reading a value from a stale render. These refs track the sort the user actually picked
+  // and the one we last fetched, so we always compare and refetch the current values.
+  const selectedSortValueRef = useRef(DEFAULT_SORT_OPTION)
+  const lastFetchedSortValueRef = useRef(DEFAULT_SORT_OPTION)
 
   const queryData = useLazyLoadQuery<ArtworkListQuery>(
     ArtworkListScreenQuery,
@@ -65,11 +69,16 @@ export const ArtworkList: FC<ArtworkListScreenProps> = ({ listID }) => {
   const handleSortByModalClosed = () => {
     setSortModalVisible(false)
 
-    if (selectedSortValue === prevSelectedSortValue) {
+    const newSortValue = selectedSortValueRef.current
+
+    if (newSortValue === lastFetchedSortValueRef.current) {
       return
     }
+
+    lastFetchedSortValueRef.current = newSortValue
+
     refetch(
-      { sort: selectedSortValue },
+      { sort: newSortValue },
       {
         fetchPolicy: "store-and-network",
       }
@@ -81,6 +90,7 @@ export const ArtworkList: FC<ArtworkListScreenProps> = ({ listID }) => {
   }
 
   const handleSelectOption = (option: SortOption) => {
+    selectedSortValueRef.current = option.value as CollectionArtworkSorts
     setSelectedSortValue(option.value as CollectionArtworkSorts)
     closeSortModal()
   }

--- a/src/app/Scenes/ArtworkList/__tests__/ArtworkList.tests.tsx
+++ b/src/app/Scenes/ArtworkList/__tests__/ArtworkList.tests.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@artsy/palette-mobile"
-import { fireEvent, screen } from "@testing-library/react-native"
+import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { ArtworkList_Test_Query } from "__generated__/ArtworkList_Test_Query.graphql"
 import { ArtworkListScreen } from "app/Scenes/ArtworkList/ArtworkList"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
@@ -43,6 +43,78 @@ describe("ArtworkList", () => {
 
     expect(screen.getByText("Artwork Title 1")).toBeOnTheScreen()
     expect(screen.getByText("Artwork Title 2")).toBeOnTheScreen()
+  })
+
+  /**
+   * These cover the wiring only: picking an option dismisses the sheet, and the dismissal
+   * refetches with the picked sort (or doesn't, when nothing changed).
+   *
+   * They deliberately do NOT guard against the stale-closure bug this wiring once had, and they
+   * pass against that buggy implementation. Reproducing it needs a parent re-render to land
+   * between the selection and the sheet's dismissal — production gets that for free during the
+   * close animation, but a test would have to force it, which the current mock can't do with a
+   * microtask. Don't mistake these for that regression guard.
+   */
+  describe("changing the sort option", () => {
+    /**
+     * Opens the sort sheet and picks an option. The sheet reports its dismissal asynchronously
+     * (see the `@gorhom/bottom-sheet` mock in `setupJest`), which is what triggers the refetch,
+     * so callers need to await the resulting operation.
+     */
+    const selectSortOption = (optionText: string) => {
+      fireEvent.press(screen.getByText("Sort"))
+      fireEvent.press(screen.getByText(optionText))
+    }
+
+    it("refetches with the picked sort value when the sheet is dismissed", async () => {
+      const { env, mockResolveLastOperation } = renderWithRelay()
+
+      mockResolveLastOperation({ Me: () => me })
+
+      selectSortOption("First Added")
+
+      await waitFor(() => {
+        expect(env.mock.getMostRecentOperation().request.variables.sort).toBe("SAVED_AT_ASC")
+      })
+    })
+
+    it("refetches again when the sort value is changed a second time", async () => {
+      const { env, mockResolveLastOperation } = renderWithRelay()
+
+      mockResolveLastOperation({ Me: () => me })
+
+      selectSortOption("First Added")
+
+      await waitFor(() => {
+        expect(env.mock.getMostRecentOperation().request.variables.sort).toBe("SAVED_AT_ASC")
+      })
+
+      mockResolveLastOperation({ Me: () => me })
+
+      selectSortOption("Recently Added")
+
+      await waitFor(() => {
+        expect(env.mock.getMostRecentOperation().request.variables.sort).toBe("SAVED_AT_DESC")
+      })
+    })
+
+    it("does not refetch when re-selecting the already-selected sort value", async () => {
+      const { env, mockResolveLastOperation } = renderWithRelay()
+
+      mockResolveLastOperation({ Me: () => me })
+
+      const operationCountBefore = env.mock.getAllOperations().length
+
+      // "Recently Added" (SAVED_AT_DESC) is already the selected value
+      selectSortOption("Recently Added")
+
+      // Give the sheet's asynchronous dismissal a chance to trigger a refetch it shouldn't
+      await waitFor(() => {
+        expect(screen.getByText("Recently Added")).toBeOnTheScreen()
+      })
+
+      expect(env.mock.getAllOperations()).toHaveLength(operationCountBefore)
+    })
   })
 
   describe("Contextual menu button", () => {

--- a/src/setupJest.tsx
+++ b/src/setupJest.tsx
@@ -659,11 +659,57 @@ jest.mock("app/system/navigation/useReloadedDevNavigationState", () => ({
 
 jest.mock("@gorhom/bottom-sheet", () => {
   const { View } = require("react-native")
+  const bottomSheetMock = require("@gorhom/bottom-sheet/mock")
+
+  /**
+   * The bundled mock's `BottomSheetModal` stubs out `present`/`dismiss` entirely, so it never
+   * invokes the `onAnimate`/`onDismiss` callbacks that the real component fires. That makes any
+   * logic hanging off those props unreachable from tests. Mirror the real component instead:
+   *
+   * - `present()` reports the presentation through `onAnimate`.
+   * - dismissing reports it through `onDismiss`, but only *once* and only if the sheet was
+   *   actually presented (the real one early-exits when it is already closed).
+   * - `onDismiss` fires asynchronously, because the real sheet only reports a dismissal once its
+   *   closing animation has finished — i.e. a tick after whatever triggered the close. Callbacks
+   *   that read component state therefore see it already committed, and tests that depend on
+   *   this ordering stay honest.
+   */
+  class BottomSheetModal extends bottomSheetMock.BottomSheetModal {
+    isPresented = false
+
+    present(data: unknown) {
+      if (this.isPresented) {
+        return
+      }
+      this.isPresented = true
+      super.present(data)
+      this.props.onAnimate?.(-1, 0)
+    }
+
+    dismiss() {
+      if (!this.isPresented) {
+        return
+      }
+      this.isPresented = false
+      super.dismiss()
+      Promise.resolve().then(() => this.props.onDismiss?.())
+    }
+
+    close() {
+      this.dismiss()
+    }
+
+    forceClose() {
+      this.dismiss()
+    }
+  }
+
   return {
     __esModule: true,
     SCROLLABLE_TYPE: {},
     createBottomSheetScrollableComponent: jest.fn().mockReturnValue(View),
-    ...require("@gorhom/bottom-sheet/mock"),
+    ...bottomSheetMock,
+    BottomSheetModal,
   }
 })
 


### PR DESCRIPTION
This PR resolves [PHIRE-3410]

### Description

Changing the sort option on a saved artwork list didn't refresh the list.

`handleSortByModalClosed` compared `selectedSortValue` against `usePrevious(selectedSortValue)`. Both are values captured in a render closure, and `usePrevious` updates its ref in a dependency-less effect that runs after *every* render. The sort sheet reports its dismissal asynchronously, after the close animation — so any parent re-render landing in that window produced a closure where both values were already equal. The guard compared the value against itself, concluded nothing had changed, and skipped the refetch. Being render-timing dependent, it was intermittent rather than a clean always-fails.

Fix: track the picked sort and the last fetched sort in refs, so the comparison doesn't depend on render timing.

The `setupJest` change is needed to test this at all: the bundled `@gorhom/bottom-sheet` mock stubs out `present`/`dismiss` without firing `onAnimate`/`onDismiss`, leaving the dismissal path unreachable from tests. The mock now mirrors the real component, including dismissing asynchronously.

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Fix sorting not refreshing on saved artwork lists

#### iOS user-facing changes

-

#### Android user-facing changes

-

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PHIRE-3410]: https://artsyproduct.atlassian.net/browse/PHIRE-3410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ