### PR TITLE
feat(DI-360): animate artworks cards

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
@@ -18,6 +18,7 @@ const CARD_HEIGHT = 106
 const SPREAD_ANGLE = 56
 const ARC_RADIUS = 260
 const FAN_OUT_DELAY = 1000
+const ROTATION_START_RATIO = 0.25
 
 const CARD_COUNT = 5
 const toRad = (deg: number) => (deg * Math.PI) / 180
@@ -25,6 +26,7 @@ const toRad = (deg: number) => (deg * Math.PI) / 180
 const FAN_CONFIGS = Array.from({ length: CARD_COUNT }, (_, i) => {
   const angle = ((i - Math.floor(CARD_COUNT / 2)) * SPREAD_ANGLE) / (CARD_COUNT - 1)
   return {
+    angle,
     left: REFERENCE_WIDTH / 2 + ARC_RADIUS * Math.sin(toRad(angle)) - CARD_WIDTH / 2,
     top: ARC_RADIUS * (1 - Math.cos(toRad(angle))),
     rotate: `${angle.toFixed(2)}deg`,
@@ -99,17 +101,21 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
               const config = FAN_CONFIGS[index]
               return (
                 // `style` sets the card's final fanned-out position; `from`/`animate` offset it
-                // back to the middle card's position and animate that offset down to zero, so
-                // the card appears to travel from the middle of the fan out to its final spot.
+                // back to the middle card's position (with a proportional rotation) and animate
+                // that offset down to zero, so the card appears to travel from the middle of the
+                // fan out to its final spot while slightly rotating.
                 <MotiView
                   key={artwork.internalID}
                   from={{
                     transform: [
                       { translateX: (FAN_MIDDLE_CARD_CONFIG.left - config.left) * scale },
                       { translateY: (FAN_MIDDLE_CARD_CONFIG.top - config.top) * scale },
+                      { rotate: `${(config.angle * ROTATION_START_RATIO).toFixed(2)}deg` },
                     ],
                   }}
-                  animate={{ transform: [{ translateX: 0 }, { translateY: 0 }] }}
+                  animate={{
+                    transform: [{ translateX: 0 }, { translateY: 0 }, { rotate: config.rotate }],
+                  }}
                   transition={{
                     type: "spring",
                     delay: FAN_OUT_DELAY,
@@ -125,7 +131,6 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
                     blurhash={artwork.blurhash}
                     width={CARD_WIDTH * scale}
                     height={CARD_HEIGHT * scale}
-                    rotate={config.rotate}
                   />
                 </MotiView>
               )

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
@@ -8,6 +8,7 @@ import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/Automoun
 import { ArtworkThumbnail } from "app/Scenes/InfiniteDiscovery/Components/ArtworkThumbnail"
 import { useOnboardingTracking } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useOnboardingTracking"
 import { GlobalStore } from "app/store/GlobalStore"
+import { MotiView } from "moti"
 import { useCallback } from "react"
 import { View } from "react-native"
 
@@ -16,6 +17,7 @@ const CARD_WIDTH = 85
 const CARD_HEIGHT = 106
 const SPREAD_ANGLE = 56
 const ARC_RADIUS = 260
+const FAN_OUT_DELAY = 1000
 
 const CARD_COUNT = 5
 const toRad = (deg: number) => (deg * Math.PI) / 180
@@ -28,6 +30,7 @@ const FAN_CONFIGS = Array.from({ length: CARD_COUNT }, (_, i) => {
     rotate: `${angle.toFixed(2)}deg`,
   }
 })
+const FAN_MIDDLE_CARD_CONFIG = FAN_CONFIGS[Math.floor(CARD_COUNT / 2)]
 
 const FAN_CONTAINER_HEIGHT = ARC_RADIUS * (1 - Math.cos(toRad(SPREAD_ANGLE / 2))) + CARD_HEIGHT + 10
 
@@ -95,19 +98,36 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
             {savedArtworks.map((artwork, index) => {
               const config = FAN_CONFIGS[index]
               return (
-                <ArtworkThumbnail
+                // `style` sets the card's final fanned-out position; `from`/`animate` offset it
+                // back to the middle card's position and animate that offset down to zero, so
+                // the card appears to travel from the middle of the fan out to its final spot.
+                <MotiView
                   key={artwork.internalID}
-                  imageUrl={artwork.url}
-                  blurhash={artwork.blurhash}
-                  width={CARD_WIDTH * scale}
-                  height={CARD_HEIGHT * scale}
-                  rotate={config.rotate}
+                  from={{
+                    transform: [
+                      { translateX: (FAN_MIDDLE_CARD_CONFIG.left - config.left) * scale },
+                      { translateY: (FAN_MIDDLE_CARD_CONFIG.top - config.top) * scale },
+                    ],
+                  }}
+                  animate={{ transform: [{ translateX: 0 }, { translateY: 0 }] }}
+                  transition={{
+                    type: "spring",
+                    delay: FAN_OUT_DELAY,
+                  }}
                   style={{
                     position: "absolute",
                     left: config.left * scale,
                     top: config.top * scale,
                   }}
-                />
+                >
+                  <ArtworkThumbnail
+                    imageUrl={artwork.url}
+                    blurhash={artwork.blurhash}
+                    width={CARD_WIDTH * scale}
+                    height={CARD_HEIGHT * scale}
+                    rotate={config.rotate}
+                  />
+                </MotiView>
               )
             })}
           </View>


### PR DESCRIPTION
This PR resolves [DI-360](https://www.notion.so/375cab0764a080838a0bec44fb364b45)

Assisted-by: Claude:Sonnet-5

### Description

This PR animates the artwork cards that are displayed in the onboarding completion bottom sheet when a new user saves 5 artworks in Discover Daily during onboarding.

| iOS | Android |
|-|-|
| https://github.com/user-attachments/assets/9fd0c41f-73aa-4179-989a-632bbbae8e3c | https://github.com/user-attachments/assets/e165d60d-93e6-4cb1-a1de-7ba1e4de83ca |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Added animation to another onboarding bottom sheet

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
