### PR TITLE
refactor: add tests for useInfiniteDiscoveryCardSave

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/hooks/__tests__/useInfiniteDiscoveryCardSave.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/__tests__/useInfiniteDiscoveryCardSave.tests.tsx
@@ -1,0 +1,184 @@
+import { ScreenDimensionsProvider } from "@artsy/palette-mobile"
+import { act, renderHook } from "@testing-library/react-native"
+import { InfiniteDiscoveryArtworkCard_artwork$data } from "__generated__/InfiniteDiscoveryArtworkCard_artwork.graphql"
+import * as useSaveArtworkToArtworkListsModule from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
+import { useInfiniteDiscoveryCardSave } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave"
+import { GlobalStore, GlobalStoreProvider, __globalStoreTestUtils__ } from "app/store/GlobalStore"
+
+const mockTrack = { savedArtwork: jest.fn() }
+
+jest.mock("app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking", () => ({
+  useInfiniteDiscoveryTracking: () => mockTrack,
+}))
+
+const mockArtwork = {
+  internalID: "artwork-1",
+  slug: "artwork-1-slug",
+  images: [{ url: "https://example.com/image.jpg", blurhash: "blurhash-1" }],
+} as unknown as InfiniteDiscoveryArtworkCard_artwork$data
+
+const mockSaveArtworkToLists = jest.fn()
+let capturedOptions: any
+
+const mockUseSaveArtworkToArtworkLists = (isSaved: boolean) => {
+  jest
+    .spyOn(useSaveArtworkToArtworkListsModule, "useSaveArtworkToArtworkLists")
+    .mockImplementation((options) => {
+      capturedOptions = options
+      return { isSaved, saveArtworkToLists: mockSaveArtworkToLists }
+    })
+}
+
+const wrapper = ({ children }: any) => (
+  <ScreenDimensionsProvider>
+    <GlobalStoreProvider>{children}</GlobalStoreProvider>
+  </ScreenDimensionsProvider>
+)
+
+const getState = () => __globalStoreTestUtils__!.getCurrentState().infiniteDiscovery
+
+describe("useInfiniteDiscoveryCardSave", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    GlobalStore.actions.infiniteDiscovery.resetSavedArtworksCount()
+    GlobalStore.actions.infiniteDiscovery.resetNewUserOnboardingSessionState()
+    GlobalStore.actions.infiniteDiscovery.setHasSavedArtworks(false)
+    GlobalStore.actions.onboarding.setOnboardingState("complete")
+  })
+
+  it("saves the artwork: increments the count and marks that artworks have been saved", () => {
+    mockUseSaveArtworkToArtworkLists(false)
+    const { result } = renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
+
+    act(() => result.current.handleSaveButtonPress())
+
+    expect(getState().savedArtworksCount).toBe(1)
+    expect(getState().hasSavedArtworks).toBe(true)
+    expect(mockSaveArtworkToLists).toHaveBeenCalledTimes(1)
+  })
+
+  it("unsaves the artwork: decrements the count", () => {
+    mockUseSaveArtworkToArtworkLists(true)
+    GlobalStore.actions.infiniteDiscovery.incrementSavedArtworksCount()
+    const { result } = renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
+
+    act(() => result.current.handleSaveButtonPress())
+
+    expect(getState().savedArtworksCount).toBe(0)
+  })
+
+  it("saves on double-tap when not already saved", () => {
+    mockUseSaveArtworkToArtworkLists(false)
+    const { result } = renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
+
+    act(() => result.current.handleDoubleTapSave())
+
+    expect(getState().savedArtworksCount).toBe(1)
+    expect(mockSaveArtworkToLists).toHaveBeenCalledTimes(1)
+  })
+
+  it("ignores a double-tap when the artwork is already saved", () => {
+    mockUseSaveArtworkToArtworkLists(true)
+    const { result } = renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
+
+    act(() => result.current.handleDoubleTapSave())
+
+    expect(getState().savedArtworksCount).toBe(0)
+    expect(mockSaveArtworkToLists).not.toHaveBeenCalled()
+  })
+
+  it("tracks the save once the mutation completes", () => {
+    mockUseSaveArtworkToArtworkLists(false)
+    renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
+
+    act(() => capturedOptions.onCompleted(true))
+
+    expect(mockTrack.savedArtwork).toHaveBeenCalledWith(true, "artwork-1", "artwork-1-slug")
+  })
+
+  it("reverts a failed save: decrements the count", () => {
+    mockUseSaveArtworkToArtworkLists(false)
+    GlobalStore.actions.infiniteDiscovery.incrementSavedArtworksCount()
+    renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
+
+    act(() => capturedOptions.onError())
+
+    expect(getState().savedArtworksCount).toBe(0)
+  })
+
+  it("reverts a failed unsave: increments the count", () => {
+    mockUseSaveArtworkToArtworkLists(true)
+    renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
+
+    act(() => capturedOptions.onError())
+
+    expect(getState().savedArtworksCount).toBe(1)
+  })
+
+  describe("during onboarding", () => {
+    beforeEach(() => {
+      GlobalStore.actions.onboarding.setOnboardingState("incomplete")
+    })
+
+    it("adds the artwork to the onboarding list when saved", () => {
+      mockUseSaveArtworkToArtworkLists(false)
+      const { result } = renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
+
+      act(() => result.current.handleSaveButtonPress())
+
+      expect(getState().sessionState.newUserOnboardingSavedArtworks).toEqual([
+        expect.objectContaining({ internalID: "artwork-1", blurhash: "blurhash-1" }),
+      ])
+    })
+
+    it("removes the artwork from the onboarding list when unsaved", () => {
+      mockUseSaveArtworkToArtworkLists(true)
+      GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
+        internalID: "artwork-1",
+        url: "https://example.com/image.jpg",
+        blurhash: "blurhash-1",
+      })
+      const { result } = renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
+
+      act(() => result.current.handleSaveButtonPress())
+
+      expect(getState().sessionState.newUserOnboardingSavedArtworks).toEqual([])
+    })
+
+    it("adds the artwork to the onboarding list when saved via double-tap", () => {
+      mockUseSaveArtworkToArtworkLists(false)
+      const { result } = renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
+
+      act(() => result.current.handleDoubleTapSave())
+
+      expect(getState().sessionState.newUserOnboardingSavedArtworks).toEqual([
+        expect.objectContaining({ internalID: "artwork-1" }),
+      ])
+    })
+
+    it("removes the artwork from the onboarding list when reverting a failed save", () => {
+      mockUseSaveArtworkToArtworkLists(false)
+      GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
+        internalID: "artwork-1",
+        url: "https://example.com/image.jpg",
+        blurhash: "blurhash-1",
+      })
+      renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
+
+      act(() => capturedOptions.onError())
+
+      expect(getState().sessionState.newUserOnboardingSavedArtworks).toEqual([])
+    })
+
+    it("re-adds the artwork to the onboarding list when reverting a failed unsave", () => {
+      mockUseSaveArtworkToArtworkLists(true)
+      renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
+
+      act(() => capturedOptions.onError())
+
+      expect(getState().sessionState.newUserOnboardingSavedArtworks).toEqual([
+        expect.objectContaining({ internalID: "artwork-1" }),
+      ])
+    })
+  })
+})

--- a/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave.ts
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave.ts
@@ -35,20 +35,20 @@ export const useInfiniteDiscoveryCardSave = (
     removeNewUserOnboardingSavedArtwork,
   } = GlobalStore.actions.infiniteDiscovery
 
-  const addOnboardingArtwork = () => {
-    if (isNewUserOnboardingSession && artwork) {
-      addNewUserOnboardingSavedArtwork({
-        internalID: artwork.internalID,
-        url: getThumbnailUrl(artwork.images[0]?.url ?? "", screenWidth),
-        blurhash: artwork.images[0]?.blurhash,
-      })
-    }
+  const addOnboardingSavedArtwork = () => {
+    if (!artwork) return
+
+    addNewUserOnboardingSavedArtwork({
+      internalID: artwork.internalID,
+      url: getThumbnailUrl(artwork.images[0]?.url ?? "", screenWidth),
+      blurhash: artwork.images[0]?.blurhash,
+    })
   }
 
-  const removeOnboardingArtwork = () => {
-    if (isNewUserOnboardingSession && artwork) {
-      removeNewUserOnboardingSavedArtwork(artwork.internalID)
-    }
+  const removeOnboardingSavedArtwork = () => {
+    if (!artwork) return
+
+    removeNewUserOnboardingSavedArtwork(artwork.internalID)
   }
 
   const { isSaved, saveArtworkToLists } = useSaveArtworkToArtworkLists({
@@ -69,11 +69,11 @@ export const useInfiniteDiscoveryCardSave = (
       if (isSaved) {
         // if the artwork is currently saved, we optimistically decremented the count, so increment it back
         incrementSavedArtworksCount()
-        addOnboardingArtwork()
+        if (isNewUserOnboardingSession) addOnboardingSavedArtwork()
       } else {
         // if the artwork is currently unsaved, we optimistically incremented the count, so decrement it back
         decrementSavedArtworksCount()
-        removeOnboardingArtwork()
+        if (isNewUserOnboardingSession) removeOnboardingSavedArtwork()
       }
     },
   })
@@ -84,11 +84,11 @@ export const useInfiniteDiscoveryCardSave = (
     if (isSaved) {
       // if the artwork is currently saved, it will become unsaved, so optimistically decrement the count
       decrementSavedArtworksCount()
-      removeOnboardingArtwork()
+      if (isNewUserOnboardingSession) removeOnboardingSavedArtwork()
     } else {
       // if the artwork is currently unsaved, it will become saved, so optimistically increment the count
       incrementSavedArtworksCount()
-      addOnboardingArtwork()
+      if (isNewUserOnboardingSession) addOnboardingSavedArtwork()
     }
 
     saveArtworkToLists()
@@ -99,7 +99,7 @@ export const useInfiniteDiscoveryCardSave = (
 
     if (!hasSavedArtworks) setHasSavedArtworks(true)
     incrementSavedArtworksCount()
-    addOnboardingArtwork()
+    if (isNewUserOnboardingSession) addOnboardingSavedArtwork()
     saveArtworkToLists()
   }
 


### PR DESCRIPTION
This PR adds tests to (and rearranges some of) the `useInfiniteDiscoveryCardSave` hook that is used by Discover Daily to manage saves and un-saves on artworks.

I am doing this work in preparation to add a new animation to Discover Daily when artworks are saved during the onboarding flow.

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Added tests to the useInfiniteDiscoveryCardSave hook

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
