### PR TITLE
 fix(search): recover trending searches after offline error

### DIFF
--- a/src/app/Scenes/Search/TrendingSearches/TrendingSearches.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/TrendingSearches.tsx
@@ -2,6 +2,7 @@ import { ActionType, ContextModule, OwnerType, type RailViewed } from "@artsy/co
 import { Flex, Join, Skeleton, SkeletonBox, SkeletonText, Spacer } from "@artsy/palette-mobile"
 import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs"
 import { ARTWORK_RAIL_CARD_IMAGE_HEIGHT } from "app/Components/ArtworkRail/ArtworkRailCardImage"
+import { LoadFailureView } from "app/Components/LoadFailureView"
 import { RecentSearchesPillsRail } from "app/Scenes/Search/TrendingSearches/components/RecentSearchesPillsRail"
 import { TrendingArtistsAvatarsRail } from "app/Scenes/Search/TrendingSearches/components/TrendingArtistsAvatarsRail"
 import { TrendingArtworksRail } from "app/Scenes/Search/TrendingSearches/components/TrendingArtworksRail"
@@ -11,18 +12,28 @@ import {
   TrendingPeriod,
   useTrendingSearches,
 } from "app/Scenes/Search/TrendingSearches/useTrendingSearches"
-import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
+import { withSuspense } from "app/utils/hooks/withSuspense"
 import { times } from "lodash"
-import { startTransition, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { ScrollView } from "react-native"
 import { useTracking } from "react-tracking"
+
+interface TrendingSectionProps {
+  period: TrendingPeriod
+  retryCount: number
+  onPeriodChange: (next: TrendingPeriod) => void
+  onRetry: () => void
+}
 
 export const TrendingSearches: React.FC = () => {
   const tabBarHeight = useBottomTabBarHeight()
   const [period, setPeriod] = useState<TrendingPeriod>("ONE_DAY")
+  // Monotonic — never reset. Each bump produces a fresh QueryResource cache slot,
+  // so a previously cached error entry can't hijack the next attempt.
+  const [retryCount, setRetryCount] = useState(0)
 
-  const handlePeriodChange = (next: TrendingPeriod) => {
-    startTransition(() => setPeriod(next))
+  const handleRetry = () => {
+    setRetryCount((count) => count + 1)
   }
 
   return (
@@ -30,19 +41,27 @@ export const TrendingSearches: React.FC = () => {
       keyboardShouldPersistTaps="handled"
       keyboardDismissMode="on-drag"
       showsVerticalScrollIndicator={false}
-      contentContainerStyle={{ paddingBottom: tabBarHeight + 24 }}
+      // flexGrow: 1 lets the error fallback fill the viewport so it can center vertically.
+      contentContainerStyle={{ flexGrow: 1, paddingBottom: tabBarHeight + 24 }}
     >
-      <Join separator={<Spacer y={2} />}>
-        <RecentSearchesPillsRail />
-        <TrendingSection period={period} />
-        <TrendingPeriodToggle value={period} onChange={handlePeriodChange} />
-      </Join>
+      <RecentSearchesPillsRail />
+      <Spacer y={2} />
+      <TrendingSection
+        period={period}
+        retryCount={retryCount}
+        onPeriodChange={setPeriod}
+        onRetry={handleRetry}
+      />
     </ScrollView>
   )
 }
 
-const TrendingContent: React.FC<{ period: TrendingPeriod }> = ({ period }) => {
-  const { artists, artworks } = useTrendingSearches(period)
+const TrendingContent: React.FC<TrendingSectionProps> = ({
+  period,
+  retryCount,
+  onPeriodChange,
+}) => {
+  const { artists, artworks } = useTrendingSearches(period, retryCount)
   const { trackEvent } = useTracking()
 
   useEffect(() => {
@@ -65,19 +84,34 @@ const TrendingContent: React.FC<{ period: TrendingPeriod }> = ({ period }) => {
   }, [])
 
   return (
-    <Flex>
-      <Join separator={<Spacer y={2} />}>
-        <TrendingArtistsAvatarsRail artists={artists} resetKey={period} />
-        <TrendingArtworksRail artworks={artworks} resetKey={period} />
-      </Join>
-    </Flex>
+    <Join separator={<Spacer y={2} />}>
+      <TrendingArtistsAvatarsRail artists={artists} resetKey={period} />
+      <TrendingArtworksRail artworks={artworks} resetKey={period} />
+      <TrendingPeriodToggle value={period} onChange={onPeriodChange} />
+    </Join>
   )
 }
 
-const TrendingSection = withSuspense({
+const TrendingLoadingFallback: React.FC<TrendingSectionProps> = ({ period, onPeriodChange }) => (
+  <>
+    <TrendingPlaceholder />
+    <Spacer y={2} />
+    <TrendingPeriodToggle value={period} onChange={onPeriodChange} />
+  </>
+)
+
+const TrendingSection = withSuspense<TrendingSectionProps>({
   Component: TrendingContent,
-  LoadingFallback: () => <TrendingPlaceholder />,
-  ErrorFallback: NoFallback,
+  LoadingFallback: TrendingLoadingFallback,
+  ErrorFallback: ({ error }, { onRetry }) => (
+    <LoadFailureView
+      error={error}
+      onRetry={onRetry}
+      trackErrorBoundary={false}
+      useSafeArea={false}
+    />
+  ),
+  resetKeys: ({ period, retryCount }) => [period, retryCount],
 })
 
 const AVATAR_ITEM_COUNT = 4

--- a/src/app/Scenes/Search/TrendingSearches/useTrendingSearches.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/useTrendingSearches.tsx
@@ -39,11 +39,13 @@ export const trendingSearchesQuery = graphql`
 
 export type TrendingPeriod = TrendingSearchPeriod
 
-export const useTrendingSearches = (period: TrendingPeriod) => {
+export const useTrendingSearches = (period: TrendingPeriod, retryCount = 0) => {
+  // `fetchKey` bumps allocate a fresh QueryResource cache slot on retry, sidestepping
+  // any error entry cached from a previous failed fetch for the same variables.
   const data = useLazyLoadQuery<useTrendingSearchesQuery>(
     trendingSearchesQuery,
     { period },
-    { fetchPolicy: "store-or-network" }
+    { fetchPolicy: "store-or-network", fetchKey: retryCount }
   )
 
   const trending = data.viewer?.searchDropdown.trending

--- a/src/app/utils/hooks/withSuspense.tsx
+++ b/src/app/utils/hooks/withSuspense.tsx
@@ -34,6 +34,14 @@ type WithSuspenseOptions<T> = {
   ErrorFallback:
     | ((props: FallbackProps, componentProps: T) => ReactElement | null)
     | typeof NoFallback
+
+  /**
+   * Selector for `ErrorBoundary`'s `resetKeys`. When any value in the returned array
+   * changes between renders, the boundary auto-resets — useful when a caught error
+   * should clear as soon as the parent swaps to a different variant of the same tree
+   * (e.g. filter changes, retry counters).
+   */
+  resetKeys?: (props: T) => unknown[]
 }
 
 const DefaultLoadingFallback: React.FC = () => (
@@ -56,6 +64,7 @@ export const withSuspense = <T extends Object | any>({
   Component,
   LoadingFallback,
   ErrorFallback,
+  resetKeys,
 }: WithSuspenseOptions<T>): React.FC<T> => {
   const LoadingFallbackComponent =
     LoadingFallback === SpinnerFallback ? DefaultLoadingFallback : LoadingFallback
@@ -64,6 +73,7 @@ export const withSuspense = <T extends Object | any>({
     // we display the fallback component if error or we defensively hide the component
     return (
       <ErrorBoundary
+        resetKeys={resetKeys?.(props)}
         fallbackRender={(error) => {
           if (ErrorFallback === NoFallback) {
             // No fallback means render nothing when an error occurs


### PR DESCRIPTION
 Assisted-by: Claude Code

This PR resolves [PBRW-2039] 

### Description

Reproduction from the ticket:
1. Open Search.
2. Turn off the internet.
3. Tap Past 7 Days / Past 30 Days.
4. Restore the internet.
5. Switch tabs and come back to Search.
6. Tap Past 7 Days / Past 30 Days again.

Expected: content loads once we're back online. Actual: those tabs stayed blank until the app was killed.

### Root cause

Two things stacked on top of each other:
1. withSuspense's ErrorBoundary had no resetKeys wired up. Once the offline fetch threw, the boundary latched forever — switching periods didn't re-mount TrendingContent, so useLazyLoadQuery never got a chance to retry.
2. Relay's QueryResource caches the error entry by (query, variables, fetchPolicy, fetchKey). Even if the boundary reset, re-rendering with the same fetchKey would return the cached error immediately.

Fix
- withSuspense: added an optional resetKeys selector, forwarded to react-error-boundary. General-purpose — any consumer can now auto-unlatch the boundary when a prop changes.
- useTrendingSearches: takes a retryCount param and passes it as fetchKey.
- TrendingSearches: retryCount state + retry button that bumps it.
  
### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-2039]: https://artsyproduct.atlassian.net/browse/PBRW-2039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ