### PR TITLE
feat(DI-572): animate artist avatars

### DIFF
--- a/src/app/Scenes/HomeView/Components/FollowArtistsOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/HomeView/Components/FollowArtistsOnboardingCompletionBottomSheet.tsx
@@ -8,10 +8,14 @@ import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/Automoun
 import { PaginationBars } from "app/Scenes/InfiniteDiscovery/Components/PaginationBars"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { MotiView } from "moti"
 import { useState, useRef, useCallback, useEffect } from "react"
 import { Platform, Pressable, StyleSheet } from "react-native"
 import { Gesture, GestureDetector } from "react-native-gesture-handler"
 import PagerView, { PagerViewOnPageScrollEvent } from "react-native-pager-view"
+
+const AVATAR_FAN_OUT_START_POSITIONS = [40, 0, -40]
+const AVATAR_FAN_OUT_ANIMATION_DELAY = 1000
 
 export const FollowArtistsOnboardingCompletionBottomSheet = () => {
   const showFollowedArtistSummaryBottomSheet = GlobalStore.useAppState(
@@ -110,27 +114,36 @@ export const FollowArtistsOnboardingCompletionBottomSheet = () => {
 
             <Flex flexDirection="row" justifyContent="center" alignItems="center">
               {followedOnboardingArtists.slice(-3).map((artist, index) => (
-                <Flex
+                <MotiView
                   key={artist.internalID}
-                  backgroundColor="mono0"
-                  borderRadius={35}
-                  style={{
-                    marginLeft: index > 0 ? -10 : 0,
-                    zIndex: index,
-                    shadowColor: "#000",
-                    shadowOffset: { width: 0, height: 2 },
-                    shadowOpacity: 0.08,
-                    shadowRadius: 4,
-                    elevation: 2,
+                  from={{ translateX: AVATAR_FAN_OUT_START_POSITIONS[index] ?? 0 }}
+                  animate={{ translateX: 0 }}
+                  transition={{
+                    type: "spring",
+                    delay: AVATAR_FAN_OUT_ANIMATION_DELAY,
                   }}
                 >
-                  <Avatar
-                    src={artist.imageUrl ?? undefined}
-                    blurhash={artist.blurhash}
-                    initials={artist.initials ?? undefined}
-                    size="sm"
-                  />
-                </Flex>
+                  <Flex
+                    backgroundColor="mono0"
+                    borderRadius={35}
+                    style={{
+                      marginLeft: index > 0 ? -10 : 0,
+                      zIndex: index,
+                      shadowColor: "#000",
+                      shadowOffset: { width: 0, height: 2 },
+                      shadowOpacity: 0.08,
+                      shadowRadius: 4,
+                      elevation: 2,
+                    }}
+                  >
+                    <Avatar
+                      src={artist.imageUrl ?? undefined}
+                      blurhash={artist.blurhash}
+                      initials={artist.initials ?? undefined}
+                      size="sm"
+                    />
+                  </Flex>
+                </MotiView>
               ))}
             </Flex>
 


### PR DESCRIPTION
This PR resolves [DI-572](https://www.notion.so/3c7cab0764a0807daa95f8e73c728222)

Co-authored-by: [JanaeHijaz](https://github.com/JanaeHijaz)
Assisted-by: Claude:Sonnet-5

### Description

This is a follow-up to #13720 that animates the avatars of the 3 followed artists in the post-onboarding confirmation bottom sheet. It changes the transition type from "timing" to "spring" to give it a bit more of a natural movement.

| iOS | Android |
|-|-|
| https://github.com/user-attachments/assets/38327b80-99d2-4d05-93ed-e2d6ff48850a | https://github.com/user-attachments/assets/a0eb9b07-1cc0-4c0e-b796-376ef5588302 |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Added animation to onboarding bottom sheet

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
