### PR TITLE
fix(search): reset trending rails scroll when the period changes

### DIFF
--- a/src/app/Scenes/Search/TrendingSearches/TrendingSearches.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/TrendingSearches.tsx
@@ -67,8 +67,8 @@ const TrendingContent: React.FC<{ period: TrendingPeriod }> = ({ period }) => {
   return (
     <Flex>
       <Join separator={<Spacer y={2} />}>
-        <TrendingArtistsAvatarsRail artists={artists} />
-        <TrendingArtworksRail artworks={artworks} />
+        <TrendingArtistsAvatarsRail artists={artists} resetKey={period} />
+        <TrendingArtworksRail artworks={artworks} resetKey={period} />
       </Join>
     </Flex>
   )

--- a/src/app/Scenes/Search/TrendingSearches/components/TrendingArtistsAvatarsRail.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/TrendingArtistsAvatarsRail.tsx
@@ -5,20 +5,28 @@ import { TrendingSectionHeader } from "app/Scenes/Search/TrendingSearches/compon
 import { AVATAR_ITEM_WIDTH, AVATAR_SIZE } from "app/Scenes/Search/TrendingSearches/constants"
 import { TrendingArtist } from "app/Scenes/Search/TrendingSearches/useTrendingSearches"
 import { RouterLink } from "app/system/navigation/RouterLink"
+import { useEffect, useRef } from "react"
 import { FlatList } from "react-native"
 import { useTracking } from "react-tracking"
 
 interface TrendingArtistsAvatarsRailProps {
   artists: TrendingArtist[]
+  resetKey?: string
   title?: string
 }
 
 export const TrendingArtistsAvatarsRail: React.FC<TrendingArtistsAvatarsRailProps> = ({
   artists,
+  resetKey,
   title = "Trending Artists",
 }) => {
   const space = useSpace()
   const { trackEvent } = useTracking()
+  const listRef = useRef<FlatList<TrendingArtist>>(null)
+
+  useEffect(() => {
+    listRef.current?.scrollToOffset({ offset: 0, animated: false })
+  }, [resetKey])
 
   if (!artists.length) {
     return null
@@ -43,6 +51,7 @@ export const TrendingArtistsAvatarsRail: React.FC<TrendingArtistsAvatarsRailProp
       <TrendingSectionHeader title={title} />
 
       <FlatList
+        ref={listRef}
         horizontal
         data={artists}
         keyboardShouldPersistTaps="handled"

--- a/src/app/Scenes/Search/TrendingSearches/components/TrendingArtworksRail.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/components/TrendingArtworksRail.tsx
@@ -3,16 +3,26 @@ import { Flex } from "@artsy/palette-mobile"
 import { ArtworkRail_artworks$key } from "__generated__/ArtworkRail_artworks.graphql"
 import { ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
 import { TrendingSectionHeader } from "app/Scenes/Search/TrendingSearches/components/TrendingSectionHeader"
+import { useEffect, useRef } from "react"
+import { FlatList } from "react-native"
 
 interface TrendingArtworksRailProps {
   artworks: ArtworkRail_artworks$key
+  resetKey?: string
   title?: string
 }
 
 export const TrendingArtworksRail: React.FC<TrendingArtworksRailProps> = ({
   artworks,
+  resetKey,
   title = "Trending Artworks",
 }) => {
+  const listRef = useRef<FlatList<any>>(null)
+
+  useEffect(() => {
+    listRef.current?.scrollToOffset({ offset: 0, animated: false })
+  }, [resetKey])
+
   if (!artworks.length) {
     return null
   }
@@ -22,6 +32,7 @@ export const TrendingArtworksRail: React.FC<TrendingArtworksRailProps> = ({
       <TrendingSectionHeader title={title} />
       <ArtworkRail
         artworks={artworks}
+        listRef={listRef}
         showSaveIcon
         contextModule={ContextModule.trendingArtworksRail}
         contextScreenOwnerType={OwnerType.search}


### PR DESCRIPTION
Assisted-by: Claude Code

This PR resolves [PBRW-2037]

### Description

**Bug:** in the Trending Searches section on the Search screen, toggling the period (Today / Past 7 Days / Past 30 Days) after scrolling one of the horizontal rails to the right could leave the rail blank until the user swiped back — the freshly fetched items were outside the FlatList render window because the previous horizontal `contentOffset` was preserved across the data swap.

**Fix:** `TrendingArtistsAvatarsRail` and `TrendingArtworksRail` now accept a `resetKey` prop. When it changes, the rail scrolls its horizontal `FlatList` back to offset 0 via a `useRef` + `useEffect`. `TrendingContent` passes `period` as the reset key, so switching periods always brings the rail back to the beginning — matching the user's expectation that a filter change presents the results "from the start."

Under the hood `TrendingArtworksRail` reuses `ArtworkRail`'s existing `listRef` prop, so no changes were needed in the shared component.

| Platform | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/271f3293-2910-4b59-99ab-f7441fe02de5" /> |  <video src="https://github.com/user-attachments/assets/95e68470-7434-4796-852f-84462df4dc9d" /> |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>
#nochangelog
</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-2037]: https://artsyproduct.atlassian.net/browse/PBRW-2037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ