### PR TITLE
fix: keep the artwork card bottom sheet footer on the first tab

### DIFF
--- a/src/app/Components/ArtworkCard/ArtworkCardBottomSheet.tsx
+++ b/src/app/Components/ArtworkCard/ArtworkCardBottomSheet.tsx
@@ -7,9 +7,11 @@ import { ArtworkCardBottomSheetHandle } from "app/Components/ArtworkCard/Artwork
 import {
   ArtworkCardBottomSheetTabs,
   ArtworkCardBottomSheetTabsSkeleton,
+  TABS,
 } from "app/Components/ArtworkCard/ArtworkCardBottomSheetTabs"
 import { FC, useEffect, useState } from "react"
 import { Dimensions } from "react-native"
+import { IndexChangeEventData } from "react-native-collapsible-tab-view/lib/typescript/src/types"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { graphql } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -29,16 +31,18 @@ export const ArtworkCardBottomSheet: FC<ArtworkCardBottomSheetProps> = ({
 }) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const { bottom } = useSafeAreaInsets()
-  const [footerVisible, setFooterVisible] = useState(true)
+  const [activeTabName, setActiveTabName] = useState(TABS[0].name)
   const color = useColor()
   const { trackEvent } = useTracking()
 
   useEffect(() => {
-    setFooterVisible(true)
-  }, [artworkID])
+    if (isExpanded) {
+      setActiveTabName(TABS[0].name)
+    }
+  }, [isExpanded])
 
-  const handleOnTabChange = () => {
-    setFooterVisible((prev) => !prev)
+  const handleOnTabChange = (data: IndexChangeEventData) => {
+    setActiveTabName(data.tabName)
   }
 
   return (
@@ -58,7 +62,7 @@ export const ArtworkCardBottomSheet: FC<ArtworkCardBottomSheetProps> = ({
         }}
         handleComponent={ArtworkCardBottomSheetHandle}
         footerComponent={(props) => {
-          if (!footerVisible) {
+          if (activeTabName !== TABS[0].name) {
             return null
           }
 


### PR DESCRIPTION
This PR resolves a bug I observed while testing #13957.

#### How to reproduce

1. Open the bottom sheet of an artwork card in Discover Daily
2. Switch to the second tab in the bottom sheet
3. Close the bottom sheet
4. Re-open the bottom sheet

- Notice that the footer with commercial actions is **not** visible on the first tab
- Notice that the footer with the commercial actions is visible on the second tab

#### How I solved it

Previously the bottom sheet flipped the visibility of the bottom sheet assuming that it would be turned **on** → **off** → **on** → **off** ... in that order. However, when you close the bottom sheet while it is **off** and then re-open it, we show the user the 1st tab without having set the footer's visibility back to **on**.

This PR solves that by (1) setting the visibility based on the currently selected tab (instead of an independent state variable), and (2) resetting it whenever the bottom sheet becomes visible (instead of when the underlying artwork changes).

#### What it looks like

| Before | After |
|-|-|
| https://github.com/user-attachments/assets/0d6d597e-0081-4b3e-a54c-4e0a392811b6 | https://github.com/user-attachments/assets/cd6860db-125d-4559-bed5-6b60b9a3a34e |
| https://github.com/user-attachments/assets/9f82b8cf-d4a7-42f9-9869-14e76ed434a4 | https://github.com/user-attachments/assets/799a56f2-a105-45a2-8958-ff329ca8ef31 |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fixed a glitch in Discover Daily that caused commercial actions to show up unexpectedly.

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
