### PR TITLE
feat(DI-359): animate artwork saves during onboarding

### DIFF
--- a/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
+++ b/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
@@ -1,7 +1,7 @@
 import { Flex, Text } from "@artsy/palette-mobile"
 import { MotiView } from "moti"
 import { useEffect, useLayoutEffect, useMemo, useState } from "react"
-import { Easing } from "react-native-reanimated"
+import { Easing, useReducedMotion } from "react-native-reanimated"
 
 export type OnboardingProgressUnit = "follows" | "saves"
 
@@ -67,17 +67,18 @@ export const OnboardingProgressBadge: React.FC<OnboardingProgressBadgeProps> = (
   total,
   unit,
 }) => {
+  const isReducedMotionEnabled = useReducedMotion()
   const [isJumping, setIsJumping] = useState(false)
   const [displayedCount, setDisplayedCount] = useState(currentCount)
 
   // starts the jump when currentCount increases, or updates displayedCount directly otherwise
   useLayoutEffect(() => {
-    if (currentCount > displayedCount) {
+    if (currentCount > displayedCount && !isReducedMotionEnabled) {
       setIsJumping(true)
     } else {
       setDisplayedCount(currentCount)
     }
-  }, [currentCount, displayedCount])
+  }, [currentCount, displayedCount, isReducedMotionEnabled])
 
   // schedules the mid-jump number swap and the end-of-animation reset
   useEffect(() => {
@@ -112,7 +113,12 @@ export const OnboardingProgressBadge: React.FC<OnboardingProgressBadgeProps> = (
   }
 
   return (
-    <Flex flexDirection="row" alignItems="baseline">
+    <Flex
+      flexDirection="row"
+      alignItems="baseline"
+      accessible
+      accessibilityLabel={`${displayedCount} ${getProgressText(unit, total)}`}
+    >
       <MotiView {...jumpAnimationProps}>
         <Text
           variant="sm-display"

--- a/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
+++ b/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
@@ -1,4 +1,7 @@
-import { Text } from "@artsy/palette-mobile"
+import { Flex, Text } from "@artsy/palette-mobile"
+import { MotiView } from "moti"
+import { useEffect, useLayoutEffect, useMemo, useState } from "react"
+import { Easing } from "react-native-reanimated"
 
 export type OnboardingProgressUnit = "follows" | "saves"
 
@@ -11,6 +14,48 @@ const getProgressText = (unit: OnboardingProgressUnit, total: number) => {
   }
 }
 
+const JUMP_HEIGHT = 6
+const UNDERSHOOT_DEPTH = 2
+
+const JUMP_UP_DURATION = 100
+const FALL_TO_FLOOR_DURATION = 70
+const PAST_FLOOR_DURATION = 40
+const SPRING_SETTLE_DURATION = 80
+
+const TIME_TO_HIT_FLOOR = JUMP_UP_DURATION + FALL_TO_FLOOR_DURATION
+const JUMP_AND_LAND_DURATION = TIME_TO_HIT_FLOOR + PAST_FLOOR_DURATION + SPRING_SETTLE_DURATION
+
+const JUMP_SEQUENCE = [
+  // rise up off the baseline
+  {
+    value: -JUMP_HEIGHT,
+    type: "timing" as const,
+    duration: JUMP_UP_DURATION,
+    easing: Easing.out(Easing.ease),
+  },
+  // fall back down to the baseline (this is "hitting the floor")
+  {
+    value: 0,
+    type: "timing" as const,
+    duration: FALL_TO_FLOOR_DURATION,
+    easing: Easing.in(Easing.ease),
+  },
+  // keep going slightly past the baseline
+  {
+    value: UNDERSHOOT_DEPTH,
+    type: "timing" as const,
+    duration: PAST_FLOOR_DURATION,
+    easing: Easing.out(Easing.ease),
+  },
+  // spring back up to rest
+  {
+    value: 0,
+    type: "timing" as const,
+    duration: SPRING_SETTLE_DURATION,
+    easing: Easing.out(Easing.ease),
+  },
+]
+
 interface OnboardingProgressBadgeProps {
   current: number
   total: number
@@ -18,11 +63,47 @@ interface OnboardingProgressBadgeProps {
 }
 
 export const OnboardingProgressBadge: React.FC<OnboardingProgressBadgeProps> = ({
-  current,
+  current: currentCount,
   total,
   unit,
 }) => {
-  if (current >= total) {
+  const [isJumping, setIsJumping] = useState(false)
+  const [displayedCount, setDisplayedCount] = useState(currentCount)
+
+  // starts the jump when currentCount increases, or updates displayedCount directly otherwise
+  useLayoutEffect(() => {
+    if (currentCount > displayedCount) {
+      setIsJumping(true)
+    } else {
+      setDisplayedCount(currentCount)
+    }
+  }, [currentCount, displayedCount])
+
+  // schedules the mid-jump number swap and the end-of-animation reset
+  useEffect(() => {
+    if (!isJumping) return
+
+    // swap the number in right as the jump touches down
+    const hitFloorTimeout = setTimeout(() => setDisplayedCount(currentCount), TIME_TO_HIT_FLOOR)
+    // reset once the whole sequence has finished
+    const landedTimeout = setTimeout(() => setIsJumping(false), JUMP_AND_LAND_DURATION)
+
+    return () => {
+      clearTimeout(hitFloorTimeout)
+      clearTimeout(landedTimeout)
+    }
+  }, [isJumping, currentCount])
+
+  // stable reference while isJumping is unchanged, so the number swap doesn't restart the sequence
+  const jumpAnimationProps = useMemo(
+    () => ({
+      from: { transform: [{ translateY: 0 }] },
+      animate: { transform: [{ translateY: isJumping ? JUMP_SEQUENCE : 0 }] },
+    }),
+    [isJumping]
+  )
+
+  if (displayedCount >= total) {
     return (
       <Text variant="sm-display" color="blue100">
         Complete
@@ -31,11 +112,20 @@ export const OnboardingProgressBadge: React.FC<OnboardingProgressBadgeProps> = (
   }
 
   return (
-    <Text variant="sm-display" color="mono100">
-      <Text variant="sm-display" weight="medium" color="blue100">
-        {current}
+    <Flex flexDirection="row" alignItems="baseline">
+      <MotiView {...jumpAnimationProps}>
+        <Text
+          variant="sm-display"
+          weight="medium"
+          color="blue100"
+          style={{ fontVariant: ["tabular-nums"] }}
+        >
+          {displayedCount}
+        </Text>
+      </MotiView>
+      <Text variant="sm-display" color="mono100">
+        {` ${getProgressText(unit, total)}`}
       </Text>
-      {` ${getProgressText(unit, total)}`}
-    </Text>
+    </Flex>
   )
 }

--- a/src/app/Components/OnboardingProgressBadge/__tests__/OnboardingProgressBadge.tests.tsx
+++ b/src/app/Components/OnboardingProgressBadge/__tests__/OnboardingProgressBadge.tests.tsx
@@ -6,26 +6,30 @@ describe("OnboardingProgressBadge", () => {
   it("renders current and total for follows", () => {
     renderWithWrappers(<OnboardingProgressBadge current={2} total={5} unit="follows" />)
 
-    expect(screen.getByText("2 of 5 follows")).toBeOnTheScreen()
+    expect(screen.getByText("2")).toBeOnTheScreen()
+    expect(screen.getByText("of 5 follows")).toBeOnTheScreen()
   })
 
   it("renders current and total for saves", () => {
     renderWithWrappers(<OnboardingProgressBadge current={2} total={5} unit="saves" />)
 
-    expect(screen.getByText("2 of 5 saves")).toBeOnTheScreen()
+    expect(screen.getByText("2")).toBeOnTheScreen()
+    expect(screen.getByText("of 5 saves")).toBeOnTheScreen()
   })
 
   it("renders zero state", () => {
     renderWithWrappers(<OnboardingProgressBadge current={0} total={5} unit="saves" />)
 
-    expect(screen.getByText("0 of 5 saves")).toBeOnTheScreen()
+    expect(screen.getByText("0")).toBeOnTheScreen()
+    expect(screen.getByText("of 5 saves")).toBeOnTheScreen()
   })
 
   it("shows Complete once current reaches total", () => {
     renderWithWrappers(<OnboardingProgressBadge current={5} total={5} unit="saves" />)
 
     expect(screen.getByText("Complete")).toBeOnTheScreen()
-    expect(screen.queryByText("5 of 5 saves")).not.toBeOnTheScreen()
+    expect(screen.queryByText("5")).not.toBeOnTheScreen()
+    expect(screen.queryByText("of 5 saves")).not.toBeOnTheScreen()
   })
 
   it("shows Complete when current exceeds total", () => {

--- a/src/app/Components/OnboardingProgressBadge/__tests__/OnboardingProgressBadge.tests.tsx
+++ b/src/app/Components/OnboardingProgressBadge/__tests__/OnboardingProgressBadge.tests.tsx
@@ -1,8 +1,20 @@
 import { screen } from "@testing-library/react-native"
 import { OnboardingProgressBadge } from "app/Components/OnboardingProgressBadge/OnboardingProgressBadge"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { useReducedMotion } from "react-native-reanimated"
+
+jest.mock("react-native-reanimated", () => ({
+  ...require("react-native-reanimated/mock"),
+  useReducedMotion: jest.fn(),
+}))
+
+const mockUseReducedMotion = useReducedMotion as jest.Mock
 
 describe("OnboardingProgressBadge", () => {
+  beforeEach(() => {
+    mockUseReducedMotion.mockReturnValue(false)
+  })
+
   it("renders current and total for follows", () => {
     renderWithWrappers(<OnboardingProgressBadge current={2} total={5} unit="follows" />)
 
@@ -36,5 +48,17 @@ describe("OnboardingProgressBadge", () => {
     renderWithWrappers(<OnboardingProgressBadge current={7} total={5} unit="saves" />)
 
     expect(screen.getByText("Complete")).toBeOnTheScreen()
+  })
+
+  it("updates the count immediately, without a jump, when Reduce Motion is enabled", () => {
+    mockUseReducedMotion.mockReturnValue(true)
+    const { rerender } = renderWithWrappers(
+      <OnboardingProgressBadge current={2} total={5} unit="saves" />
+    )
+
+    rerender(<OnboardingProgressBadge current={3} total={5} unit="saves" />)
+
+    expect(screen.getByText("3")).toBeOnTheScreen()
+    expect(screen.queryByText("2")).not.toBeOnTheScreen()
   })
 })

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -5,6 +5,7 @@ import { InfiniteDiscoveryArtworkCard_artwork$key } from "__generated__/Infinite
 import { ArtistListItemContainer } from "app/Components/ArtistListItem"
 import { ArtworkSaveIconWrapper } from "app/Components/ArtworkGrids/ArtworkSaveIconWrapper"
 import { InfiniteDiscoveryArtworkCardPopover } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCardPopover"
+import { InfiniteDiscoverySaveFlightAnimation } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveFlightAnimation"
 import { PaginationBars } from "app/Scenes/InfiniteDiscovery/Components/PaginationBars"
 import { useInfiniteDiscoveryCardSave } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave"
 import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking"
@@ -58,6 +59,8 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
       isSaved: isSavedToArtworkList,
       handleSaveButtonPress,
       handleDoubleTapSave,
+      pendingSaveAnimationArtwork,
+      completeSaveAnimation,
     } = useInfiniteDiscoveryCardSave(artwork)
 
     const isSaved = isSavedProp !== undefined ? isSavedProp : isSavedToArtworkList
@@ -128,7 +131,9 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
           state.numTaps = 0
           if (!isSaved) {
             Haptic.trigger("impactLight")
-            setShowScreenTapToSave(true)
+            if (!isNewUserOnboardingSession) {
+              setShowScreenTapToSave(true)
+            }
             handleDoubleTapSave()
           }
           return true
@@ -296,6 +301,10 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
             </InfiniteDiscoveryArtworkCardPopover>
           </Touchable>
         </Flex>
+        <InfiniteDiscoverySaveFlightAnimation
+          artwork={pendingSaveAnimationArtwork}
+          onComplete={completeSaveAnimation}
+        />
       </Flex>
     )
   }

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -47,6 +47,9 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
     const color = useColor()
     const isNewUserOnboardingSession =
       GlobalStore.useAppState((state) => state.onboarding.onboardingState) === "incomplete"
+    const newUserOnboardingGoalReached = GlobalStore.useAppState(
+      (state) => state.infiniteDiscovery.sessionState.newUserOnboardingGoalReached
+    )
 
     const artwork = useFragment<InfiniteDiscoveryArtworkCard_artwork$key>(
       infiniteDiscoveryArtworkCardFragment,
@@ -131,7 +134,7 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
           state.numTaps = 0
           if (!isSaved) {
             Haptic.trigger("impactLight")
-            if (!isNewUserOnboardingSession) {
+            if (!isNewUserOnboardingSession || newUserOnboardingGoalReached) {
               setShowScreenTapToSave(true)
             }
             handleDoubleTapSave()

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveFlightAnimation.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveFlightAnimation.tsx
@@ -1,0 +1,191 @@
+import { Image, useScreenDimensions } from "@artsy/palette-mobile"
+import { Portal } from "@gorhom/portal"
+import { NewUserOnboardingSavedArtwork } from "app/store/InfiniteDiscoveryModel"
+import { BLURHASH_DECODE_ASYNC } from "app/utils/blurhashDecodeAsync"
+import { MotiView } from "moti"
+import { useEffect, useRef, useState } from "react"
+import { Easing } from "react-native-reanimated"
+
+export const INFINITE_DISCOVERY_SAVE_ANIMATION_PORTAL_HOST = "InfiniteDiscovery-SaveAnimation"
+
+const CARD_WIDTH = 50
+const CARD_HEIGHT = 66
+const CARD_BORDER_WIDTH = 5
+const CARD_BORDER_RADIUS = 9
+
+const POP_OVERSHOOT_DURATION = 90
+const POP_SETTLE_DURATION = 150
+const POP_DURATION = POP_OVERSHOOT_DURATION + POP_SETTLE_DURATION
+const FADE_IN_DURATION = POP_OVERSHOOT_DURATION
+const FLIGHT_DURATION = 500
+const FADE_OUT_DURATION = 125
+const OPACITY_DROP_DURATION = 75
+const FADE_OUT_SCALE = 0.35
+
+const BASE_SCALE = 1
+const POP_START_SCALE = 0.4
+const POP_OVERSHOOT_SCALE = 1.1
+
+const BADGE_APPROXIMATE_LEFT = 20
+
+interface InfiniteDiscoverySaveFlightAnimationProps {
+  artwork: NewUserOnboardingSavedArtwork | null
+  onComplete: () => void
+}
+
+export const InfiniteDiscoverySaveFlightAnimation: React.FC<
+  InfiniteDiscoverySaveFlightAnimationProps
+> = ({ artwork, onComplete }) => {
+  const { width: screenWidth, height: screenHeight, safeAreaInsets } = useScreenDimensions()
+
+  if (!artwork) {
+    return null
+  }
+
+  const startLeft = screenWidth / 2 - CARD_WIDTH / 2
+  const startTop = screenHeight / 2 - CARD_HEIGHT / 2
+  const endLeft = BADGE_APPROXIMATE_LEFT
+  const endTop = safeAreaInsets.top
+
+  return (
+    <Portal hostName={INFINITE_DISCOVERY_SAVE_ANIMATION_PORTAL_HOST}>
+      <SaveFlightCard
+        key={artwork.internalID}
+        imageUrl={artwork.url}
+        blurhash={artwork.blurhash}
+        startLeft={startLeft}
+        startTop={startTop}
+        translateX={endLeft - startLeft}
+        translateY={endTop - startTop}
+        onComplete={onComplete}
+      />
+    </Portal>
+  )
+}
+
+interface SaveFlightCardProps {
+  imageUrl: string
+  blurhash?: string | null
+  startLeft: number
+  startTop: number
+  translateX: number
+  translateY: number
+  onComplete: () => void
+}
+
+type FlightPhase = "pop_in" | "flight" | "fade_out"
+
+const PHASE_DURATIONS: Record<FlightPhase, number> = {
+  pop_in: POP_DURATION,
+  flight: FLIGHT_DURATION - FADE_OUT_DURATION,
+  fade_out: FADE_OUT_DURATION,
+}
+
+const POP_IN_SCALE_SEQUENCE = [
+  {
+    value: POP_OVERSHOOT_SCALE,
+    type: "timing" as const,
+    duration: POP_OVERSHOOT_DURATION,
+    easing: Easing.out(Easing.ease),
+  },
+  {
+    value: BASE_SCALE,
+    type: "timing" as const,
+    duration: POP_SETTLE_DURATION,
+    easing: Easing.out(Easing.ease),
+  },
+]
+
+const SaveFlightCard: React.FC<SaveFlightCardProps> = ({
+  imageUrl,
+  blurhash,
+  startLeft,
+  startTop,
+  translateX,
+  translateY,
+  onComplete,
+}) => {
+  const [phase, setPhase] = useState<FlightPhase>("pop_in")
+  const onCompleteRef = useRef(onComplete)
+  onCompleteRef.current = onComplete
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      if (phase === "pop_in") setPhase("flight")
+      else if (phase === "flight") setPhase("fade_out")
+      else onCompleteRef.current()
+    }, PHASE_DURATIONS[phase])
+
+    return () => clearTimeout(timeout)
+  }, [phase])
+
+  const isPoppingIn = phase === "pop_in"
+  const isFadingOut = phase === "fade_out"
+
+  return (
+    <MotiView
+      pointerEvents="none"
+      from={{
+        transform: [{ translateX: 0 }, { translateY: 0 }, { scale: POP_START_SCALE }],
+        opacity: 0,
+      }}
+      animate={{
+        transform: [
+          { translateX: isPoppingIn ? 0 : translateX },
+          { translateY: isPoppingIn ? 0 : translateY },
+          {
+            scale: isPoppingIn ? POP_IN_SCALE_SEQUENCE : isFadingOut ? FADE_OUT_SCALE : BASE_SCALE,
+          },
+        ],
+        opacity: isFadingOut ? 0 : 1,
+      }}
+      transition={{
+        translateY: {
+          type: "timing",
+          duration: FLIGHT_DURATION,
+          easing: Easing.in(Easing.quad),
+        },
+        translateX: {
+          type: "timing",
+          duration: FLIGHT_DURATION,
+          easing: Easing.out(Easing.quad),
+        },
+        scale: {
+          type: "timing",
+          duration: FADE_OUT_DURATION,
+          easing: Easing.inOut(Easing.quad),
+        },
+        opacity: {
+          type: "timing",
+          duration: isFadingOut ? OPACITY_DROP_DURATION : FADE_IN_DURATION,
+          delay: isFadingOut ? FADE_OUT_DURATION - OPACITY_DROP_DURATION : 0,
+        },
+      }}
+      style={{
+        position: "absolute",
+        left: startLeft,
+        top: startTop,
+        width: CARD_WIDTH,
+        height: CARD_HEIGHT,
+        borderRadius: CARD_BORDER_RADIUS,
+        borderWidth: CARD_BORDER_WIDTH,
+        borderColor: "white",
+        overflow: "hidden",
+        backgroundColor: "white",
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.08,
+        shadowRadius: 4,
+        elevation: 2,
+      }}
+    >
+      <Image
+        src={imageUrl}
+        blurhash={blurhash ?? undefined}
+        blurhashDecodeAsync={BLURHASH_DECODE_ASYNC}
+        width={CARD_WIDTH - CARD_BORDER_WIDTH * 2}
+        height={CARD_HEIGHT - CARD_BORDER_WIDTH * 2}
+      />
+    </MotiView>
+  )
+}

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveFlightAnimation.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveFlightAnimation.tsx
@@ -157,6 +157,8 @@ const SaveFlightCard: React.FC<SaveFlightCardProps> = ({
   return (
     <MotiView
       pointerEvents="none"
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
       {...flightAnimationProps}
       style={{
         position: "absolute",

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveFlightAnimation.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveFlightAnimation.tsx
@@ -1,9 +1,10 @@
 import { Image, useScreenDimensions } from "@artsy/palette-mobile"
 import { Portal } from "@gorhom/portal"
+import { useSaveFlightPhase } from "app/Scenes/InfiniteDiscovery/hooks/useSaveFlightPhase"
 import { NewUserOnboardingSavedArtwork } from "app/store/InfiniteDiscoveryModel"
 import { BLURHASH_DECODE_ASYNC } from "app/utils/blurhashDecodeAsync"
 import { MotiView } from "moti"
-import { useEffect, useRef, useState } from "react"
+import { useMemo } from "react"
 import { Easing } from "react-native-reanimated"
 
 export const INFINITE_DISCOVERY_SAVE_ANIMATION_PORTAL_HOST = "InfiniteDiscovery-SaveAnimation"
@@ -73,21 +74,15 @@ interface SaveFlightCardProps {
   onComplete: () => void
 }
 
-type FlightPhase = "pop_in" | "flight" | "fade_out"
-
-const PHASE_DURATIONS: Record<FlightPhase, number> = {
-  pop_in: POP_DURATION,
-  flight: FLIGHT_DURATION - FADE_OUT_DURATION,
-  fade_out: FADE_OUT_DURATION,
-}
-
 const POP_IN_SCALE_SEQUENCE = [
+  // overshoot past full size
   {
     value: POP_OVERSHOOT_SCALE,
     type: "timing" as const,
     duration: POP_OVERSHOOT_DURATION,
     easing: Easing.out(Easing.ease),
   },
+  // settle back down to full size
   {
     value: BASE_SCALE,
     type: "timing" as const,
@@ -105,31 +100,24 @@ const SaveFlightCard: React.FC<SaveFlightCardProps> = ({
   translateY,
   onComplete,
 }) => {
-  const [phase, setPhase] = useState<FlightPhase>("pop_in")
-  const onCompleteRef = useRef(onComplete)
-  onCompleteRef.current = onComplete
-
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      if (phase === "pop_in") setPhase("flight")
-      else if (phase === "flight") setPhase("fade_out")
-      else onCompleteRef.current()
-    }, PHASE_DURATIONS[phase])
-
-    return () => clearTimeout(timeout)
-  }, [phase])
+  const phase = useSaveFlightPhase({
+    popInDuration: POP_DURATION,
+    flightDuration: FLIGHT_DURATION - FADE_OUT_DURATION,
+    fadeOutDuration: FADE_OUT_DURATION,
+    onComplete,
+  })
 
   const isPoppingIn = phase === "pop_in"
   const isFadingOut = phase === "fade_out"
 
-  return (
-    <MotiView
-      pointerEvents="none"
-      from={{
+  // stable reference while phase is unchanged, so unrelated re-renders don't restart the sequence
+  const flightAnimationProps = useMemo(
+    () => ({
+      from: {
         transform: [{ translateX: 0 }, { translateY: 0 }, { scale: POP_START_SCALE }],
         opacity: 0,
-      }}
-      animate={{
+      },
+      animate: {
         transform: [
           { translateX: isPoppingIn ? 0 : translateX },
           { translateY: isPoppingIn ? 0 : translateY },
@@ -138,29 +126,38 @@ const SaveFlightCard: React.FC<SaveFlightCardProps> = ({
           },
         ],
         opacity: isFadingOut ? 0 : 1,
-      }}
-      transition={{
+      },
+      transition: {
         translateY: {
-          type: "timing",
+          type: "timing" as const,
           duration: FLIGHT_DURATION,
           easing: Easing.in(Easing.quad),
         },
         translateX: {
-          type: "timing",
+          type: "timing" as const,
           duration: FLIGHT_DURATION,
           easing: Easing.out(Easing.quad),
         },
         scale: {
-          type: "timing",
+          type: "timing" as const,
           duration: FADE_OUT_DURATION,
           easing: Easing.inOut(Easing.quad),
         },
         opacity: {
-          type: "timing",
+          type: "timing" as const,
           duration: isFadingOut ? OPACITY_DROP_DURATION : FADE_IN_DURATION,
+          // stays fully opaque while shrinking, then only fades in the final slice of fade_out
           delay: isFadingOut ? FADE_OUT_DURATION - OPACITY_DROP_DURATION : 0,
         },
-      }}
+      },
+    }),
+    [isPoppingIn, isFadingOut, translateX, translateY]
+  )
+
+  return (
+    <MotiView
+      pointerEvents="none"
+      {...flightAnimationProps}
       style={{
         position: "absolute",
         left: startLeft,

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -5,7 +5,15 @@ import { InfiniteDiscoveryArtwork } from "app/Scenes/InfiniteDiscovery/InfiniteD
 import { GlobalStore, __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { useReducedMotion } from "react-native-reanimated"
 import RNShare from "react-native-share"
+
+jest.mock("react-native-reanimated", () => ({
+  ...require("react-native-reanimated/mock"),
+  useReducedMotion: jest.fn(),
+}))
+
+const mockUseReducedMotion = useReducedMotion as jest.Mock
 
 const mockGoBack = jest.fn()
 const mockNavigate = jest.fn()
@@ -77,6 +85,7 @@ describe("InfiniteDiscoveryHeader", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockUseReducedMotion.mockReturnValue(false)
     ;(mockAddListener as any).beforeRemoveCallback = undefined
     GlobalStore.actions.infiniteDiscovery.resetSavedArtworksCount()
     GlobalStore.actions.onboarding.setOnboardingState("complete")
@@ -133,7 +142,8 @@ describe("InfiniteDiscoveryHeader", () => {
     it("shows the progress badge instead of the exit chevron", () => {
       renderWithWrappers(<InfiniteDiscoveryHeader />)
 
-      expect(screen.getByText("0 of 5 saves")).toBeOnTheScreen()
+      expect(screen.getByText("0")).toBeOnTheScreen()
+      expect(screen.getByText("of 5 saves")).toBeOnTheScreen()
       expect(screen.queryByTestId("close-icon")).not.toBeOnTheScreen()
     })
 
@@ -148,7 +158,8 @@ describe("InfiniteDiscoveryHeader", () => {
       })
       renderWithWrappers(<InfiniteDiscoveryHeader />)
 
-      expect(screen.getByText("2 of 5 saves")).toBeOnTheScreen()
+      expect(screen.getByText("2")).toBeOnTheScreen()
+      expect(screen.getByText("of 5 saves")).toBeOnTheScreen()
     })
 
     it("shows a Skip button instead of the share/more button", () => {

--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
@@ -1,5 +1,6 @@
 import { ContextModule } from "@artsy/cohesion"
 import { Screen } from "@artsy/palette-mobile"
+import { PortalHost } from "@gorhom/portal"
 import { captureMessage } from "@sentry/react-native"
 import { InfiniteDiscoveryNegativeSignalsBottomSheetQuery$variables } from "__generated__/InfiniteDiscoveryNegativeSignalsBottomSheetQuery.graphql"
 import { InfiniteDiscoveryQueryRendererQuery$data } from "__generated__/InfiniteDiscoveryQueryRendererQuery.graphql"
@@ -10,6 +11,7 @@ import {
   negativeSignalsQuery,
 } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryNegativeSignalsBottomSheet"
 import { InfiniteDiscoveryOnboarding } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding"
+import { INFINITE_DISCOVERY_SAVE_ANIMATION_PORTAL_HOST } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveFlightAnimation"
 import { NewUserOnboardingArtworkCardBottomSheet } from "app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet"
 import { NewUserOnboardingCompletionBottomSheet } from "app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet"
 import { Swiper } from "app/Scenes/InfiniteDiscovery/Components/Swiper/Swiper"
@@ -217,6 +219,8 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
         )}
         <NewUserOnboardingCompletionBottomSheet />
       </Screen.Body>
+      {/* Outside Screen.Body so its marginTop doesn't offset this host's coordinate space */}
+      <PortalHost name={INFINITE_DISCOVERY_SAVE_ANIMATION_PORTAL_HOST} />
     </Screen>
   )
 }

--- a/src/app/Scenes/InfiniteDiscovery/hooks/__tests__/useInfiniteDiscoveryCardSave.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/__tests__/useInfiniteDiscoveryCardSave.tests.tsx
@@ -188,6 +188,23 @@ describe("useInfiniteDiscoveryCardSave", () => {
       expect(getState().sessionState.newUserOnboardingSavedArtworks).toEqual([])
     })
 
+    it("does not commit the artwork to the onboarding list if it was un-saved before the flight animation finished", () => {
+      mockUseSaveArtworkToArtworkLists(false)
+      const { result, rerender } = renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), {
+        wrapper,
+      })
+
+      act(() => result.current.handleSaveButtonPress())
+
+      mockUseSaveArtworkToArtworkLists(true)
+      rerender(undefined)
+      act(() => result.current.handleSaveButtonPress())
+
+      act(() => result.current.completeSaveAnimation())
+
+      expect(getState().sessionState.newUserOnboardingSavedArtworks).toEqual([])
+    })
+
     it("re-adds the artwork to the onboarding list when reverting a failed unsave", () => {
       mockUseSaveArtworkToArtworkLists(true)
       renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })

--- a/src/app/Scenes/InfiniteDiscovery/hooks/__tests__/useInfiniteDiscoveryCardSave.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/__tests__/useInfiniteDiscoveryCardSave.tests.tsx
@@ -4,12 +4,20 @@ import { InfiniteDiscoveryArtworkCard_artwork$data } from "__generated__/Infinit
 import * as useSaveArtworkToArtworkListsModule from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
 import { useInfiniteDiscoveryCardSave } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave"
 import { GlobalStore, GlobalStoreProvider, __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { useReducedMotion } from "react-native-reanimated"
 
 const mockTrack = { savedArtwork: jest.fn() }
 
 jest.mock("app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking", () => ({
   useInfiniteDiscoveryTracking: () => mockTrack,
 }))
+
+jest.mock("react-native-reanimated", () => ({
+  ...require("react-native-reanimated/mock"),
+  useReducedMotion: jest.fn(),
+}))
+
+const mockUseReducedMotion = useReducedMotion as jest.Mock
 
 const mockArtwork = {
   internalID: "artwork-1",
@@ -44,6 +52,7 @@ describe("useInfiniteDiscoveryCardSave", () => {
     GlobalStore.actions.infiniteDiscovery.resetNewUserOnboardingSessionState()
     GlobalStore.actions.infiniteDiscovery.setHasSavedArtworks(false)
     GlobalStore.actions.onboarding.setOnboardingState("complete")
+    mockUseReducedMotion.mockReturnValue(false)
   })
 
   it("saves the artwork: increments the count and marks that artworks have been saved", () => {
@@ -130,6 +139,19 @@ describe("useInfiniteDiscoveryCardSave", () => {
         expect.objectContaining({ internalID: "artwork-1", blurhash: "blurhash-1" })
       )
       expect(getState().sessionState.newUserOnboardingSavedArtworks).toEqual([])
+    })
+
+    it("commits the artwork to the onboarding list immediately when Reduce Motion is enabled, skipping the flight animation", () => {
+      mockUseReducedMotion.mockReturnValue(true)
+      mockUseSaveArtworkToArtworkLists(false)
+      const { result } = renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
+
+      act(() => result.current.handleSaveButtonPress())
+
+      expect(result.current.pendingSaveAnimationArtwork).toBeNull()
+      expect(getState().sessionState.newUserOnboardingSavedArtworks).toEqual([
+        expect.objectContaining({ internalID: "artwork-1", blurhash: "blurhash-1" }),
+      ])
     })
 
     it("adds the artwork to the onboarding list once the flight animation completes", () => {

--- a/src/app/Scenes/InfiniteDiscovery/hooks/__tests__/useInfiniteDiscoveryCardSave.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/__tests__/useInfiniteDiscoveryCardSave.tests.tsx
@@ -120,15 +120,29 @@ describe("useInfiniteDiscoveryCardSave", () => {
       GlobalStore.actions.onboarding.setOnboardingState("incomplete")
     })
 
-    it("adds the artwork to the onboarding list when saved", () => {
+    it("stages the artwork for the flight animation when saved, without adding it to the onboarding list yet", () => {
       mockUseSaveArtworkToArtworkLists(false)
       const { result } = renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
 
       act(() => result.current.handleSaveButtonPress())
 
+      expect(result.current.pendingSaveAnimationArtwork).toEqual(
+        expect.objectContaining({ internalID: "artwork-1", blurhash: "blurhash-1" })
+      )
+      expect(getState().sessionState.newUserOnboardingSavedArtworks).toEqual([])
+    })
+
+    it("adds the artwork to the onboarding list once the flight animation completes", () => {
+      mockUseSaveArtworkToArtworkLists(false)
+      const { result } = renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
+
+      act(() => result.current.handleSaveButtonPress())
+      act(() => result.current.completeSaveAnimation())
+
       expect(getState().sessionState.newUserOnboardingSavedArtworks).toEqual([
         expect.objectContaining({ internalID: "artwork-1", blurhash: "blurhash-1" }),
       ])
+      expect(result.current.pendingSaveAnimationArtwork).toBeNull()
     })
 
     it("removes the artwork from the onboarding list when unsaved", () => {
@@ -145,11 +159,15 @@ describe("useInfiniteDiscoveryCardSave", () => {
       expect(getState().sessionState.newUserOnboardingSavedArtworks).toEqual([])
     })
 
-    it("adds the artwork to the onboarding list when saved via double-tap", () => {
+    it("adds the artwork to the onboarding list once the flight animation completes after a double-tap save", () => {
       mockUseSaveArtworkToArtworkLists(false)
       const { result } = renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
 
       act(() => result.current.handleDoubleTapSave())
+
+      expect(getState().sessionState.newUserOnboardingSavedArtworks).toEqual([])
+
+      act(() => result.current.completeSaveAnimation())
 
       expect(getState().sessionState.newUserOnboardingSavedArtworks).toEqual([
         expect.objectContaining({ internalID: "artwork-1" }),

--- a/src/app/Scenes/InfiniteDiscovery/hooks/__tests__/useInfiniteDiscoveryCardSave.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/__tests__/useInfiniteDiscoveryCardSave.tests.tsx
@@ -154,6 +154,28 @@ describe("useInfiniteDiscoveryCardSave", () => {
       ])
     })
 
+    it("commits the artwork to the onboarding list immediately once the onboarding goal has been reached, skipping the flight animation", () => {
+      mockUseSaveArtworkToArtworkLists(false)
+      for (let i = 0; i < 5; i++) {
+        GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
+          internalID: `goal-artwork-${i}`,
+          url: "https://example.com/image.jpg",
+          blurhash: "blurhash-1",
+        })
+      }
+      const { result } = renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })
+
+      act(() => result.current.handleSaveButtonPress())
+
+      expect(result.current.pendingSaveAnimationArtwork).toBeNull()
+      expect(getState().sessionState.newUserOnboardingSavedArtworks).toEqual([
+        ...Array.from({ length: 5 }, (_, i) =>
+          expect.objectContaining({ internalID: `goal-artwork-${i}` })
+        ),
+        expect.objectContaining({ internalID: "artwork-1" }),
+      ])
+    })
+
     it("adds the artwork to the onboarding list once the flight animation completes", () => {
       mockUseSaveArtworkToArtworkLists(false)
       const { result } = renderHook(() => useInfiniteDiscoveryCardSave(mockArtwork), { wrapper })

--- a/src/app/Scenes/InfiniteDiscovery/hooks/__tests__/useSaveFlightPhase.tests.ts
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/__tests__/useSaveFlightPhase.tests.ts
@@ -1,0 +1,85 @@
+import { act, renderHook } from "@testing-library/react-native"
+import { useSaveFlightPhase } from "app/Scenes/InfiniteDiscovery/hooks/useSaveFlightPhase"
+
+const POP_IN_DURATION = 100
+const FLIGHT_DURATION = 200
+const FADE_OUT_DURATION = 50
+
+describe("useSaveFlightPhase", () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  const renderPhase = (onComplete: () => void) =>
+    renderHook(() =>
+      useSaveFlightPhase({
+        popInDuration: POP_IN_DURATION,
+        flightDuration: FLIGHT_DURATION,
+        fadeOutDuration: FADE_OUT_DURATION,
+        onComplete,
+      })
+    )
+
+  it("starts in the pop_in phase", () => {
+    const { result } = renderPhase(jest.fn())
+
+    expect(result.current).toBe("pop_in")
+  })
+
+  it("advances to flight after popInDuration", () => {
+    const { result } = renderPhase(jest.fn())
+
+    act(() => jest.advanceTimersByTime(POP_IN_DURATION))
+
+    expect(result.current).toBe("flight")
+  })
+
+  it("advances to fade_out after flightDuration", () => {
+    const { result } = renderPhase(jest.fn())
+
+    act(() => jest.advanceTimersByTime(POP_IN_DURATION))
+    act(() => jest.advanceTimersByTime(FLIGHT_DURATION))
+
+    expect(result.current).toBe("fade_out")
+  })
+
+  it("calls onComplete after fadeOutDuration, and not before", () => {
+    const onComplete = jest.fn()
+    renderPhase(onComplete)
+
+    act(() => jest.advanceTimersByTime(POP_IN_DURATION))
+    act(() => jest.advanceTimersByTime(FLIGHT_DURATION))
+    expect(onComplete).not.toHaveBeenCalled()
+
+    act(() => jest.advanceTimersByTime(FADE_OUT_DURATION))
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it("calls the latest onComplete even if it changes mid-sequence", () => {
+    const staleOnComplete = jest.fn()
+    const freshOnComplete = jest.fn()
+
+    const { rerender } = renderHook(
+      ({ onComplete }: { onComplete: () => void }) =>
+        useSaveFlightPhase({
+          popInDuration: POP_IN_DURATION,
+          flightDuration: FLIGHT_DURATION,
+          fadeOutDuration: FADE_OUT_DURATION,
+          onComplete,
+        }),
+      { initialProps: { onComplete: staleOnComplete } }
+    )
+
+    act(() => jest.advanceTimersByTime(POP_IN_DURATION))
+    rerender({ onComplete: freshOnComplete })
+    act(() => jest.advanceTimersByTime(FLIGHT_DURATION))
+    act(() => jest.advanceTimersByTime(FADE_OUT_DURATION))
+
+    expect(staleOnComplete).not.toHaveBeenCalled()
+    expect(freshOnComplete).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave.ts
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave.ts
@@ -32,6 +32,9 @@ export const useInfiniteDiscoveryCardSave = (
   const setHasSavedArtworks = GlobalStore.actions.infiniteDiscovery.setHasSavedArtworks
   const isNewUserOnboardingSession =
     GlobalStore.useAppState((state) => state.onboarding.onboardingState) === "incomplete"
+  const newUserOnboardingGoalReached = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.newUserOnboardingGoalReached
+  )
   const {
     incrementSavedArtworksCount,
     decrementSavedArtworksCount,
@@ -68,7 +71,7 @@ export const useInfiniteDiscoveryCardSave = (
   const animateOnboardingSavedArtwork = () => {
     if (!artwork) return
 
-    if (isReducedMotionEnabled) {
+    if (isReducedMotionEnabled || newUserOnboardingGoalReached) {
       addOnboardingSavedArtwork()
       return
     }

--- a/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave.ts
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave.ts
@@ -7,6 +7,7 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { NewUserOnboardingSavedArtwork } from "app/store/InfiniteDiscoveryModel"
 import { useState } from "react"
 import { PixelRatio } from "react-native"
+import { useReducedMotion } from "react-native-reanimated"
 
 const getThumbnailUrl = (url: string, screenWidth: number) => {
   const referenceWidth = 85
@@ -25,6 +26,7 @@ export const useInfiniteDiscoveryCardSave = (
 ) => {
   const { width: screenWidth } = useScreenDimensions()
   const track = useInfiniteDiscoveryTracking()
+  const isReducedMotionEnabled = useReducedMotion()
 
   const { hasSavedArtworks } = GlobalStore.useAppState((state) => state.infiniteDiscovery)
   const setHasSavedArtworks = GlobalStore.actions.infiniteDiscovery.setHasSavedArtworks
@@ -65,6 +67,11 @@ export const useInfiniteDiscoveryCardSave = (
 
   const animateOnboardingSavedArtwork = () => {
     if (!artwork) return
+
+    if (isReducedMotionEnabled) {
+      addOnboardingSavedArtwork()
+      return
+    }
 
     setPendingSaveAnimationArtwork(buildOnboardingSavedArtwork(artwork))
   }

--- a/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave.ts
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave.ts
@@ -4,6 +4,8 @@ import { InfiniteDiscoveryArtworkCard_artwork$data } from "__generated__/Infinit
 import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
 import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking"
 import { GlobalStore } from "app/store/GlobalStore"
+import { NewUserOnboardingSavedArtwork } from "app/store/InfiniteDiscoveryModel"
+import { useState } from "react"
 import { PixelRatio } from "react-native"
 
 const getThumbnailUrl = (url: string, screenWidth: number) => {
@@ -35,20 +37,33 @@ export const useInfiniteDiscoveryCardSave = (
     removeNewUserOnboardingSavedArtwork,
   } = GlobalStore.actions.infiniteDiscovery
 
+  const [pendingSaveAnimationArtwork, setPendingSaveAnimationArtwork] =
+    useState<NewUserOnboardingSavedArtwork | null>(null)
+
+  const buildOnboardingSavedArtwork = (
+    artwork: NonNullable<InfiniteDiscoveryArtworkCard_artwork$data>
+  ) => ({
+    internalID: artwork.internalID,
+    url: getThumbnailUrl(artwork.images[0]?.url ?? "", screenWidth),
+    blurhash: artwork.images[0]?.blurhash,
+  })
+
   const addOnboardingSavedArtwork = () => {
     if (!artwork) return
 
-    addNewUserOnboardingSavedArtwork({
-      internalID: artwork.internalID,
-      url: getThumbnailUrl(artwork.images[0]?.url ?? "", screenWidth),
-      blurhash: artwork.images[0]?.blurhash,
-    })
+    addNewUserOnboardingSavedArtwork(buildOnboardingSavedArtwork(artwork))
   }
 
   const removeOnboardingSavedArtwork = () => {
     if (!artwork) return
 
     removeNewUserOnboardingSavedArtwork(artwork.internalID)
+  }
+
+  const animateOnboardingSavedArtwork = () => {
+    if (!artwork) return
+
+    setPendingSaveAnimationArtwork(buildOnboardingSavedArtwork(artwork))
   }
 
   const { isSaved, saveArtworkToLists } = useSaveArtworkToArtworkLists({
@@ -88,7 +103,9 @@ export const useInfiniteDiscoveryCardSave = (
     } else {
       // if the artwork is currently unsaved, it will become saved, so optimistically increment the count
       incrementSavedArtworksCount()
-      if (isNewUserOnboardingSession) addOnboardingSavedArtwork()
+      if (isNewUserOnboardingSession) {
+        animateOnboardingSavedArtwork()
+      }
     }
 
     saveArtworkToLists()
@@ -99,9 +116,25 @@ export const useInfiniteDiscoveryCardSave = (
 
     if (!hasSavedArtworks) setHasSavedArtworks(true)
     incrementSavedArtworksCount()
-    if (isNewUserOnboardingSession) addOnboardingSavedArtwork()
+    if (isNewUserOnboardingSession) {
+      animateOnboardingSavedArtwork()
+    }
     saveArtworkToLists()
   }
 
-  return { isSaved, handleSaveButtonPress, handleDoubleTapSave }
+  const completeSaveAnimation = () => {
+    if (pendingSaveAnimationArtwork) {
+      addNewUserOnboardingSavedArtwork(pendingSaveAnimationArtwork)
+    }
+
+    setPendingSaveAnimationArtwork(null)
+  }
+
+  return {
+    isSaved,
+    handleSaveButtonPress,
+    handleDoubleTapSave,
+    pendingSaveAnimationArtwork,
+    completeSaveAnimation,
+  }
 }

--- a/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave.ts
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave.ts
@@ -57,6 +57,9 @@ export const useInfiniteDiscoveryCardSave = (
   const removeOnboardingSavedArtwork = () => {
     if (!artwork) return
 
+    setPendingSaveAnimationArtwork((pending) =>
+      pending?.internalID === artwork.internalID ? null : pending
+    )
     removeNewUserOnboardingSavedArtwork(artwork.internalID)
   }
 

--- a/src/app/Scenes/InfiniteDiscovery/hooks/useSaveFlightPhase.ts
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/useSaveFlightPhase.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useState } from "react"
+
+export type FlightPhase = "pop_in" | "flight" | "fade_out"
+
+interface UseSaveFlightPhaseOptions {
+  popInDuration: number
+  flightDuration: number
+  fadeOutDuration: number
+  onComplete: () => void
+}
+
+export const useSaveFlightPhase = ({
+  popInDuration,
+  flightDuration,
+  fadeOutDuration,
+  onComplete,
+}: UseSaveFlightPhaseOptions) => {
+  const [phase, setPhase] = useState<FlightPhase>("pop_in")
+  const onCompleteRef = useRef(onComplete)
+  // lets the timer below call the freshest onComplete, without restarting the timer to get it
+  onCompleteRef.current = onComplete
+
+  // advances pop_in -> flight -> fade_out, then calls onComplete once fade_out finishes
+  useEffect(() => {
+    const duration =
+      phase === "pop_in" ? popInDuration : phase === "flight" ? flightDuration : fadeOutDuration
+
+    const timeout = setTimeout(() => {
+      if (phase === "pop_in") setPhase("flight")
+      else if (phase === "flight") setPhase("fade_out")
+      else onCompleteRef.current()
+    }, duration)
+
+    return () => clearTimeout(timeout)
+  }, [phase, popInDuration, flightDuration, fadeOutDuration])
+
+  return phase
+}

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
@@ -6,6 +6,7 @@ import { __globalStoreTestUtils__, GlobalStore } from "app/store/GlobalStore"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { KeyboardController } from "react-native-keyboard-controller"
+import { useReducedMotion } from "react-native-reanimated"
 
 // Extend the global mock rather than replace it — replacing it drops KeyboardAwareScrollView
 // which BottomSheetKeyboardAwareScrollView depends on.
@@ -13,6 +14,13 @@ jest.mock("react-native-keyboard-controller", () => ({
   ...require("react-native-keyboard-controller/jest"),
   KeyboardStickyView: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
+
+jest.mock("react-native-reanimated", () => ({
+  ...require("react-native-reanimated/mock"),
+  useReducedMotion: jest.fn(),
+}))
+
+const mockUseReducedMotion = useReducedMotion as jest.Mock
 
 jest.mock("app/utils/hooks/useDebouncedValue", () => ({
   useDebouncedValue: ({ value }: { value: string }) => ({ debouncedValue: value }),
@@ -58,6 +66,7 @@ describe("FollowArtists", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockUseReducedMotion.mockReturnValue(false)
     dismissSpy = jest.spyOn(KeyboardController, "dismiss").mockImplementation(jest.fn())
   })
 
@@ -130,19 +139,21 @@ describe("FollowArtists", () => {
     it("shows 0 of 3 follows initially", () => {
       renderWithWrappers(<FollowArtists />)
 
-      expect(screen.getByText("0 of 3 follows")).toBeOnTheScreen()
+      expect(screen.getByText("0")).toBeOnTheScreen()
+      expect(screen.getByText("of 3 follows")).toBeOnTheScreen()
     })
 
-    it("reflects the number of followed artists", () => {
+    it("reflects the number of followed artists", async () => {
       renderWithWrappers(<FollowArtists />)
 
       fireEvent.press(screen.getByText("OrderedSet"))
       fireEvent.press(screen.getByText("OrderedSet"))
 
-      expect(screen.getByText("2 of 3 follows")).toBeOnTheScreen()
+      expect(await screen.findByText("2")).toBeOnTheScreen()
+      expect(screen.getByText("of 3 follows")).toBeOnTheScreen()
     })
 
-    it("shows Complete once 3 or more artists are followed", () => {
+    it("shows Complete once 3 or more artists are followed", async () => {
       renderWithWrappers(<FollowArtists />)
 
       fireEvent.press(screen.getByText("OrderedSet"))
@@ -150,7 +161,7 @@ describe("FollowArtists", () => {
       fireEvent.press(screen.getByText("OrderedSet"))
       fireEvent.press(screen.getByText("OrderedSet"))
 
-      expect(screen.getByText("Complete")).toBeOnTheScreen()
+      expect(await screen.findByText("Complete")).toBeOnTheScreen()
     })
   })
 


### PR DESCRIPTION
This PR resolves [DI-359](https://www.notion.so/375cab0764a0802b8ca7c230bf167796)
Assisted-by: Claude:Sonnet-5

### Description

This PR adds an animation to Discover Daily that plays during onboarding when a user saves an artwork.

The animation shows a miniature artwork card fly from the center of the artwork to the badge at the top-left, that increments the number of saved artworks once the card reaches it and disappears. The progress count then bounces up and increments when it touches down.

- The progress count's "bouncing" animation will also be added to the Follow Artists onboarding task.
- If a user un-saves an artwork while the "flight" animation is playing, it will be aborted.
- These animations will be omitted when "Reduced Motion" a11y settings are enabled.
- These animations will be omitted when the user continues browsing after completing the onboarding task.

| iOS | Android |
|-|-|
| https://github.com/user-attachments/assets/d064fd69-3010-46be-a75e-c7e1cd322205 | https://github.com/user-attachments/assets/d9beafa0-83be-4b07-aca0-94a1f3d4992f |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Animate an artwork save during onboarding

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
