### PR TITLE
perf: lazily render inactive tabs in City guide

### DIFF
--- a/src/app/Components/Containers/Inbox.tsx
+++ b/src/app/Components/Containers/Inbox.tsx
@@ -77,6 +77,7 @@ export const Inbox: React.FC<Props> = memo(({ me, relay: _relay, isVisible: _isV
     <TabsContainer
       initialTabName={initialPageName}
       onTabChange={({ tabName }) => handleNavigationTab(tabName)}
+      lazy
     >
       <Tabs.Tab name="bids" label="Bids">
         <MyBidsContainer isActiveTab={activeTab === Tab.bids} me={me} />

--- a/src/app/Scenes/City/City.tsx
+++ b/src/app/Scenes/City/City.tsx
@@ -93,6 +93,7 @@ export const CityView: React.FC<CityViewProps> = () => {
           onTabChange={(tab) => {
             setSelectedTab(Number(tab.index))
           }}
+          lazy
         >
           {cityTabs.map((tab) => {
             if (tab.id === "all") {


### PR DESCRIPTION
This PR resolves []

### Description

Pass `lazy` to the Inbox and City guide tab containers so an inactive tab's screen only mounts once it's actually visited, instead of every tab mounting up front on first render.

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Lazily mount inactive tabs in Inbox and City guide instead of mounting all tabs up front.

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

Made with [Cursor](https://cursor.com)