### PR TITLE
fix(PHIRE-3409): Update live auction error screen for safe area view

### DIFF
--- a/ios/Artsy/View_Controllers/Live_Auctions/LiveAuctionViewController.swift
+++ b/ios/Artsy/View_Controllers/Live_Auctions/LiveAuctionViewController.swift
@@ -175,8 +175,6 @@ class LiveAuctionViewController: UIViewController {
         closeButton.addTarget(self, action: #selector(dismissLiveAuctionsModal), for: .touchUpInside)
 
         offlineView.addSubview(closeButton)
-        // Pin to the safe area (not the raw edges) so the button clears the notch/Dynamic Island
-        // and the sensor housing in landscape.
         closeButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             closeButton.topAnchor.constraint(equalTo: offlineView.safeAreaLayoutGuide.topAnchor, constant: 20),

--- a/ios/Artsy/View_Controllers/Live_Auctions/LiveAuctionViewController.swift
+++ b/ios/Artsy/View_Controllers/Live_Auctions/LiveAuctionViewController.swift
@@ -175,8 +175,13 @@ class LiveAuctionViewController: UIViewController {
         closeButton.addTarget(self, action: #selector(dismissLiveAuctionsModal), for: .touchUpInside)
 
         offlineView.addSubview(closeButton)
-        closeButton.alignTrailingEdge(withView: offlineView, predicate: "-20")
-        closeButton.alignTopEdge(withView: offlineView, predicate: "20")
+        // Pin to the safe area (not the raw edges) so the button clears the notch/Dynamic Island
+        // and the sensor housing in landscape.
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            closeButton.topAnchor.constraint(equalTo: offlineView.safeAreaLayoutGuide.topAnchor, constant: 20),
+            closeButton.trailingAnchor.constraint(equalTo: offlineView.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+        ])
         closeButton.constrainWidth("\(dimension)", height: "\(dimension)")
     }
 

--- a/ios/Artsy/Views/Utilities/AROfflineView.m
+++ b/ios/Artsy/Views/Utilities/AROfflineView.m
@@ -46,7 +46,19 @@
         [stackView addSubview:buttonContainer withTopMargin:@"20" sideMargin:@"0"];
 
         [self addSubview:stackView];
-        [stackView alignCenterWithView:self];
+
+        // FLKAutoLayout sets this for us, native anchors do not. We need native anchors here because
+        // alignCenterWithView: only takes a UIView, and safeAreaLayoutGuide is a UILayoutGuide.
+        stackView.translatesAutoresizingMaskIntoConstraints = NO;
+
+        UILayoutGuide *safeAreaLayoutGuide = self.safeAreaLayoutGuide;
+        [NSLayoutConstraint activateConstraints:@[
+            [stackView.centerXAnchor constraintEqualToAnchor:safeAreaLayoutGuide.centerXAnchor],
+            [stackView.centerYAnchor constraintEqualToAnchor:safeAreaLayoutGuide.centerYAnchor],
+            // Keep the title and subtitle clear of the rounded corners and sensor housing in landscape.
+            [stackView.leadingAnchor constraintGreaterThanOrEqualToAnchor:safeAreaLayoutGuide.leadingAnchor constant:20],
+            [stackView.trailingAnchor constraintLessThanOrEqualToAnchor:safeAreaLayoutGuide.trailingAnchor constant:-20],
+        ]];
     }
     return self;
 }


### PR DESCRIPTION
This PR resolves [PHIRE-3409] <!-- eg [PROJECT-XXXX] -->

### Description
This PR attempts to fix an issue where a live auction error screen cannot be dismissed due to the close button being behind the battery icon on iOS

| | Before | After |
|---|---|---|
| iPhone 17 Pro | <img width="383" height="830" alt="image" src="https://github.com/user-attachments/assets/e0ed6192-3f1d-422e-b1ca-4b0866f6899c" /> | <img width="381" height="830" alt="image" src="https://github.com/user-attachments/assets/87d81ace-e8f2-4e6f-b9b4-50d53d6bf414" /> |
| iPhone SE | <img width="412" height="733" alt="image" src="https://github.com/user-attachments/assets/4cfe9021-be71-4b43-ab11-9380d42c77a4" /> | <img width="412" height="733" alt="image" src="https://github.com/user-attachments/assets/5d652266-0e85-4f3a-9893-808f39c48e9b" /> |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- make live auction error screen closable again

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3409]: https://artsyproduct.atlassian.net/browse/PHIRE-3409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ