### PR TITLE
refactor(city): remove any types from EventSection and SavedEventSection

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -342,7 +342,7 @@
         "filename": "src/app/Scenes/City/Components/EventSection/__tests__/EventSection.tests.tsx",
         "hashed_secret": "4d3f5429714b267f0714ed59737e6c2475826176",
         "is_verified": false,
-        "line_number": 8
+        "line_number": 9
       }
     ],
     "src/app/Scenes/City/Components/FairEventSection/__tests__/FairEventSection.tests.tsx": [
@@ -1227,5 +1227,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-22T08:41:01Z"
+  "generated_at": "2026-08-24T10:00:43Z"
 }

--- a/src/app/Scenes/City/Components/EventSection/EventSection.tsx
+++ b/src/app/Scenes/City/Components/EventSection/EventSection.tsx
@@ -3,10 +3,11 @@ import { CaretButton } from "app/Components/Buttons/CaretButton"
 import { Event } from "app/Scenes/City/Components/Event/Event"
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
+import { Show } from "app/utils/cityGuide/types"
 
 export interface Props {
   title: string
-  data: any
+  data: Show[]
   section: string
   citySlug: string
 }
@@ -17,11 +18,9 @@ export const EventSection: React.FC<Props> = ({ title, data, section, citySlug }
   }
 
   const eligibleForBrick = data.filter(
-    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-    (s) => !s.isStubShow && !!s.cover_image && !!s.cover_image.url
+    (show) => !show.isStubShow && !!show.cover_image && !!show.cover_image.url
   )
   const finalShowsForPreviewBricks = eligibleForBrick.slice(0, 2)
-  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const eventBricks = finalShowsForPreviewBricks.map((event) => (
     <Box key={event.id}>
       <Event event={event} />

--- a/src/app/Scenes/City/Components/EventSection/__tests__/EventSection.tests.tsx
+++ b/src/app/Scenes/City/Components/EventSection/__tests__/EventSection.tests.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react-native"
 import { EventSection } from "app/Scenes/City/Components/EventSection/EventSection"
+import { Show } from "app/utils/cityGuide/types"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 const data = [
@@ -16,7 +17,7 @@ const data = [
       name: "Pacita Abad Art Estate",
     },
   },
-]
+] as any as Show[]
 
 describe("CityEvent", () => {
   it("renders properly", () => {

--- a/src/app/Scenes/City/Components/SavedEventSection/SavedEventSection.tsx
+++ b/src/app/Scenes/City/Components/SavedEventSection/SavedEventSection.tsx
@@ -4,10 +4,11 @@ import PinSavedOff from "app/Components/Icons/PinSavedOff"
 import PinSavedOn from "app/Components/Icons/PinSavedOn"
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
+import { Show } from "app/utils/cityGuide/types"
 import { TouchableWithoutFeedback } from "react-native"
 
 export interface Props {
-  data: any
+  data: Show[]
   citySlug: string
 }
 


### PR DESCRIPTION
This PR resolves [FIREWORKS-7]

### Description

Part of the `Scenes/City` best-practices cleanup (item 4 of 5, "any-type cleanup"). Stacked on top of #13962 (shared type extraction) since these files now type against the relocated `Show` type — **the diff below includes #13962's changes until that PR merges; once it does and this branch is rebased, this diff will only contain the type cleanup.**

Types `EventSection`'s and `SavedEventSection`'s `data`/props against `Show` instead of `any`, and removes the `@ts-expect-error` suppressions inside `EventSection`'s filtering logic that the loose `any` typing previously required. No behavior change.

**Combined concerns in this PR (noted per the split-to-prs request):**
- Deletes the now-stale duplicate `EventSection/__tests__/index.tests.tsx` (identical to `EventSection/EventSection.tests.tsx`). Its untyped fixture stopped satisfying `EventSection`'s stricter `Props` once this PR's type change landed, so it had to go here rather than waiting for the separate test-dedupe PR (#13963), which handles the equivalent cleanup for the other City test files.

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**. (no UI change; verified via `yarn tsc`, `yarn lint`, and scoped `yarn jest` runs)
  - [x] **iOS**. (no UI change; verified via `yarn tsc`, `yarn lint`, and scoped `yarn jest` runs)
- [x] I hid my changes behind a **feature flag**, or they don't need one. (pure type-safety refactor, no behavior change)
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any. (existing coverage preserved)
- [x] I added an **app state migration**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog

</details>

Made with [Cursor](https://cursor.com)

[FIREWORKS-7]: https://artsyproduct.atlassian.net/browse/FIREWORKS-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ