### PR TITLE
feat(city): show an artwork rail on each event card

### DIFF
--- a/src/app/Scenes/City/Components/Event/Event.tsx
+++ b/src/app/Scenes/City/Components/Event/Event.tsx
@@ -1,5 +1,6 @@
-import { Box, Button, Flex, Image, Text, useColor } from "@artsy/palette-mobile"
+import { Box, Button, Flex, Text, useColor } from "@artsy/palette-mobile"
 import { EventMutation } from "__generated__/EventMutation.graphql"
+import { EventArtworkRailQueryRenderer } from "app/Scenes/City/Components/Event/EventArtworkRail"
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { Show } from "app/utils/cityGuide/types"
@@ -17,9 +18,8 @@ interface Props {
 }
 
 export const Event: React.FC<Props> = ({ event }) => {
-  const { name, exhibition_period, partner, cover_image, is_followed, end_at } = event
+  const { name, exhibition_period, partner, is_followed, end_at } = event
   const partnerName = partner?.name
-  const url = cover_image ? cover_image.url : null
   const color = useColor()
   const { trackEvent } = useTracking()
   const [isFollowedSaving, setIsFollowedSaving] = useState(false)
@@ -69,11 +69,6 @@ export const Event: React.FC<Props> = ({ event }) => {
   return (
     <TouchableWithoutFeedback accessibilityRole="button" onPress={handleTap}>
       <Box mb={2}>
-        {!!url && (
-          <Box mb={2} justifyContent="center" overflow="hidden">
-            <Image src={url} height={145} />
-          </Box>
-        )}
         <Flex flexDirection="row" flexWrap="nowrap" justifyContent="space-between">
           <Box width={TEXT_CONTAINER_WIDTH} mb={2}>
             <Text variant="sm" weight="medium" numberOfLines={1} ellipsizeMode="tail">
@@ -98,6 +93,14 @@ export const Event: React.FC<Props> = ({ event }) => {
             {is_followed ? "Saved" : "Save"}
           </Button>
         </Flex>
+
+        <Box mb={2} mx={-2}>
+          <EventArtworkRailQueryRenderer showID={event.internalID} />
+        </Box>
+
+        <Button variant="fillGray" onPress={handleTap} block size="small">
+          Read More
+        </Button>
       </Box>
     </TouchableWithoutFeedback>
   )

--- a/src/app/Scenes/City/Components/Event/EventArtworkRail.tsx
+++ b/src/app/Scenes/City/Components/Event/EventArtworkRail.tsx
@@ -1,0 +1,109 @@
+import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
+import { EventArtworkRailQuery } from "__generated__/EventArtworkRailQuery.graphql"
+import {
+  EventArtworkRail_show$data,
+  EventArtworkRail_show$key,
+} from "__generated__/EventArtworkRail_show.graphql"
+import { ArtworkRail, ArtworkRailPlaceholder } from "app/Components/ArtworkRail/ArtworkRail"
+import { extractNodes } from "app/utils/extractNodes"
+import {
+  CollectorSignals,
+  getArtworkSignalTrackingFields,
+} from "app/utils/getArtworkSignalTrackingFields"
+import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
+import { memo } from "react"
+import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
+import { useTracking } from "react-tracking"
+
+interface EventArtworkRailProps {
+  show: EventArtworkRail_show$key
+}
+
+export const EventArtworkRail: React.FC<EventArtworkRailProps> = memo(({ show: showProp }) => {
+  const show = useFragment(eventArtworkRailFragment, showProp)
+  const { trackEvent } = useTracking()
+
+  const artworks = extractNodes(show?.artworksConnection)
+
+  if (!artworks.length) {
+    return null
+  }
+
+  return (
+    <ArtworkRail
+      artworks={artworks}
+      onPress={(artwork, position) => {
+        trackEvent(
+          tracks.tappedArtwork(
+            show,
+            artwork?.internalID ?? "",
+            artwork?.slug ?? "",
+            position,
+            artwork.collectorSignals
+          )
+        )
+      }}
+      showSaveIcon
+      moreHref={show?.href ?? null}
+    />
+  )
+})
+
+const eventArtworkRailFragment = graphql`
+  fragment EventArtworkRail_show on Show {
+    internalID
+    slug
+    href
+    artworksConnection(first: 10) {
+      edges {
+        node {
+          ...ArtworkRail_artworks
+        }
+      }
+    }
+  }
+`
+
+const eventArtworkRailQuery = graphql`
+  query EventArtworkRailQuery($id: String!) {
+    show(id: $id) {
+      ...EventArtworkRail_show
+    }
+  }
+`
+
+export const EventArtworkRailQueryRenderer: React.FC<{ showID: string }> = withSuspense({
+  Component: ({ showID }) => {
+    const data = useLazyLoadQuery<EventArtworkRailQuery>(eventArtworkRailQuery, { id: showID })
+
+    if (!data.show) {
+      return null
+    }
+
+    return <EventArtworkRail show={data.show} />
+  },
+  LoadingFallback: () => <ArtworkRailPlaceholder />,
+  ErrorFallback: NoFallback,
+})
+
+const tracks = {
+  tappedArtwork: (
+    show: EventArtworkRail_show$data,
+    artworkID: string,
+    artworkSlug: string,
+    position: number,
+    collectorSignals: CollectorSignals
+  ) => ({
+    action: ActionType.tappedArtworkGroup,
+    context_module: ContextModule.otherWorksFromShowRail,
+    context_screen_owner_type: OwnerType.show,
+    context_screen_owner_id: show.internalID,
+    context_screen_owner_slug: show.slug,
+    destination_screen_owner_type: OwnerType.artwork,
+    destination_screen_owner_id: artworkID,
+    destination_screen_owner_slug: artworkSlug,
+    horizontal_slide_position: position,
+    type: "thumbnail",
+    ...getArtworkSignalTrackingFields(collectorSignals),
+  }),
+}

--- a/src/app/Scenes/City/Components/Event/__tests__/Event.tests.tsx
+++ b/src/app/Scenes/City/Components/Event/__tests__/Event.tests.tsx
@@ -1,16 +1,13 @@
 import { screen } from "@testing-library/react-native"
 import { Event } from "app/Scenes/City/Components/Event/Event"
 import { Show } from "app/utils/cityGuide/types"
-import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 
 const eventData = {
   name: "PALAY, Trapunto Murals by Pacita Abad",
   id: "U2hvdzpwYWNpdGEtYWJhZC1hcnQtZXN0YXRlLXBhbGF5LXRyYXB1bnRvLW11cmFscy1ieS1wYWNpdGEtYWJhZA==",
   internalID: "1234567",
-  gravityID: "pacita-abad-art-estate-palay-trapunto-murals-by-pacita-abad",
-  cover_image: {
-    url: "",
-  },
+  slug: "pacita-abad-art-estate-palay-trapunto-murals-by-pacita-abad",
   is_followed: true,
   end_at: "2001-12-15T12:00:00+00:00",
   start_at: "2001-11-12T12:00:00+00:00",
@@ -20,10 +17,35 @@ const eventData = {
   },
 } as any as Show
 
-describe("CityEvent", () => {
+describe("Event", () => {
+  const { renderWithRelay } = setupTestWrapper({
+    Component: Event,
+  })
+
   it("renders properly", () => {
-    renderWithWrappers(<Event event={eventData} />)
+    renderWithRelay({}, { event: eventData })
 
     expect(screen.getByText("Pacita Abad Art Estate")).toBeTruthy()
+  })
+
+  it("renders a rail of artworks from the show", async () => {
+    renderWithRelay(
+      {
+        Show: () => ({
+          artworksConnection: {
+            edges: [
+              {
+                node: {
+                  artistNames: "Pacita Abad",
+                },
+              },
+            ],
+          },
+        }),
+      },
+      { event: eventData }
+    )
+
+    expect(await screen.findByText("Pacita Abad")).toBeTruthy()
   })
 })

--- a/src/app/Scenes/City/Components/Event/__tests__/EventArtworkRail.tests.tsx
+++ b/src/app/Scenes/City/Components/Event/__tests__/EventArtworkRail.tests.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import { EventArtworkRailTestsQuery } from "__generated__/EventArtworkRailTestsQuery.graphql"
+import { EventArtworkRail } from "app/Scenes/City/Components/Event/EventArtworkRail"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
+
+describe("EventArtworkRail", () => {
+  const { renderWithRelay } = setupTestWrapper<EventArtworkRailTestsQuery>({
+    Component: ({ show }) => (show ? <EventArtworkRail show={show} /> : null),
+    query: graphql`
+      query EventArtworkRailTestsQuery @relay_test_operation {
+        show(id: "the-show-id") {
+          ...EventArtworkRail_show
+        }
+      }
+    `,
+  })
+
+  it("renders artworks from the show", () => {
+    renderWithRelay({
+      Show: () => ({
+        artworksConnection: {
+          edges: [
+            {
+              node: {
+                artistNames: "Pacita Abad",
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    expect(screen.getByText("Pacita Abad")).toBeTruthy()
+  })
+
+  it("tracks taps on artworks in the rail", () => {
+    renderWithRelay({
+      Show: () => ({
+        internalID: "show-id",
+        slug: "some-show",
+        artworksConnection: {
+          edges: [
+            {
+              node: {
+                internalID: "artwork1234",
+                slug: "cool-artwork-1",
+                collectorSignals: null,
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    fireEvent.press(screen.getByTestId("artwork-cool-artwork-1"))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "tappedArtworkGroup",
+        context_module: "otherWorksFromShowRail",
+        context_screen_owner_type: "show",
+        context_screen_owner_id: "show-id",
+        context_screen_owner_slug: "some-show",
+        destination_screen_owner_id: "artwork1234",
+        destination_screen_owner_slug: "cool-artwork-1",
+        destination_screen_owner_type: "artwork",
+        type: "thumbnail",
+      })
+    )
+  })
+})

--- a/src/app/Scenes/Fair/Components/FairExhibitorRail.tsx
+++ b/src/app/Scenes/Fair/Components/FairExhibitorRail.tsx
@@ -7,7 +7,6 @@ import {
 } from "__generated__/FairExhibitorRail_show.graphql"
 import { ArtworkRail, ArtworkRailPlaceholder } from "app/Components/ArtworkRail/ArtworkRail"
 import { SectionTitle } from "app/Components/SectionTitle"
-import { ShowFollowButton } from "app/Components/ShowFollowButton"
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
@@ -51,8 +50,6 @@ export const FairExhibitorRail: React.FC<FairExhibitorRailProps> = memo(({ show:
             mb={0}
           />
         </Flex>
-
-        <ShowFollowButton show={show} ml={1} />
       </Flex>
       <ArtworkRail
         artworks={artworks}
@@ -81,7 +78,6 @@ export const FairExhibitorRail: React.FC<FairExhibitorRailProps> = memo(({ show:
 
 const fairExhibitorRailFragment = graphql`
   fragment FairExhibitorRail_show on Show {
-    ...ShowFollowButton_show
     internalID
     slug
     href


### PR DESCRIPTION
This PR resolves [FIREWORKS-9]

### Description

Replaces the static cover image on each City guide event card with a horizontal rail of artworks from that show, mirroring the pattern `FairExhibitorRail` already uses for fair booths: a per-card fragment + lazy-loaded query (via `EventArtworkRailQueryRenderer`), so each card loads its own artworks independently, wrapped in Suspense/error boundaries via `withSuspense`. Tracking uses cohesion's `otherWorksFromShowRail` context module and `show` owner type.

Also removes the follow button (`ShowFollowButton`) from `FairExhibitorRail`'s header, since `EventArtworkRail` mirrors that component and `Event` already has its own follow/save affordance — a second follow control in the rail header was redundant.

Note: this loads artworks per-row via its own query, so each visible `Event` card fires an independent request — same trade-off `FairExhibitorRail` makes.

| iOS | Android |
|--------|--------|
| <img width="1206" height="2622" alt="simulator_screenshot_ADB226C4-9183-4609-8F69-AAD718EC44FC" src="https://github.com/user-attachments/assets/c98eedcf-9440-43d4-8f84-93b45cf616d2" /> | <img width="1080" height="2424" alt="Screenshot_1787586372" src="https://github.com/user-attachments/assets/0cd1d79a-3a56-459f-9665-294ccb0c5809" /> | 



### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Show a scrollable rail of artworks from the show on each City guide event card, instead of a single static cover image - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- 

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

Made with [Cursor](https://cursor.com)

[FIREWORKS-9]: https://artsyproduct.atlassian.net/browse/FIREWORKS-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ