### PR TITLE
fix: prevent Home impressions behind search overlay

### DIFF
--- a/src/app/Components/GlobalSearchInput/GlobalSearchInput.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInput.tsx
@@ -4,20 +4,33 @@ import { GlobalSearchInputOverlay } from "app/Components/GlobalSearchInput/Globa
 import { useDismissSearchOverlayOnTabBarPress } from "app/Components/GlobalSearchInput/utils/useDismissSearchOverlayOnTabBarPress"
 import { ICON_HIT_SLOP } from "app/Components/constants"
 import { useDebouncedValue } from "app/utils/hooks/useDebouncedValue"
-import { forwardRef, Fragment, useImperativeHandle, useState } from "react"
+import { forwardRef, Fragment, useEffect, useImperativeHandle, useState } from "react"
 import { useTracking } from "react-tracking"
 
 export type GlobalSearchInput = {
   focus: () => void
 }
 
-export const GlobalSearchInput = forwardRef<GlobalSearchInput, { ownerType: OwnerType }>(
-  ({ ownerType }, ref) => {
+interface GlobalSearchInputProps {
+  ownerType: OwnerType
+  onOverlayVisibilityChange?: (isVisible: boolean) => void
+}
+
+export const GlobalSearchInput = forwardRef<GlobalSearchInput, GlobalSearchInputProps>(
+  ({ ownerType, onOverlayVisibilityChange }, ref) => {
     const [isVisible, setIsVisible] = useState(false)
 
     const debouncedIsVisible = useDebouncedValue({ value: isVisible })
 
     const tracking = useTracking()
+
+    useEffect(() => {
+      onOverlayVisibilityChange?.(isVisible)
+    }, [isVisible, onOverlayVisibilityChange])
+
+    useEffect(() => {
+      return () => onOverlayVisibilityChange?.(false)
+    }, [onOverlayVisibilityChange])
 
     useDismissSearchOverlayOnTabBarPress({ isVisible, ownerType, setIsVisible })
 

--- a/src/app/Components/GlobalSearchInput/GlobalSearchInput.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInput.tsx
@@ -26,11 +26,8 @@ export const GlobalSearchInput = forwardRef<GlobalSearchInput, GlobalSearchInput
 
     useEffect(() => {
       onOverlayVisibilityChange?.(isVisible)
-    }, [isVisible, onOverlayVisibilityChange])
-
-    useEffect(() => {
       return () => onOverlayVisibilityChange?.(false)
-    }, [onOverlayVisibilityChange])
+    }, [isVisible, onOverlayVisibilityChange])
 
     useDismissSearchOverlayOnTabBarPress({ isVisible, ownerType, setIsVisible })
 

--- a/src/app/Components/GlobalSearchInput/__tests__/GlobalSearchInput.tests.tsx
+++ b/src/app/Components/GlobalSearchInput/__tests__/GlobalSearchInput.tests.tsx
@@ -38,4 +38,24 @@ describe("GlobalSearchInput", () => {
       })
     )
   })
+
+  it("reports overlay visibility changes", () => {
+    const onOverlayVisibilityChange = jest.fn()
+    const { unmount } = renderWithWrappers(
+      <GlobalSearchInput
+        ownerType={OwnerType.home}
+        onOverlayVisibilityChange={onOverlayVisibilityChange}
+      />
+    )
+
+    expect(onOverlayVisibilityChange).toHaveBeenLastCalledWith(false)
+
+    fireEvent.press(screen.getByTestId("search-button"))
+
+    expect(onOverlayVisibilityChange).toHaveBeenLastCalledWith(true)
+
+    unmount()
+
+    expect(onOverlayVisibilityChange).toHaveBeenLastCalledWith(false)
+  })
 })

--- a/src/app/Scenes/HomeView/Components/HomeHeader.tsx
+++ b/src/app/Scenes/HomeView/Components/HomeHeader.tsx
@@ -7,7 +7,9 @@ import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { memo } from "react"
 import { ActivityIndicator } from "./ActivityIndicator"
 
-export const HomeHeader: React.FC = memo(() => {
+export const HomeHeader: React.FC<{
+  onSearchOverlayVisibilityChange?: (isVisible: boolean) => void
+}> = memo(({ onSearchOverlayVisibilityChange }) => {
   const showPaymentFailureBanner = useFeatureFlag("AREnablePaymentFailureBanner")
   const hasUnseenNotifications = GlobalStore.useAppState(
     (state) => state.bottomTabs.hasUnseenNotifications
@@ -19,7 +21,10 @@ export const HomeHeader: React.FC = memo(() => {
       <Flex pb={1} pt={2}>
         <Flex flexDirection="row" px={2} gap={1} justifyContent="space-around" alignItems="center">
           <Flex flex={1}>
-            <GlobalSearchInput ownerType={OwnerType.home} />
+            <GlobalSearchInput
+              ownerType={OwnerType.home}
+              onOverlayVisibilityChange={onSearchOverlayVisibilityChange}
+            />
           </Flex>
           <Flex alignItems="flex-end">
             <ActivityIndicator hasUnseenNotifications={hasUnseenNotifications} />

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -21,6 +21,7 @@ import { Section } from "app/Scenes/HomeView/Sections/Section"
 import { useHomeViewExperimentTracking } from "app/Scenes/HomeView/hooks/useHomeViewExperimentTracking"
 import { useHomeViewTracking } from "app/Scenes/HomeView/hooks/useHomeViewTracking"
 import { useLiveHomeViewSectionIDs } from "app/Scenes/HomeView/hooks/useLiveHomeViewSectionIDs"
+import { useRefreshLiveHomeViewSections } from "app/Scenes/HomeView/hooks/useRefreshLiveHomeViewSections"
 import { Playground } from "app/Scenes/Playground/Playground"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useExperimentVariant } from "app/system/flags/hooks/useExperimentVariant"
@@ -155,23 +156,10 @@ export const HomeView: React.FC = memo(() => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Refresh all live rails when returning to home (skipping the initial mount focus).
-  // useFocusEffect is used because inactive screens are frozen and wouldn't observe the transition.
-  const hasFocusedHomeOnce = useRef(false)
-  useFocusEffect(
-    useCallback(() => {
-      if (!hasLiveSections) {
-        return
-      }
-
-      if (!hasFocusedHomeOnce.current) {
-        hasFocusedHomeOnce.current = true
-        return
-      }
-
-      bumpLiveRefetchKey()
-    }, [hasLiveSections, bumpLiveRefetchKey])
-  )
+  const { onSearchOverlayVisibilityChange } = useRefreshLiveHomeViewSections({
+    hasLiveSections,
+    refresh: bumpLiveRefetchKey,
+  })
 
   const fetchSavedArtworksCount = async () => {
     fetchQuery<HomeViewFetchMeQuery>(
@@ -231,6 +219,11 @@ export const HomeView: React.FC = memo(() => {
     [refetchKey]
   )
 
+  const renderHomeHeader = useCallback(
+    () => <HomeHeader onSearchOverlayVisibilityChange={onSearchOverlayVisibilityChange} />,
+    [onSearchOverlayVisibilityChange]
+  )
+
   return (
     <Screen safeArea={true}>
       <Screen.Body fullwidth>
@@ -244,7 +237,7 @@ export const HomeView: React.FC = memo(() => {
           keyExtractor={(item) => item.internalID}
           renderItem={renderItem}
           onEndReached={() => loadNext(NUMBER_OF_SECTIONS_TO_LOAD)}
-          ListHeaderComponent={HomeHeader}
+          ListHeaderComponent={renderHomeHeader}
           ListFooterComponent={() =>
             hasNext ? (
               <Flex width="100%" justifyContent="center" alignItems="center" height={200}>

--- a/src/app/Scenes/HomeView/hooks/__tests__/useRefreshLiveHomeViewSections.tests.ts
+++ b/src/app/Scenes/HomeView/hooks/__tests__/useRefreshLiveHomeViewSections.tests.ts
@@ -1,0 +1,97 @@
+import { act, renderHook } from "@testing-library/react-native"
+import { useRefreshLiveHomeViewSections } from "app/Scenes/HomeView/hooks/useRefreshLiveHomeViewSections"
+
+type FocusEffect = () => void | (() => void)
+
+let mockFocusEffect: FocusEffect
+
+jest.mock("@react-navigation/native", () => ({
+  useFocusEffect: (effect: FocusEffect) => {
+    mockFocusEffect = effect
+  },
+}))
+
+describe("useRefreshLiveHomeViewSections", () => {
+  let cleanupFocusEffect: void | (() => void)
+
+  const focusHome = () => {
+    act(() => {
+      cleanupFocusEffect = mockFocusEffect()
+    })
+  }
+
+  const blurHome = () => {
+    act(() => {
+      cleanupFocusEffect?.()
+      cleanupFocusEffect = undefined
+    })
+  }
+
+  beforeEach(() => {
+    cleanupFocusEffect = undefined
+  })
+
+  it("refreshes when Home regains focus without an overlay", () => {
+    const refresh = jest.fn()
+
+    renderHook(() => useRefreshLiveHomeViewSections({ hasLiveSections: true, refresh }))
+
+    focusHome()
+    blurHome()
+    focusHome()
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it("defers a focus refresh until the Home overlay closes", () => {
+    const refresh = jest.fn()
+    const { result } = renderHook(() =>
+      useRefreshLiveHomeViewSections({ hasLiveSections: true, refresh })
+    )
+
+    focusHome()
+    act(() => result.current.onSearchOverlayVisibilityChange(true))
+    blurHome()
+    focusHome()
+
+    expect(refresh).not.toHaveBeenCalled()
+
+    act(() => result.current.onSearchOverlayVisibilityChange(false))
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not refresh when the overlay opens and closes without a focus change", () => {
+    const refresh = jest.fn()
+    const { result } = renderHook(() =>
+      useRefreshLiveHomeViewSections({ hasLiveSections: true, refresh })
+    )
+
+    focusHome()
+    act(() => result.current.onSearchOverlayVisibilityChange(true))
+    act(() => result.current.onSearchOverlayVisibilityChange(false))
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it("waits for the next focus if the overlay closes while Home is blurred", () => {
+    const refresh = jest.fn()
+    const { result } = renderHook(() =>
+      useRefreshLiveHomeViewSections({ hasLiveSections: true, refresh })
+    )
+
+    focusHome()
+    act(() => result.current.onSearchOverlayVisibilityChange(true))
+    blurHome()
+    focusHome()
+    blurHome()
+
+    act(() => result.current.onSearchOverlayVisibilityChange(false))
+
+    expect(refresh).not.toHaveBeenCalled()
+
+    focusHome()
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/Scenes/HomeView/hooks/useRefreshLiveHomeViewSections.ts
+++ b/src/app/Scenes/HomeView/hooks/useRefreshLiveHomeViewSections.ts
@@ -1,0 +1,79 @@
+import { useFocusEffect } from "@react-navigation/native"
+import { useCallback, useRef } from "react"
+
+interface UseRefreshLiveHomeViewSectionsProps {
+  hasLiveSections: boolean
+  refresh: () => void
+}
+
+/**
+ * Refreshes Home's live rails when the user actually sees Home — not just when
+ * Home regains navigation focus. If the search overlay is on top, focus alone
+ * would trigger a refetch that re-fires `railViewed` / `itemViewed` for a Home
+ * the user isn't looking at. This hook defers the refresh until the overlay
+ * closes with Home still focused.
+ *
+ * Wire the returned `onSearchOverlayVisibilityChange` into GlobalSearchInput.
+ */
+export const useRefreshLiveHomeViewSections = ({
+  hasLiveSections,
+  refresh,
+}: UseRefreshLiveHomeViewSectionsProps) => {
+  // Refs (not state) so overlay toggles don't re-render HomeView, and so the
+  // close handler below can stay `useCallback([])` — a stable identity matters
+  // because GlobalSearchInput's cleanup effect would emit a spurious `false`
+  // if the callback prop changed.
+  const hasFocusedHomeOnceRef = useRef(false)
+  const isHomeFocusedRef = useRef(false)
+  const isSearchOverlayVisibleRef = useRef(false)
+  const hasPendingRefreshRef = useRef(false)
+  // Mirrored so the close handler (empty deps) can read the latest values.
+  const hasLiveSectionsRef = useRef(hasLiveSections)
+  const refreshRef = useRef(refresh)
+
+  hasLiveSectionsRef.current = hasLiveSections
+  refreshRef.current = refresh
+
+  // Inactive screens may be frozen, so focus remains the source of truth for returning to Home.
+  useFocusEffect(
+    useCallback(() => {
+      isHomeFocusedRef.current = true
+
+      if (hasLiveSections) {
+        if (!hasFocusedHomeOnceRef.current) {
+          // First focus: initial query already delivered fresh data, skip refetch.
+          hasFocusedHomeOnceRef.current = true
+        } else if (isSearchOverlayVisibleRef.current) {
+          // Overlay covers Home — defer the refresh until it closes.
+          hasPendingRefreshRef.current = true
+        } else {
+          hasPendingRefreshRef.current = false
+          refreshRef.current()
+        }
+      }
+
+      return () => {
+        isHomeFocusedRef.current = false
+      }
+    }, [hasLiveSections])
+  )
+
+  // Fires the deferred refresh at the moment Home becomes visible again — i.e.
+  // overlay just closed, a refresh was actually pending, and Home is focused.
+  const onSearchOverlayVisibilityChange = useCallback((isVisible: boolean) => {
+    const justClosed = isSearchOverlayVisibleRef.current && !isVisible
+    isSearchOverlayVisibleRef.current = isVisible
+
+    if (
+      justClosed &&
+      hasPendingRefreshRef.current &&
+      isHomeFocusedRef.current &&
+      hasLiveSectionsRef.current
+    ) {
+      hasPendingRefreshRef.current = false
+      refreshRef.current()
+    }
+  }, [])
+
+  return { onSearchOverlayVisibilityChange }
+}


### PR DESCRIPTION
Assisted-by: Claude Code and Codex

### Description

Home currently refreshes its live rails when it regains navigation focus, even if the global search overlay is still covering the screen. The refresh resets impression tracking and causes `railViewed` and `itemViewed` events to fire while Home is not visible.

Originally reported by Dorota [here](https://app.notion.com/p/artsy/App-tapping-on-trending-artist-and-coming-back-to-search-screen-triggers-NWFY-railViewed-event-3c3cab0764a080ffa659f6f4bce299ba?v=b04cab0764a0820e87a388eb0e9e2298&source=copy_link).

This PR:

- reports search overlay visibility from `GlobalSearchInput` through an optional callback;
- keeps this state local to Home, so the Search tab cannot affect Home refreshes;
- defers the focus refresh only when Home regains focus behind an open overlay;
- runs the deferred refresh exactly once when the overlay closes;
- avoids refreshing when the overlay is opened and closed without a navigation focus change;

There are no visual changes.

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
