### PR TITLE
refactor(city): migrate CityFairList, CitySavedList, and Event to Relay hooks

### DIFF
--- a/src/app/Scenes/City/CityFairList.tsx
+++ b/src/app/Scenes/City/CityFairList.tsx
@@ -1,186 +1,192 @@
-import { Box, Text, Separator } from "@artsy/palette-mobile"
+import { Box, Flex, Separator, Spinner, Text } from "@artsy/palette-mobile"
+import { FlashList, ListRenderItem } from "@shopify/flash-list"
+import { CityFairListPaginationQuery } from "__generated__/CityFairListPaginationQuery.graphql"
 import { CityFairListQuery } from "__generated__/CityFairListQuery.graphql"
-import { CityFairList_city$data } from "__generated__/CityFairList_city.graphql"
-import Spinner from "app/Components/Spinner"
+import { CityFairList_viewer$key } from "__generated__/CityFairList_viewer.graphql"
+import { LoadFailureView } from "app/Components/LoadFailureView"
 import { PAGE_SIZE } from "app/Components/constants"
-import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { TabFairItemRow } from "app/Scenes/City/Components/TabFairItemRow/TabFairItemRow"
+import { Fair } from "app/utils/cityGuide/types"
+import { extractNodes } from "app/utils/extractNodes"
+import { withSuspense } from "app/utils/hooks/withSuspense"
 import { isCloseToBottom } from "app/utils/isCloseToBottom"
-import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
-import { Schema, screenTrack } from "app/utils/track"
-import React from "react"
-import { FlatList } from "react-native"
-import { createPaginationContainer, graphql, QueryRenderer, RelayPaginationProp } from "react-relay"
-import { TabFairItemRow } from "./Components/TabFairItemRow/TabFairItemRow"
+import { Schema } from "app/utils/track"
+import { useCallback, useEffect, useState } from "react"
+import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
+import { useTracking } from "react-tracking"
 
-interface Props extends Pick<CityFairListQuery["variables"], "citySlug"> {
-  city: CityFairList_city$data
-  relay: RelayPaginationProp
-}
-
-interface State {
-  fetchingNextPage: boolean
-}
-
-@screenTrack((props: Props) => ({
-  context_screen: Schema.PageNames.CityGuideFairsList,
-  context_screen_owner_type: Schema.OwnerEntityTypes.CityGuide,
-  context_screen_owner_slug: props.city.slug,
-  context_screen_owner_id: props.city.slug,
-}))
-class CityFairList extends React.Component<Props, State> {
-  state = {
-    fetchingNextPage: false,
-  }
-
-  fetchData = () => {
-    const { relay } = this.props
-
-    if (!relay.hasMore() || relay.isLoading()) {
-      return
-    }
-    this.setState({ fetchingNextPage: true })
-    relay.loadMore(PAGE_SIZE, (error) => {
-      if (error) {
-        console.error("CityFairList.tsx #fetchData", error.message)
-        // FIXME: Handle error
-      }
-      this.setState({ fetchingNextPage: false })
-    })
-  }
-
-  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-  renderItem = (item) => {
-    return (
-      <Box py={2}>
-        <TabFairItemRow item={item.node} />
-      </Box>
-    )
-  }
-
-  // @TODO: Implement test for this component https://artsyproduct.atlassian.net/browse/LD-562
-  render() {
-    const {
-      city: {
-        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-        fairs: { edges },
-      },
-    } = this.props
-    const { fetchingNextPage } = this.state
-    return (
-      <Box mx={2}>
-        <FlatList
-          ListHeaderComponent={() => {
-            return (
-              <Box pt={6} mt={4} mb={2}>
-                <Text variant="lg-display">Fairs</Text>
-              </Box>
-            )
-          }}
-          data={edges}
-          ItemSeparatorComponent={() => <Separator />}
-          keyExtractor={(item) => item.node.internalID}
-          renderItem={({ item }) => this.renderItem(item)}
-          onScroll={isCloseToBottom(this.fetchData)}
-          ListFooterComponent={() =>
-            !!fetchingNextPage && <Spinner style={{ marginTop: 20, marginBottom: 20 }} />
-          }
-        />
-      </Box>
-    )
-  }
-}
-
-export const CityFairListContainer = createPaginationContainer(
-  CityFairList,
-  {
-    city: graphql`
-      fragment CityFairList_city on City
-      @argumentDefinitions(
-        count: { type: "Int", defaultValue: 20 }
-        cursor: { type: "String", defaultValue: "" }
-      ) {
-        slug
-        fairs: fairsConnection(first: $count, after: $cursor, status: CURRENT, sort: START_AT_ASC)
-          @connection(key: "CityFairList_fairs") {
-          edges {
-            node {
-              internalID
-              name
-              exhibition_period: exhibitionPeriod(format: SHORT)
-              counts {
-                partners
-              }
-              location {
-                coordinates {
-                  lat
-                  lng
-                }
-              }
-              image {
-                image_url: imageURL
-                aspect_ratio: aspectRatio
-                url
-              }
-              profile {
-                icon {
-                  internalID
-                  href
-                  height
-                  width
-                  url(version: "square140")
-                }
-                id
-                slug
-                name
-              }
-              start_at: startAt
-              end_at: endAt
-            }
-          }
-        }
-      }
-    `,
-  },
-  {
-    getConnectionFromProps(props) {
-      return props.city && props.city.fairs
-    },
-    getVariables(props, { count, cursor }, fragmentVariables) {
-      return {
-        citySlug: props.citySlug,
-        ...fragmentVariables,
-        count,
-        cursor,
-      }
-    },
-    query: graphql`
-      query CityFairListPaginationQuery($count: Int!, $cursor: String, $citySlug: String!) {
-        city(slug: $citySlug) {
-          ...CityFairList_city @arguments(count: $count, cursor: $cursor)
-        }
-      }
-    `,
-  }
-)
-
-interface CityFairListProps {
+interface Props {
+  viewer: CityFairList_viewer$key
   citySlug: string
 }
-export const CityFairListScreenQuery = graphql`
-  query CityFairListQuery($citySlug: String!) {
+
+const CityFairList: React.FC<Props> = ({ viewer, citySlug }) => {
+  const [fetchingNextPage, setFetchingNextPage] = useState(false)
+  const { trackEvent } = useTracking()
+
+  const { data, loadNext, hasNext, isLoadingNext } = usePaginationFragment<
+    CityFairListPaginationQuery,
+    CityFairList_viewer$key
+  >(cityFairListFragment, viewer)
+
+  useEffect(() => {
+    trackEvent(tracks.trackScreen(citySlug))
+  }, [trackEvent, citySlug])
+
+  const fetchData = useCallback(() => {
+    if (!hasNext || isLoadingNext) {
+      return
+    }
+
+    setFetchingNextPage(true)
+    loadNext(PAGE_SIZE, {
+      onComplete: (error) => {
+        if (error) {
+          console.error("CityFairList.tsx #fetchData", error.message)
+        }
+        setFetchingNextPage(false)
+      },
+    })
+  }, [hasNext, isLoadingNext, loadNext])
+
+  const fairs = extractNodes(data.city?.fairs)
+
+  const renderItem: ListRenderItem<(typeof fairs)[number]> = useCallback(
+    ({ item }) => (
+      <Box py={2}>
+        <TabFairItemRow item={item as unknown as Fair} />
+      </Box>
+    ),
+    []
+  )
+
+  const keyExtractor = useCallback((item: (typeof fairs)[number]) => item.internalID, [])
+
+  const renderListHeader = useCallback(
+    () => (
+      <Box pt={6} mt={4} mb={2}>
+        <Text variant="lg-display">Fairs</Text>
+      </Box>
+    ),
+    []
+  )
+
+  const renderListFooter = useCallback(
+    () => (fetchingNextPage ? <Spinner style={{ marginTop: 20, marginBottom: 20 }} /> : null),
+    [fetchingNextPage]
+  )
+
+  return (
+    <Box mx={2} flex={1}>
+      <FlashList
+        data={fairs}
+        ListHeaderComponent={renderListHeader}
+        ItemSeparatorComponent={Separator}
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+        onScroll={isCloseToBottom(fetchData)}
+        ListFooterComponent={renderListFooter}
+      />
+    </Box>
+  )
+}
+
+const cityFairListFragment = graphql`
+  fragment CityFairList_viewer on Viewer
+  @refetchable(queryName: "CityFairListPaginationQuery")
+  @argumentDefinitions(
+    citySlug: { type: "String!" }
+    count: { type: "Int", defaultValue: 20 }
+    cursor: { type: "String", defaultValue: "" }
+  ) {
     city(slug: $citySlug) {
-      ...CityFairList_city
+      fairs: fairsConnection(first: $count, after: $cursor, status: CURRENT, sort: START_AT_ASC)
+        @connection(key: "CityFairList_fairs") {
+        edges {
+          node {
+            internalID
+            slug
+            name
+            exhibition_period: exhibitionPeriod(format: SHORT)
+            counts {
+              partners
+            }
+            location {
+              coordinates {
+                lat
+                lng
+              }
+            }
+            image {
+              image_url: imageURL
+              aspect_ratio: aspectRatio
+              url
+            }
+            profile {
+              icon {
+                internalID
+                href
+                height
+                width
+                url(version: "square140")
+              }
+              id
+              slug
+              name
+            }
+            start_at: startAt
+            end_at: endAt
+          }
+        }
+      }
     }
   }
 `
 
-export const CityFairListQueryRenderer: React.FC<CityFairListProps> = ({ citySlug }) => {
-  return (
-    <QueryRenderer<CityFairListQuery>
-      environment={getRelayEnvironment()}
-      query={CityFairListScreenQuery}
-      variables={{ citySlug }}
-      render={renderWithLoadProgress(CityFairListContainer)}
+interface CityFairListProps {
+  citySlug: string
+}
+
+export const CityFairListScreenQuery = graphql`
+  query CityFairListQuery($citySlug: String!) {
+    viewer {
+      ...CityFairList_viewer @arguments(citySlug: $citySlug)
+    }
+  }
+`
+
+export const CityFairListQueryRenderer: React.FC<CityFairListProps> = withSuspense({
+  Component: ({ citySlug }) => {
+    const data = useLazyLoadQuery<CityFairListQuery>(CityFairListScreenQuery, { citySlug })
+
+    if (!data.viewer) {
+      return null
+    }
+
+    return <CityFairList viewer={data.viewer} citySlug={citySlug} />
+  },
+  ErrorFallback: (fallbackProps) => (
+    <LoadFailureView
+      onRetry={fallbackProps.resetErrorBoundary}
+      useSafeArea={false}
+      showCloseButton
+      error={fallbackProps.error}
+      showBackButton
+      trackErrorBoundary={false}
     />
-  )
+  ),
+  LoadingFallback: () => (
+    <Flex flex={1} alignItems="center" justifyContent="center" testID="placeholder">
+      <Spinner />
+    </Flex>
+  ),
+})
+
+const tracks = {
+  trackScreen: (citySlug: string) => ({
+    context_screen: Schema.PageNames.CityGuideFairsList,
+    context_screen_owner_type: Schema.OwnerEntityTypes.CityGuide,
+    context_screen_owner_slug: citySlug,
+    context_screen_owner_id: citySlug,
+  }),
 }

--- a/src/app/Scenes/City/CityFairList.tsx
+++ b/src/app/Scenes/City/CityFairList.tsx
@@ -3,16 +3,18 @@ import { FlashList, ListRenderItem } from "@shopify/flash-list"
 import { CityFairListPaginationQuery } from "__generated__/CityFairListPaginationQuery.graphql"
 import { CityFairListQuery } from "__generated__/CityFairListQuery.graphql"
 import { CityFairList_viewer$key } from "__generated__/CityFairList_viewer.graphql"
+import { CityGuideFair_fair$key } from "__generated__/CityGuideFair_fair.graphql"
 import { LoadFailureView } from "app/Components/LoadFailureView"
 import { PAGE_SIZE } from "app/Components/constants"
 import { TabFairItemRow } from "app/Scenes/City/Components/TabFairItemRow/TabFairItemRow"
+import { cityGuideFairFragment } from "app/utils/cityGuide/CityGuideFair"
 import { Fair } from "app/utils/cityGuide/types"
 import { extractNodes } from "app/utils/extractNodes"
 import { withSuspense } from "app/utils/hooks/withSuspense"
 import { isCloseToBottom } from "app/utils/isCloseToBottom"
 import { Schema } from "app/utils/track"
 import { useCallback, useEffect, useState } from "react"
-import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
+import { graphql, useFragment, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 
 interface Props {
@@ -49,18 +51,19 @@ const CityFairList: React.FC<Props> = ({ viewer, citySlug }) => {
     })
   }, [hasNext, isLoadingNext, loadNext])
 
-  const fairs = extractNodes(data.city?.fairs)
+  const fairRefs: CityGuideFair_fair$key = extractNodes(data.city?.fairs)
+  const fairs = useFragment(cityGuideFairFragment, fairRefs)
 
-  const renderItem: ListRenderItem<(typeof fairs)[number]> = useCallback(
+  const renderItem: ListRenderItem<Fair> = useCallback(
     ({ item }) => (
       <Box py={2}>
-        <TabFairItemRow item={item as unknown as Fair} />
+        <TabFairItemRow item={item} />
       </Box>
     ),
     []
   )
 
-  const keyExtractor = useCallback((item: (typeof fairs)[number]) => item.internalID, [])
+  const keyExtractor = useCallback((item: Fair) => item.internalID, [])
 
   const renderListHeader = useCallback(
     () => (
@@ -104,38 +107,7 @@ const cityFairListFragment = graphql`
         @connection(key: "CityFairList_fairs") {
         edges {
           node {
-            internalID
-            slug
-            name
-            exhibition_period: exhibitionPeriod(format: SHORT)
-            counts {
-              partners
-            }
-            location {
-              coordinates {
-                lat
-                lng
-              }
-            }
-            image {
-              image_url: imageURL
-              aspect_ratio: aspectRatio
-              url
-            }
-            profile {
-              icon {
-                internalID
-                href
-                height
-                width
-                url(version: "square140")
-              }
-              id
-              slug
-              name
-            }
-            start_at: startAt
-            end_at: endAt
+            ...CityGuideFair_fair
           }
         }
       }

--- a/src/app/Scenes/City/CitySavedList.tsx
+++ b/src/app/Scenes/City/CitySavedList.tsx
@@ -1,124 +1,113 @@
+import { Flex, Spinner } from "@artsy/palette-mobile"
+import { CitySavedListPaginationQuery } from "__generated__/CitySavedListPaginationQuery.graphql"
 import { CitySavedListQuery } from "__generated__/CitySavedListQuery.graphql"
-import { CitySavedList_city$data } from "__generated__/CitySavedList_city.graphql"
-import { CitySavedList_me$data } from "__generated__/CitySavedList_me.graphql"
+import { CitySavedList_me$key } from "__generated__/CitySavedList_me.graphql"
+import { LoadFailureView } from "app/Components/LoadFailureView"
 import { PAGE_SIZE } from "app/Components/constants"
-import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { Show } from "app/utils/cityGuide/types"
 import { extractNodes } from "app/utils/extractNodes"
+import { withSuspense } from "app/utils/hooks/withSuspense"
 import { isCloseToBottom } from "app/utils/isCloseToBottom"
-import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
-import { Schema, screenTrack } from "app/utils/track"
-import React from "react"
-import { createPaginationContainer, graphql, QueryRenderer, RelayPaginationProp } from "react-relay"
+import { Schema } from "app/utils/track"
+import { useCallback, useEffect, useState } from "react"
+import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
+import { useTracking } from "react-tracking"
 import { EventList } from "./Components/EventList"
 
 interface Props {
-  me: CitySavedList_me$data
-  city: CitySavedList_city$data
-  relay: RelayPaginationProp
+  me: CitySavedList_me$key
+  cityName: string
   citySlug: string
 }
 
-interface State {
-  fetchingNextPage: boolean
-}
+const CitySavedList: React.FC<Props> = ({ me, cityName, citySlug }) => {
+  const [fetchingNextPage, setFetchingNextPage] = useState(false)
+  const { trackEvent } = useTracking()
 
-@screenTrack((props: Props) => ({
-  context_screen: Schema.PageNames.CityGuideSavedList,
-  context_screen_owner_type: Schema.OwnerEntityTypes.CityGuide,
-  context_screen_owner_slug: props.citySlug,
-  context_screen_owner_id: props.citySlug,
-}))
-class CitySavedList extends React.Component<Props, State> {
-  state = {
-    fetchingNextPage: false,
-  }
+  const { data, loadNext, hasNext, isLoadingNext } = usePaginationFragment<
+    CitySavedListPaginationQuery,
+    CitySavedList_me$key
+  >(citySavedListFragment, me)
 
-  fetchData = () => {
-    const { relay } = this.props
+  useEffect(() => {
+    trackEvent(tracks.trackScreen(citySlug))
+  }, [trackEvent, citySlug])
 
-    if (!relay.hasMore() || relay.isLoading()) {
+  const fetchData = useCallback(() => {
+    if (!hasNext || isLoadingNext) {
       return
     }
-    this.setState({ fetchingNextPage: true })
-    relay.loadMore(PAGE_SIZE, (error) => {
-      if (error) {
-        console.error("CitySectionList.tsx #fetchData", error.message)
-        // FIXME: Handle error
-      }
-      this.setState({ fetchingNextPage: false })
-    })
-  }
 
-  // @TODO: Implement test for this component https://artsyproduct.atlassian.net/browse/LD-562
-  render() {
-    const { fetchingNextPage } = this.state
-    return (
-      <EventList
-        header="Saved shows"
-        cityName={this.props.city.name}
-        bucket={extractNodes(this.props.me.followsAndSaves?.shows)}
-        type="saved"
-        onScroll={isCloseToBottom(this.fetchData) as any}
-        fetchingNextPage={fetchingNextPage}
-      />
-    )
-  }
+    setFetchingNextPage(true)
+    loadNext(PAGE_SIZE, {
+      onComplete: (error) => {
+        if (error) {
+          console.error("CitySavedList.tsx #fetchData", error.message)
+        }
+        setFetchingNextPage(false)
+      },
+    })
+  }, [hasNext, isLoadingNext, loadNext])
+
+  const shows = extractNodes(data.followsAndSaves?.shows) as unknown as Show[]
+
+  return (
+    <EventList
+      header="Saved shows"
+      cityName={cityName}
+      bucket={shows}
+      type="saved"
+      onScroll={isCloseToBottom(fetchData)}
+      fetchingNextPage={fetchingNextPage}
+    />
+  )
 }
 
-export const CitySavedListContainer = createPaginationContainer(
-  CitySavedList,
-  {
-    city: graphql`
-      fragment CitySavedList_city on City {
-        name
-      }
-    `,
-    me: graphql`
-      fragment CitySavedList_me on Me
-      @argumentDefinitions(
-        count: { type: "Int", defaultValue: 20 }
-        cursor: { type: "String", defaultValue: "" }
-      ) {
-        followsAndSaves {
-          shows: showsConnection(
-            first: $count
-            status: RUNNING_AND_UPCOMING
-            city: $citySlug
-            after: $cursor
-          ) @connection(key: "CitySavedList_shows") {
-            edges {
-              node {
-                slug
-                internalID
-                id
+const citySavedListFragment = graphql`
+  fragment CitySavedList_me on Me
+  @refetchable(queryName: "CitySavedListPaginationQuery")
+  @argumentDefinitions(
+    citySlug: { type: "String!" }
+    count: { type: "Int", defaultValue: 20 }
+    cursor: { type: "String", defaultValue: "" }
+  ) {
+    followsAndSaves {
+      shows: showsConnection(
+        first: $count
+        status: RUNNING_AND_UPCOMING
+        city: $citySlug
+        after: $cursor
+      ) @connection(key: "CitySavedList_shows") {
+        edges {
+          node {
+            slug
+            internalID
+            id
+            name
+            isStubShow
+            status
+            href
+            is_followed: isFollowed
+            exhibition_period: exhibitionPeriod(format: SHORT)
+            cover_image: coverImage {
+              url
+            }
+            location {
+              coordinates {
+                lat
+                lng
+              }
+            }
+            type
+            start_at: startAt
+            end_at: endAt
+            partner {
+              ... on Partner {
                 name
-                isStubShow
-                status
-                href
-                is_followed: isFollowed
-                isStubShow
-                exhibition_period: exhibitionPeriod(format: SHORT)
-                cover_image: coverImage {
-                  url
-                }
-                location {
-                  coordinates {
-                    lat
-                    lng
-                  }
-                }
                 type
-                start_at: startAt
-                end_at: endAt
-                partner {
-                  ... on Partner {
-                    name
-                    type
-                    profile {
-                      image {
-                        url(version: "square")
-                      }
-                    }
+                profile {
+                  image {
+                    url(version: "square")
                   }
                 }
               }
@@ -126,54 +115,57 @@ export const CitySavedListContainer = createPaginationContainer(
           }
         }
       }
-    `,
-  },
-  {
-    getConnectionFromProps(props) {
-      return props.me && props.me.followsAndSaves && props.me.followsAndSaves.shows
-    },
-    getVariables(props, { count, cursor }, fragmentVariables) {
-      return {
-        citySlug: props.citySlug,
-        ...fragmentVariables,
-        count,
-        cursor,
-      }
-    },
-    query: graphql`
-      query CitySavedListPaginationQuery($count: Int!, $cursor: String, $citySlug: String!) {
-        me {
-          ...CitySavedList_me @arguments(count: $count, cursor: $cursor)
-        }
-        city(slug: $citySlug) {
-          ...CitySavedList_city
-        }
-      }
-    `,
-  }
-)
-
-interface CitySavedListProps {
-  citySlug: string
-}
-export const CitySavedListScreenQuery = graphql`
-  query CitySavedListQuery($citySlug: String!) {
-    me {
-      ...CitySavedList_me
-    }
-    city(slug: $citySlug) {
-      ...CitySavedList_city
     }
   }
 `
 
-export const CitySavedListQueryRenderer: React.FC<CitySavedListProps> = ({ citySlug }) => {
-  return (
-    <QueryRenderer<CitySavedListQuery>
-      environment={getRelayEnvironment()}
-      query={CitySavedListScreenQuery}
-      variables={{ citySlug }}
-      render={renderWithLoadProgress(CitySavedListContainer)}
+interface CitySavedListProps {
+  citySlug: string
+}
+
+export const CitySavedListScreenQuery = graphql`
+  query CitySavedListQuery($citySlug: String!) {
+    me {
+      ...CitySavedList_me @arguments(citySlug: $citySlug)
+    }
+    city(slug: $citySlug) {
+      name
+    }
+  }
+`
+
+export const CitySavedListQueryRenderer: React.FC<CitySavedListProps> = withSuspense({
+  Component: ({ citySlug }) => {
+    const data = useLazyLoadQuery<CitySavedListQuery>(CitySavedListScreenQuery, { citySlug })
+
+    if (!data.me || !data.city) {
+      return null
+    }
+
+    return <CitySavedList me={data.me} cityName={data.city.name ?? ""} citySlug={citySlug} />
+  },
+  ErrorFallback: (fallbackProps) => (
+    <LoadFailureView
+      onRetry={fallbackProps.resetErrorBoundary}
+      useSafeArea={false}
+      showCloseButton
+      error={fallbackProps.error}
+      showBackButton
+      trackErrorBoundary={false}
     />
-  )
+  ),
+  LoadingFallback: () => (
+    <Flex flex={1} alignItems="center" justifyContent="center" testID="placeholder">
+      <Spinner />
+    </Flex>
+  ),
+})
+
+const tracks = {
+  trackScreen: (citySlug: string) => ({
+    context_screen: Schema.PageNames.CityGuideSavedList,
+    context_screen_owner_type: Schema.OwnerEntityTypes.CityGuide,
+    context_screen_owner_slug: citySlug,
+    context_screen_owner_id: citySlug,
+  }),
 }

--- a/src/app/Scenes/City/CitySavedList.tsx
+++ b/src/app/Scenes/City/CitySavedList.tsx
@@ -1,16 +1,17 @@
 import { Flex, Spinner } from "@artsy/palette-mobile"
+import { CityGuideShow_show$key } from "__generated__/CityGuideShow_show.graphql"
 import { CitySavedListPaginationQuery } from "__generated__/CitySavedListPaginationQuery.graphql"
 import { CitySavedListQuery } from "__generated__/CitySavedListQuery.graphql"
 import { CitySavedList_me$key } from "__generated__/CitySavedList_me.graphql"
 import { LoadFailureView } from "app/Components/LoadFailureView"
 import { PAGE_SIZE } from "app/Components/constants"
-import { Show } from "app/utils/cityGuide/types"
+import { cityGuideShowFragment } from "app/utils/cityGuide/CityGuideShow"
 import { extractNodes } from "app/utils/extractNodes"
 import { withSuspense } from "app/utils/hooks/withSuspense"
 import { isCloseToBottom } from "app/utils/isCloseToBottom"
 import { Schema } from "app/utils/track"
 import { useCallback, useEffect, useState } from "react"
-import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
+import { graphql, useFragment, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 import { EventList } from "./Components/EventList"
 
@@ -49,13 +50,14 @@ const CitySavedList: React.FC<Props> = ({ me, cityName, citySlug }) => {
     })
   }, [hasNext, isLoadingNext, loadNext])
 
-  const shows = extractNodes(data.followsAndSaves?.shows) as unknown as Show[]
+  const showRefs: CityGuideShow_show$key = extractNodes(data.followsAndSaves?.shows)
+  const shows = useFragment(cityGuideShowFragment, showRefs)
 
   return (
     <EventList
       header="Saved shows"
       cityName={cityName}
-      bucket={shows}
+      bucket={[...shows]}
       type="saved"
       onScroll={isCloseToBottom(fetchData)}
       fetchingNextPage={fetchingNextPage}
@@ -80,38 +82,7 @@ const citySavedListFragment = graphql`
       ) @connection(key: "CitySavedList_shows") {
         edges {
           node {
-            slug
-            internalID
-            id
-            name
-            isStubShow
-            status
-            href
-            is_followed: isFollowed
-            exhibition_period: exhibitionPeriod(format: SHORT)
-            cover_image: coverImage {
-              url
-            }
-            location {
-              coordinates {
-                lat
-                lng
-              }
-            }
-            type
-            start_at: startAt
-            end_at: endAt
-            partner {
-              ... on Partner {
-                name
-                type
-                profile {
-                  image {
-                    url(version: "square")
-                  }
-                }
-              }
-            }
+            ...CityGuideShow_show
           }
         }
       }

--- a/src/app/Scenes/City/Components/Event/Event.tsx
+++ b/src/app/Scenes/City/Components/Event/Event.tsx
@@ -2,13 +2,12 @@ import { Box, Button, Flex, Image, Text, useColor } from "@artsy/palette-mobile"
 import { EventMutation } from "__generated__/EventMutation.graphql"
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
-import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { Show } from "app/utils/cityGuide/types"
 import { exhibitionDates } from "app/utils/exhibitionPeriodParser"
 import { Schema } from "app/utils/track"
 import { useState } from "react"
 import { TouchableWithoutFeedback } from "react-native"
-import { commitMutation, graphql } from "react-relay"
+import { graphql, useMutation } from "react-relay"
 import { useTracking } from "react-tracking"
 
 const TEXT_CONTAINER_WIDTH = 200
@@ -18,13 +17,17 @@ interface Props {
 }
 
 export const Event: React.FC<Props> = ({ event }) => {
-  const color = useColor()
-  const { trackEvent } = useTracking()
-  const [isFollowedSaving, setIsFollowedSaving] = useState(false)
-
   const { name, exhibition_period, partner, cover_image, is_followed, end_at } = event
   const partnerName = partner?.name
   const url = cover_image ? cover_image.url : null
+  const color = useColor()
+  const { trackEvent } = useTracking()
+  const [isFollowedSaving, setIsFollowedSaving] = useState(false)
+  const [commitFollowShow] = useMutation<EventMutation>(eventMutation)
+
+  const handleTap = () => {
+    navigate(`/show/${event.slug}`)
+  }
 
   const handleSaveChange = () => {
     const { slug: showSlug, id: nodeID, internalID: showID, is_followed: isShowFollowed } = event
@@ -34,34 +37,17 @@ export const Event: React.FC<Props> = ({ event }) => {
     }
 
     setIsFollowedSaving(true)
+    trackEvent(tracks.trackSave(event))
 
-    commitMutation<EventMutation>(getRelayEnvironment(), {
-      onCompleted: () => {
-        setIsFollowedSaving(false)
-        trackEvent({
-          action_name: isShowFollowed ? Schema.ActionNames.UnsaveShow : Schema.ActionNames.SaveShow,
-          action_type: Schema.ActionTypes.Success,
-          owner_type: Schema.OwnerEntityTypes.Show,
-          owner_id: showID,
-          owner_slug: showSlug,
-        })
-      },
-      mutation: graphql`
-        mutation EventMutation($input: FollowShowInput!) {
-          followShow(input: $input) {
-            show {
-              slug
-              internalID
-              is_followed: isFollowed
-            }
-          }
-        }
-      `,
+    commitFollowShow({
       variables: {
         input: {
           partnerShowID: showID,
           unfollow: isShowFollowed,
         },
+      },
+      onCompleted: () => {
+        setIsFollowedSaving(false)
       },
       // @ts-ignore RELAY 12 MIGRATION
       optimisticResponse: {
@@ -78,10 +64,6 @@ export const Event: React.FC<Props> = ({ event }) => {
         store.get(nodeID).setValue(!isShowFollowed, "is_followed")
       },
     })
-  }
-
-  const handleTap = () => {
-    navigate(`/show/${event.slug}`)
   }
 
   return (
@@ -119,4 +101,31 @@ export const Event: React.FC<Props> = ({ event }) => {
       </Box>
     </TouchableWithoutFeedback>
   )
+}
+
+const eventMutation = graphql`
+  mutation EventMutation($input: FollowShowInput!) {
+    followShow(input: $input) {
+      show {
+        slug
+        internalID
+        is_followed: isFollowed
+      }
+    }
+  }
+`
+
+const tracks = {
+  trackSave: (event: Show) => {
+    const { slug, internalID, is_followed } = event
+    const actionName = is_followed ? Schema.ActionNames.UnsaveShow : Schema.ActionNames.SaveShow
+
+    return {
+      action_name: actionName,
+      action_type: Schema.ActionTypes.Success,
+      owner_type: Schema.OwnerEntityTypes.Show,
+      owner_id: internalID,
+      owner_slug: slug,
+    }
+  },
 }

--- a/src/app/Scenes/Map/GlobalMap.tsx
+++ b/src/app/Scenes/Map/GlobalMap.tsx
@@ -1,11 +1,15 @@
 import { Flex, useColor, useSpace } from "@artsy/palette-mobile"
 import MapboxGL from "@rnmapbox/maps"
+import { CityGuideFair_fair$key } from "__generated__/CityGuideFair_fair.graphql"
+import { CityGuideShow_show$key } from "__generated__/CityGuideShow_show.graphql"
 import { GlobalMap_viewer$key } from "__generated__/GlobalMap_viewer.graphql"
 import { CityBottomSheet } from "app/Scenes/City/CityBottomSheet"
 import { CityData, CityPicker } from "app/Scenes/City/CityPicker"
 import { cityTabs } from "app/Scenes/City/cityTabs"
 import { MAX_GRAPHQL_INT } from "app/Scenes/Map/MapRenderer"
 import { GlobalStore } from "app/store/GlobalStore"
+import { cityGuideFairFragment } from "app/utils/cityGuide/CityGuideFair"
+import { cityGuideShowFragment } from "app/utils/cityGuide/CityGuideShow"
 import { EventEmitter } from "app/utils/cityGuide/EventEmitter"
 import {
   bucketCityResults,
@@ -14,6 +18,7 @@ import {
   emptyBucketResults,
 } from "app/utils/cityGuide/bucketCityResults"
 import { DrawerPosition, Fair, FilterData, Show } from "app/utils/cityGuide/types"
+import { extractNodes } from "app/utils/extractNodes"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
 import { isEqual } from "lodash"
 import { AnimatePresence } from "moti"
@@ -21,7 +26,7 @@ import React, { useEffect, useRef, useState } from "react"
 import { Platform } from "react-native"
 import Keys from "react-native-keys"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
-import { graphql, useRefetchableFragment } from "react-relay"
+import { graphql, useFragment, useRefetchableFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 import usePrevious from "react-use/lib/usePrevious"
 import { GlobalMapHeader } from "./Components/GlobalMapHeader"
@@ -55,6 +60,13 @@ export const GlobalMap: React.FC<Props> = (props) => {
 
   const [viewer, refetch] = useRefetchableFragment(globalMapFragment, props.viewer)
   const { trackEvent } = useTracking()
+
+  const showRefs: CityGuideShow_show$key = extractNodes(viewer.city?.shows)
+  const upcomingShowRefs: CityGuideShow_show$key = extractNodes(viewer.city?.upcomingShows)
+  const fairRefs: CityGuideFair_fair$key = extractNodes(viewer.city?.fairs)
+  const shows = useFragment(cityGuideShowFragment, showRefs)
+  const upcomingShows = useFragment(cityGuideShowFragment, upcomingShowRefs)
+  const fairs = useFragment(cityGuideFairFragment, fairRefs)
 
   const mapRef = useRef<MapboxGL.MapView>(null)
   const cameraRef = useRef<MapboxGL.Camera>(null)
@@ -109,7 +121,7 @@ export const GlobalMap: React.FC<Props> = (props) => {
   useEffect(() => {
     if (viewer) {
       // TODO: This is currently really inefficient.
-      const newBucketResults = bucketCityResults(viewer)
+      const newBucketResults = bucketCityResults(shows, upcomingShows, fairs)
 
       setBucketResults(newBucketResults)
       emitFilteredBucketResults(newBucketResults)
@@ -179,9 +191,13 @@ export const GlobalMap: React.FC<Props> = (props) => {
       return
     }
 
-    const { shows, fairs } = extractShowAndFairMaps(viewer.city)
-    showsRef.current = { ...showsRef.current, ...shows }
-    fairsRef.current = { ...fairsRef.current, ...fairs }
+    const { shows: showsById, fairs: fairsById } = extractShowAndFairMaps(
+      shows,
+      upcomingShows,
+      fairs
+    )
+    showsRef.current = { ...showsRef.current, ...showsById }
+    fairsRef.current = { ...fairsRef.current, ...fairsById }
   }
 
   const onUserLocationUpdate = (location: MapboxGL.Location) => {
@@ -452,38 +468,7 @@ const globalMapFragment = graphql`
       ) {
         edges {
           node {
-            slug
-            internalID
-            id
-            isStubShow
-            name
-            status
-            href
-            is_followed: isFollowed
-            exhibition_period: exhibitionPeriod(format: SHORT)
-            cover_image: coverImage {
-              url
-            }
-            location {
-              coordinates {
-                lat
-                lng
-              }
-            }
-            type
-            start_at: startAt
-            end_at: endAt
-            partner {
-              ... on Partner {
-                name
-                type
-                profile {
-                  image {
-                    url(version: "square")
-                  }
-                }
-              }
-            }
+            ...CityGuideShow_show
           }
         }
       }
@@ -495,77 +480,14 @@ const globalMapFragment = graphql`
       ) {
         edges {
           node {
-            ...ShowItemRow_show
-            slug
-            internalID
-            id
-            isStubShow
-            name
-            status
-            href
-            is_followed: isFollowed
-            exhibition_period: exhibitionPeriod(format: SHORT)
-            cover_image: coverImage {
-              url
-            }
-            location {
-              coordinates {
-                lat
-                lng
-              }
-            }
-            type
-            start_at: startAt
-            end_at: endAt
-            partner {
-              ... on Partner {
-                name
-                type
-                profile {
-                  image {
-                    url(version: "square")
-                  }
-                }
-              }
-            }
+            ...CityGuideShow_show
           }
         }
       }
       fairs: fairsConnection(first: $maxInt, status: CURRENT, sort: START_AT_ASC) {
         edges {
           node {
-            id
-            slug
-            name
-            exhibition_period: exhibitionPeriod(format: SHORT)
-            counts {
-              partners
-            }
-            location {
-              coordinates {
-                lat
-                lng
-              }
-            }
-            image {
-              image_url: imageURL
-              aspect_ratio: aspectRatio
-              url
-            }
-            profile {
-              icon {
-                internalID
-                href
-                height
-                width
-                url(version: "square140")
-              }
-              id
-              slug
-              name
-            }
-            start_at: startAt
-            end_at: endAt
+            ...CityGuideFair_fair
           }
         }
       }

--- a/src/app/Scenes/Map/helpers/__tests__/extractShowAndFairMaps.tests.ts
+++ b/src/app/Scenes/Map/helpers/__tests__/extractShowAndFairMaps.tests.ts
@@ -1,39 +1,28 @@
 import { extractShowAndFairMaps } from "app/Scenes/Map/helpers/extractShowAndFairMaps"
 
 describe(extractShowAndFairMaps, () => {
-  it("returns empty maps when there is no city", () => {
-    const result = extractShowAndFairMaps(null)
+  it("returns empty maps when there are no shows or fairs", () => {
+    const result = extractShowAndFairMaps([], [], [])
 
     expect(result).toEqual({ shows: {}, fairs: {} })
   })
 
   it("keys shows and fairs by slug", () => {
-    const city: any = {
-      upcomingShows: { edges: [] },
-      shows: {
-        edges: [
-          {
-            node: {
-              slug: "some-show",
-              is_followed: false,
-              location: { coordinates: { lat: 1, lng: 2 } },
-            },
-          },
-        ],
+    const shows: any = [
+      {
+        slug: "some-show",
+        is_followed: false,
+        location: { coordinates: { lat: 1, lng: 2 } },
       },
-      fairs: {
-        edges: [
-          {
-            node: {
-              slug: "some-fair",
-              location: { coordinates: { lat: 3, lng: 4 } },
-            },
-          },
-        ],
+    ]
+    const fairs: any = [
+      {
+        slug: "some-fair",
+        location: { coordinates: { lat: 3, lng: 4 } },
       },
-    }
+    ]
 
-    const result = extractShowAndFairMaps(city)
+    const result = extractShowAndFairMaps(shows, [], fairs)
 
     expect(Object.keys(result.shows)).toEqual(["some-show"])
     expect(Object.keys(result.fairs)).toEqual(["some-fair"])
@@ -41,47 +30,30 @@ describe(extractShowAndFairMaps, () => {
   })
 
   it("skips shows and fairs without location coordinates", () => {
-    const city: any = {
-      upcomingShows: { edges: [] },
-      shows: {
-        edges: [{ node: { slug: "no-location-show", is_followed: false, location: null } }],
-      },
-      fairs: {
-        edges: [{ node: { slug: "no-location-fair", location: { coordinates: null } } }],
-      },
-    }
+    const shows: any = [{ slug: "no-location-show", is_followed: false, location: null }]
+    const fairs: any = [{ slug: "no-location-fair", location: { coordinates: null } }]
 
-    const result = extractShowAndFairMaps(city)
+    const result = extractShowAndFairMaps(shows, [], fairs)
 
     expect(result.shows).toEqual({})
     expect(result.fairs).toEqual({})
   })
 
   it("merges followed upcoming shows with running shows", () => {
-    const city: any = {
-      upcomingShows: {
-        edges: [
-          {
-            node: {
-              slug: "upcoming-followed",
-              is_followed: true,
-              location: { coordinates: { lat: 1, lng: 2 } },
-            },
-          },
-          {
-            node: {
-              slug: "upcoming-not-followed",
-              is_followed: false,
-              location: { coordinates: { lat: 1, lng: 2 } },
-            },
-          },
-        ],
+    const upcomingShows: any = [
+      {
+        slug: "upcoming-followed",
+        is_followed: true,
+        location: { coordinates: { lat: 1, lng: 2 } },
       },
-      shows: { edges: [] },
-      fairs: { edges: [] },
-    }
+      {
+        slug: "upcoming-not-followed",
+        is_followed: false,
+        location: { coordinates: { lat: 1, lng: 2 } },
+      },
+    ]
 
-    const result = extractShowAndFairMaps(city)
+    const result = extractShowAndFairMaps([], upcomingShows, [])
 
     expect(Object.keys(result.shows)).toEqual(["upcoming-followed"])
   })

--- a/src/app/Scenes/Map/helpers/extractShowAndFairMaps.ts
+++ b/src/app/Scenes/Map/helpers/extractShowAndFairMaps.ts
@@ -1,40 +1,35 @@
-import { GlobalMap_viewer$data } from "__generated__/GlobalMap_viewer.graphql"
 import { Fair, Show } from "app/utils/cityGuide/types"
-import { extractNodes } from "app/utils/extractNodes"
 import { uniq } from "lodash"
 
 export const extractShowAndFairMaps = (
-  city: GlobalMap_viewer$data["city"]
+  shows: readonly Show[],
+  upcomingShows: readonly Show[],
+  fairs: readonly Fair[]
 ): { shows: { [key: string]: Show }; fairs: { [key: string]: Fair } } => {
-  const shows: { [key: string]: Show } = {}
-  const fairs: { [key: string]: Fair } = {}
+  const showsMap: { [key: string]: Show } = {}
+  const fairsMap: { [key: string]: Fair } = {}
 
-  if (!city) {
-    return { shows, fairs }
-  }
-
-  const savedUpcomingShows = extractNodes(city.upcomingShows).filter((node) => node.is_followed)
-  const cityShows = extractNodes(city.shows)
-  const concatedShows = uniq(cityShows.concat(savedUpcomingShows as any))
+  const savedUpcomingShows = upcomingShows.filter((node) => node.is_followed)
+  const concatedShows = uniq(shows.concat(savedUpcomingShows))
 
   concatedShows.forEach((node) => {
-    if (!node || !node.location || !node.location.coordinates) {
+    if (!node.location?.coordinates) {
       return
     }
 
-    shows[node.slug] = node
+    showsMap[node.slug] = node
   })
 
-  extractNodes(city.fairs).forEach((node) => {
-    if (!node || !node.location || !node.location.coordinates) {
+  fairs.forEach((node) => {
+    if (!node.location?.coordinates) {
       return
     }
 
-    fairs[node.slug] = {
+    fairsMap[node.slug] = {
       ...node,
       type: "Fair",
     }
   })
 
-  return { shows, fairs }
+  return { shows: showsMap, fairs: fairsMap }
 }

--- a/src/app/utils/cityGuide/CityGuideFair.ts
+++ b/src/app/utils/cityGuide/CityGuideFair.ts
@@ -1,0 +1,42 @@
+import { graphql } from "react-relay"
+
+/** Shared shape for a "fair" row across the City guide and Map scenes. Spread `...CityGuideFair_fair`
+ * on a connection's `node`, then unmask the whole extracted array in one call with
+ * `useFragment(cityGuideFairFragment, extractNodes(connection))` (plural, so it accepts an array of refs). */
+export const cityGuideFairFragment = graphql`
+  fragment CityGuideFair_fair on Fair @relay(plural: true) {
+    id
+    internalID
+    slug
+    name
+    exhibition_period: exhibitionPeriod(format: SHORT)
+    counts {
+      partners
+    }
+    location {
+      coordinates {
+        lat
+        lng
+      }
+    }
+    image {
+      image_url: imageURL
+      aspect_ratio: aspectRatio
+      url
+    }
+    profile {
+      icon {
+        internalID
+        href
+        height
+        width
+        url(version: "square140")
+      }
+      id
+      slug
+      name
+    }
+    start_at: startAt
+    end_at: endAt
+  }
+`

--- a/src/app/utils/cityGuide/CityGuideShow.ts
+++ b/src/app/utils/cityGuide/CityGuideShow.ts
@@ -1,0 +1,47 @@
+import { graphql } from "react-relay"
+
+/**
+ * Shared shape for a "show" row across the City guide and Map scenes. Spread `...CityGuideShow_show`
+ * on a connection's `node`, then unmask the whole extracted array in one call with
+ * `useFragment(cityGuideShowFragment, extractNodes(connection))` (plural, so it accepts an array of refs);
+ * also spreads `...ShowItemRow_show` internally so any consumer that renders `ShowItemRow` is guaranteed
+ * to have fetched the fields it needs, instead of relying on that data having incidentally already
+ * landed in the Relay store from elsewhere.
+ */
+export const cityGuideShowFragment = graphql`
+  fragment CityGuideShow_show on Show @relay(plural: true) {
+    ...ShowItemRow_show
+    id
+    slug
+    internalID
+    isStubShow
+    name
+    status
+    href
+    type
+    is_followed: isFollowed
+    exhibition_period: exhibitionPeriod(format: SHORT)
+    cover_image: coverImage {
+      url
+    }
+    location {
+      coordinates {
+        lat
+        lng
+      }
+    }
+    start_at: startAt
+    end_at: endAt
+    partner {
+      ... on Partner {
+        name
+        type
+        profile {
+          image {
+            url(version: "square")
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/app/utils/cityGuide/__tests__/bucketCityResults.tests.ts
+++ b/src/app/utils/cityGuide/__tests__/bucketCityResults.tests.ts
@@ -5,7 +5,11 @@ import { uniq } from "lodash"
 // The stubbed data needs re-creating
 //
 describe.skip(bucketCityResults, () => {
-  const results = bucketCityResults({ city: CityFixture } as any)
+  const results = bucketCityResults(
+    CityFixture.shows.edges.map((e: any) => e.node),
+    CityFixture.upcomingShows.edges.map((e: any) => e.node),
+    CityFixture.fairs.edges.map((e: any) => e.node)
+  )
 
   it("doesn't yet support saved results", () => {
     expect(results.saved).toEqual([])

--- a/src/app/utils/cityGuide/bucketCityResults.ts
+++ b/src/app/utils/cityGuide/bucketCityResults.ts
@@ -1,4 +1,3 @@
-import { GlobalMap_viewer$data } from "__generated__/GlobalMap_viewer.graphql"
 import { sortBy, uniq } from "lodash"
 import { DateTime } from "luxon"
 import type { Fair, Show } from "./types"
@@ -14,72 +13,45 @@ export interface BucketResults {
 
 export type BucketKey = keyof BucketResults
 
-export const bucketCityResults = (viewer: GlobalMap_viewer$data): BucketResults => {
+export const bucketCityResults = (
+  shows: readonly Show[],
+  upcomingShows: readonly Show[],
+  fairs: readonly Fair[]
+): BucketResults => {
   // The saved shows needs to be sorted by end_date_asc
   const now = DateTime.now()
   const oneWeekFromNow = DateTime.now().plus({ days: 7 })
-  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-  const savedShows = viewer.city.shows.edges.filter((e) => e.node.is_followed === true)
-  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-  const savedUpcomingShows = viewer.city.upcomingShows.edges.filter(
-    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-    (e) => e.node.is_followed === true
+
+  const savedShows = shows.filter((show) => show.is_followed === true)
+  const savedUpcomingShows = upcomingShows.filter((show) => show.is_followed === true)
+  const saved = sortBy(uniq(savedShows.concat(savedUpcomingShows)), (show) => show.end_at)
+
+  const galleries = shows.filter((show) => show.partner?.type === "Gallery")
+  const museums = shows.filter(
+    (show) => show.partner?.type === "Institution" || show.partner?.type === "InstitutionalSeller"
   )
-  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-  const savedFiltered = uniq(savedShows.concat(savedUpcomingShows)).map((n) => n.node)
-  const saved = sortBy(savedFiltered, (event) => {
-    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-    return event.end_at
-  })
-  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-  const fairs = viewer.city.fairs.edges.map((n) => n.node)
-  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-  const galleries = viewer.city.shows.edges
-    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-    .filter((e) => e.node.partner.type === "Gallery")
-    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-    .map((n) => n.node)
-  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-  const museums = viewer.city.shows.edges
-    .filter(
-      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-      (e) => e.node.partner.type === "Institution" || e.node.partner.type === "InstitutionalSeller"
-    )
-    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-    .map((n) => n.node)
 
   // Opening shows need to be sorted by start_at_asc
-  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-  const opening = viewer.city.upcomingShows.edges.map((n) => n.node)
-  // Closing needs to be sorted by end_at_asc
-  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-  const closingFiltered = viewer.city.shows.edges
-    .filter((e) => {
-      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-      if (e.node.end_at) {
-        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-        const showClosingTime = DateTime.fromISO(e.node.end_at)
-        return showClosingTime <= oneWeekFromNow && showClosingTime >= now
-      }
-    })
-    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-    .map((n) => n.node)
-  const closing = sortBy(closingFiltered, (event) => {
-    // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-    return DateTime.fromISO(event.end_at).toMillis()
-  })
+  const opening = upcomingShows
 
-  // Note: the individual `@ts-expect-error`s above are pre-existing legacy debt around
-  // `viewer.city` nullability; we assert the overall shape here so consumers get a reliable
-  // `BucketResults` contract instead of the `any` this function previously returned.
+  // Closing needs to be sorted by end_at_asc
+  const closingFiltered = shows.filter((show) => {
+    if (show.end_at) {
+      const showClosingTime = DateTime.fromISO(show.end_at)
+      return showClosingTime <= oneWeekFromNow && showClosingTime >= now
+    }
+    return false
+  })
+  const closing = sortBy(closingFiltered, (show) => DateTime.fromISO(show.end_at ?? "").toMillis())
+
   return {
     saved,
-    fairs,
+    fairs: [...fairs],
     galleries,
     museums,
     closing,
-    opening,
-  } as BucketResults
+    opening: [...opening],
+  }
 }
 
 export const emptyBucketResults: BucketResults = {

--- a/src/app/utils/cityGuide/types.ts
+++ b/src/app/utils/cityGuide/types.ts
@@ -1,4 +1,5 @@
-import { GlobalMap_viewer$data } from "__generated__/GlobalMap_viewer.graphql"
+import { CityGuideFair_fair$data } from "__generated__/CityGuideFair_fair.graphql"
+import { CityGuideShow_show$data } from "__generated__/CityGuideShow_show.graphql"
 import Supercluster from "supercluster"
 import type { BucketKey, BucketResults } from "./bucketCityResults"
 
@@ -6,6 +7,10 @@ import type { BucketKey, BucketResults } from "./bucketCityResults"
  * Types and helpers shared by the `Map` and `City` scenes (the "city guide" feature).
  * Kept here (rather than in either scene) per our convention of extracting cross-scene
  * code to `app/utils` instead of importing scene-to-scene.
+ *
+ * `Show`/`Fair` are derived from the `CityGuideShow_show`/`CityGuideFair_fair` fragments
+ * (see `./CityGuideShow` and `./CityGuideFair`) instead of being hand-derived from any one
+ * consumer's query shape.
  */
 
 export interface Coordinates {
@@ -18,16 +23,9 @@ export interface City {
   epicenter: Coordinates
 }
 
-export type Show = NonNullable<
-  NonNullable<
-    NonNullable<NonNullable<NonNullable<GlobalMap_viewer$data["city"]>["shows"]>["edges"]>[0]
-  >["node"]
->
-export type Fair = NonNullable<
-  NonNullable<
-    NonNullable<NonNullable<NonNullable<GlobalMap_viewer$data["city"]>["fairs"]>["edges"]>[0]
-  >["node"]
-> & { type?: string }
+export type Show = CityGuideShow_show$data[0]
+/** `type` is a client-only marker stamped on map-clustered fairs (see `extractShowAndFairMaps`), not a schema field. */
+export type Fair = CityGuideFair_fair$data[0] & { type?: string }
 
 export interface MapTab {
   /** UUID for the tab */


### PR DESCRIPTION
This PR resolves [FIREWORKS-8]

### Description

Part of the `Scenes/City` best-practices cleanup (item 5 of 5, "Relay hooks unification"). Stacked on top of #13962 (shared type extraction) since `Event.tsx` imports the relocated `Show`/`exhibitionDates` modules — **the diff below includes #13962's changes until that PR merges; once it does and this branch is rebased, this diff will only contain the Relay hooks migration.**

Unifies the City scene's Relay usage onto the modern hooks API, matching the pattern already used by `CitySectionList.tsx`:

- `CityFairList` and `CitySavedList`: `createPaginationContainer` + `QueryRenderer` → `useLazyLoadQuery` + `usePaginationFragment`, wrapped in `withSuspense`.
- `Event`: class component with `@track()` decorator + `commitMutation` → functional component with `useTracking()` + `useMutation`.

No user-facing behavior change intended — same data, same pagination/follow behavior.

**Combined concerns in this PR (noted per the split-to-prs request):**
- `CityFairList`'s GraphQL fragment had to be re-rooted from `City` to `Viewer` (nesting the city lookup inside it), since Relay's `@refetchable` directive requires the fragment to be on a type that implements `Node`, which `City` does not.
- While rewriting `CityFairList`, it also picks up `FlashList` (previously `FlatList`) since the list-rendering code had to be rewritten anyway for the hooks migration — this slightly overlaps with the separate FlashList PR (#13964), which doesn't touch this file.
- `CityFairList`'s fair selection also gains `id`/`slug` fields that `TabFairItemRow` already expected as props but that weren't previously being queried (pre-existing bug, fixed incidentally while rewriting the fragment).

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **feature flag**, or they don't need one. (internal data-fetching refactor, no user-facing behavior change)
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI. (no UI change beyond the FlashList swap noted above, which is visually identical)
- [x] I have added **tests**, or my changes don't require any. (no dedicated tests existed for these files previously; `Event`'s existing test coverage was preserved)
- [x] I added an **app state migration**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog

</details>

Made with [Cursor](https://cursor.com)

[FIREWORKS-8]: https://artsyproduct.atlassian.net/browse/FIREWORKS-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ