### PR TITLE
feat(future friday): add prefix to the nightly beta tag name

### DIFF
--- a/.github/workflows/build-deploy-android-firebase.yml
+++ b/.github/workflows/build-deploy-android-firebase.yml
@@ -50,7 +50,8 @@ jobs:
           echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
 
       - name: Build and deploy Android to Firebase
-        run: bundle exec fastlane ship_beta_android deployment_target:firebase version_code:$VERSION_CODE
+        # is_nightly tags the scheduled build as `-nightly` so it's identifiable among the beta tags
+        run: bundle exec fastlane ship_beta_android deployment_target:firebase version_code:$VERSION_CODE is_nightly:${{ github.event_name == 'schedule' }}
         env:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}

--- a/.github/workflows/build-deploy-android-firebase.yml
+++ b/.github/workflows/build-deploy-android-firebase.yml
@@ -50,7 +50,6 @@ jobs:
           echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
 
       - name: Build and deploy Android to Firebase
-        # is_nightly tags the scheduled build as `-nightly` so it's identifiable among the beta tags
         run: bundle exec fastlane ship_beta_android deployment_target:firebase version_code:$VERSION_CODE is_nightly:${{ github.event_name == 'schedule' }}
         env:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}

--- a/.github/workflows/build-deploy-android-playstore.yml
+++ b/.github/workflows/build-deploy-android-playstore.yml
@@ -50,7 +50,8 @@ jobs:
           echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
 
       - name: Build and deploy Android to Play Store
-        run: bundle exec fastlane ship_beta_android deployment_target:play_store version_code:$VERSION_CODE
+        # is_nightly tags the scheduled build as `-nightly` so it's identifiable among the beta tags
+        run: bundle exec fastlane ship_beta_android deployment_target:play_store version_code:$VERSION_CODE is_nightly:${{ github.event_name == 'schedule' }}
         env:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}

--- a/.github/workflows/build-deploy-android-playstore.yml
+++ b/.github/workflows/build-deploy-android-playstore.yml
@@ -50,7 +50,6 @@ jobs:
           echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
 
       - name: Build and deploy Android to Play Store
-        # is_nightly tags the scheduled build as `-nightly` so it's identifiable among the beta tags
         run: bundle exec fastlane ship_beta_android deployment_target:play_store version_code:$VERSION_CODE is_nightly:${{ github.event_name == 'schedule' }}
         env:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}

--- a/.github/workflows/build-deploy-ios-firebase.yml
+++ b/.github/workflows/build-deploy-ios-firebase.yml
@@ -47,7 +47,8 @@ jobs:
         run: brew install imagemagick librsvg
 
       - name: Build and deploy iOS to Firebase
-        run: bundle exec fastlane ship_beta_ios deployment_target:firebase
+        # is_nightly tags the scheduled build as `-nightly` so it's identifiable among the beta tags
+        run: bundle exec fastlane ship_beta_ios deployment_target:firebase is_nightly:${{ github.event_name == 'schedule' }}
         env:
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 120
           FASTLANE_XCODE_LIST_TIMEOUT: 120

--- a/.github/workflows/build-deploy-ios-firebase.yml
+++ b/.github/workflows/build-deploy-ios-firebase.yml
@@ -47,7 +47,6 @@ jobs:
         run: brew install imagemagick librsvg
 
       - name: Build and deploy iOS to Firebase
-        # is_nightly tags the scheduled build as `-nightly` so it's identifiable among the beta tags
         run: bundle exec fastlane ship_beta_ios deployment_target:firebase is_nightly:${{ github.event_name == 'schedule' }}
         env:
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 120

--- a/.github/workflows/build-deploy-ios-testflight.yml
+++ b/.github/workflows/build-deploy-ios-testflight.yml
@@ -44,7 +44,8 @@ jobs:
         uses: ./.github/actions/setup-bin-modules
 
       - name: Build and deploy iOS to TestFlight
-        run: bundle exec fastlane ship_beta_ios deployment_target:testflight
+        # is_nightly tags the scheduled build as `-nightly` so it's identifiable among the beta tags
+        run: bundle exec fastlane ship_beta_ios deployment_target:testflight is_nightly:${{ github.event_name == 'schedule' }}
         env:
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 120
           FASTLANE_XCODE_LIST_TIMEOUT: 120

--- a/.github/workflows/build-deploy-ios-testflight.yml
+++ b/.github/workflows/build-deploy-ios-testflight.yml
@@ -44,7 +44,6 @@ jobs:
         uses: ./.github/actions/setup-bin-modules
 
       - name: Build and deploy iOS to TestFlight
-        # is_nightly tags the scheduled build as `-nightly` so it's identifiable among the beta tags
         run: bundle exec fastlane ship_beta_ios deployment_target:testflight is_nightly:${{ github.event_name == 'schedule' }}
         env:
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 120

--- a/.github/workflows/rc-release-automation.yml
+++ b/.github/workflows/rc-release-automation.yml
@@ -113,12 +113,15 @@ jobs:
         env:
           VERSION: ${{ needs.guard.outputs.version }}
         run: |
-          # Beta tags: ios-<version>-<build> / android-<version>-<code>
+          # Beta tags: ios-<version>-<build> / android-<version>-<code>, with an optional
+          # -nightly suffix on the scheduled builds
           # (exclude -submission and -expo- OTA tags; newest by version sort).
           ios_tag=$(git tag -l "ios-${VERSION}-*" | grep -v -- '-expo-' | grep -v -- '-submission' | sort -V | tail -1 || true)
           android_tag=$(git tag -l "android-${VERSION}-*" | grep -v -- '-expo-' | grep -v -- '-submission' | sort -V | tail -1 || true)
-          echo "ios_build=${ios_tag#ios-${VERSION}-}" >> "$GITHUB_OUTPUT"
-          echo "android_build=${android_tag#android-${VERSION}-}" >> "$GITHUB_OUTPUT"
+          ios_build=${ios_tag#ios-${VERSION}-}
+          android_build=${android_tag#android-${VERSION}-}
+          echo "ios_build=${ios_build%-nightly}" >> "$GITHUB_OUTPUT"
+          echo "android_build=${android_build%-nightly}" >> "$GITHUB_OUTPUT"
           echo "iOS tag: ${ios_tag:-<none>} / Android tag: ${android_tag:-<none>}"
 
       - name: Setup node.js

--- a/docs/deploy_to_beta.md
+++ b/docs/deploy_to_beta.md
@@ -22,6 +22,8 @@ Deployment to TestFlight and Play Store is handled by the `build-deploy-*` GitHu
 
 When you trigger a beta yourself it runs on [Blacksmith](https://blacksmith.sh) runners and takes roughly **15–25 minutes**. Follow along in [GitHub Actions](https://github.com/artsy/eigen/actions).
 
+Every beta is tagged in git as `ios-<version>-<build>` / `android-<version>-<code>`. Nightly betas carry a `-nightly` suffix (e.g. `ios-9.16.0-2026.08.14.08-nightly`), so you can tell them apart from on-demand betas in the [tag list](https://github.com/artsy/eigen/tags) without digging through commits. Prefer the nightly for QA and releases.
+
 Note that only one beta can be deployed at a time; teams should use [feature flags](./developing_a_feature.md) to avoid the need for having two parallel beta versions.
 
 There are two types of betas on TestFlight: Internal and External. Our deploy script sends the beta to both groups. However, Internal testers get access to the beta immediately, while external testers may have a delay of several hours/days while Apple does beta review. This additional review typically only happens when we change the version number.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -42,6 +42,11 @@ IOS_BETA_TARGETS = {
 
 BETA_LANES = %i[ship_beta ship_beta_ios ship_beta_android build_maestro_android build_maestro_ios deploy_android_beta deploy_ios_beta].freeze
 
+# Suffix added to the git tag of the scheduled (nightly) betas, so they can be told apart at a
+# glance from betas triggered manually or by a push to a beta branch. The nightly is the build we
+# use for QA and releases, e.g. `ios-9.16.0-2026.08.14.08-nightly`.
+NIGHTLY_TAG_SUFFIX = '-nightly'
+
 GIT_COMMIT_SHORT_HASH = `git log -n1 --format='%h'`.chomp
 GIT_COMMIT_HASH = `git log -n1 --format='%H'`.chomp
 GIT_COMMIT_DATE_STR = DateTime.parse(`git log -n1 --format='%ci'`.chomp).iso8601
@@ -82,7 +87,7 @@ lane :ship_beta_ios do |options|
 
   # Builds the app
   sync_signing_ios(deployment_target: deployment_target)
-  tag_and_push(tag: "ios-#{latest_version}-#{bundle_version}", message: "fingerprint:#{current_fingerprint}")
+  tag_and_push(tag: "ios-#{latest_version}-#{bundle_version}#{nightly_tag_suffix(options)}", message: "fingerprint:#{current_fingerprint}")
 
   # Add badge if firebase deployment
   if deployment_target == 'firebase'
@@ -209,7 +214,7 @@ lane :promote_beta_ios do
     raw_version = build.version
     padded      = format_build_number(raw_version)
     app_version = build.pre_release_version&.version || "?"
-    commit_msg  = git_tag_commit_message("ios-#{app_version}-#{padded}") || "(no tag found)"
+    commit_msg  = beta_tag_commit_message("ios-#{app_version}-#{padded}") || "(no tag found)"
     date        = begin
       Time.parse(build.uploaded_date.to_s).strftime('%Y-%m-%d %H:%M')
     rescue
@@ -367,7 +372,7 @@ lane :ship_beta_android do |options|
   end
 
   set_git_properties_android
-  tag_and_push(tag: "android-#{vname}-#{vcode}", message: "fingerprint:#{current_fingerprint}")
+  tag_and_push(tag: "android-#{vname}-#{vcode}#{nightly_tag_suffix(options)}", message: "fingerprint:#{current_fingerprint}")
 
   build_type = deployment_target == 'play_store' ? 'release' : 'beta'
   if deployment_target == 'firebase'
@@ -482,7 +487,7 @@ lane :select_android_build do |options|
 
   build_data = sorted_parsed.map do |date, filename|
     vcode      = filename.scan(/\d+/).first
-    raw_msg    = git_tag_commit_message("android-#{app_version}-#{vcode}")
+    raw_msg    = beta_tag_commit_message("android-#{app_version}-#{vcode}")
     version    = raw_msg ? app_version : "unknown"
     commit_msg = raw_msg || "(no tag found)"
     { filename: filename, vcode: vcode, date: date, version: version, commit_msg: commit_msg }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -42,9 +42,8 @@ IOS_BETA_TARGETS = {
 
 BETA_LANES = %i[ship_beta ship_beta_ios ship_beta_android build_maestro_android build_maestro_ios deploy_android_beta deploy_ios_beta].freeze
 
-# Suffix added to the git tag of the scheduled (nightly) betas, so they can be told apart at a
-# glance from betas triggered manually or by a push to a beta branch. The nightly is the build we
-# use for QA and releases, e.g. `ios-9.16.0-2026.08.14.08-nightly`.
+# Tag suffix for the scheduled (nightly) betas, so they stand out in the tag list from betas
+# triggered manually or by a push to a beta branch, e.g. `ios-9.16.0-2026.08.14.08-nightly`.
 NIGHTLY_TAG_SUFFIX = '-nightly'
 
 GIT_COMMIT_SHORT_HASH = `git log -n1 --format='%h'`.chomp

--- a/fastlane/utility_fastlane.rb
+++ b/fastlane/utility_fastlane.rb
@@ -396,6 +396,22 @@ def resolve_promoted_fingerprint(platform:, build_number:)
   promoted_fingerprint
 end
 
+def nightly_tag_suffix(options)
+  # CI passes is_nightly:true for the scheduled builds only. Fastlane hands CLI options over as
+  # strings, hence the to_s comparison rather than a plain truthiness check.
+  options[:is_nightly].to_s == 'true' ? NIGHTLY_TAG_SUFFIX : ''
+end
+
+def beta_tag_commit_message(tag)
+  # A beta's tag exists either plain or with the nightly suffix, so look for both and flag the
+  # nightly ones — those are the builds we ship.
+  msg = git_tag_commit_message(tag)
+  return msg if msg
+
+  nightly_msg = git_tag_commit_message("#{tag}#{NIGHTLY_TAG_SUFFIX}")
+  nightly_msg && "[nightly] #{nightly_msg}"
+end
+
 def should_silence_beta_failure?
   # Set this var in circleci if you want to silence beta failure alerts for a while
   # E.g. you are working on a ci change

--- a/fastlane/utility_fastlane.rb
+++ b/fastlane/utility_fastlane.rb
@@ -368,10 +368,11 @@ end
 
 def resolve_promoted_fingerprint(platform:, build_number:)
   # Looks up the ship-time tag for the exact build being promoted (ios-*-<build_number> /
-  # android-*-<build_number>) and reads back the fingerprint from its annotation message.
+  # android-*-<build_number>, plus the nightly-suffixed form) and reads back the fingerprint from
+  # its annotation message.
   # Falls back to an interactive confirm-and-recompute if the tag can't be found unambiguously.
   `git fetch --tags 2>/dev/null`
-  ship_tags = `git tag -l '#{platform}-*-#{build_number}'`.split("\n")
+  ship_tags = `git tag -l '#{platform}-*-#{build_number}' '#{platform}-*-#{build_number}#{NIGHTLY_TAG_SUFFIX}'`.split("\n")
   promoted_fingerprint = nil
   if ship_tags.length == 1
     tag_message = `git for-each-ref refs/tags/#{ship_tags.first} --format='%(contents)'`.strip
@@ -403,7 +404,7 @@ def nightly_tag_suffix(options)
 end
 
 def beta_tag_commit_message(tag)
-  # A beta's tag exists either plain or with the nightly suffix, so look for both and flag the
+  # A beta tag exists either plain or with the nightly suffix, so look for both and label the
   # nightly ones — those are the builds we ship.
   msg = git_tag_commit_message(tag)
   return msg if msg

--- a/scripts/deploys/check_build_status_gh
+++ b/scripts/deploys/check_build_status_gh
@@ -84,12 +84,21 @@ rc_conflict=false
 # These tags are annotated, so we want `refs/tags/X^{}` (the commit) and not
 # `refs/tags/X` (the tag object, which can never match an rc-v tip). The
 # trailing `*` is what makes ls-remote emit the `^{}` line at all.
+# The nightly beta tags this same build number with a `-nightly` suffix, so
+# check that form too or a same-hour manual beta would slip past this guard.
 tag_refs=$(git ls-remote --tags origin "refs/tags/${EXPECTED_TAG}*")
-existing_tag_sha=$(awk -v ref="refs/tags/${EXPECTED_TAG}^{}" '$2 == ref {print $1}' <<<"$tag_refs")
-if [ -z "$existing_tag_sha" ]; then
+existing_tag=""
+existing_tag_sha=""
+for candidate in "$EXPECTED_TAG" "${EXPECTED_TAG}-nightly"; do
+  sha=$(awk -v ref="refs/tags/${candidate}^{}" '$2 == ref {print $1}' <<<"$tag_refs")
   # Lightweight tag: the ref points straight at the commit.
-  existing_tag_sha=$(awk -v ref="refs/tags/${EXPECTED_TAG}" '$2 == ref {print $1}' <<<"$tag_refs")
-fi
+  [ -z "$sha" ] && sha=$(awk -v ref="refs/tags/${candidate}" '$2 == ref {print $1}' <<<"$tag_refs")
+  if [ -n "$sha" ]; then
+    existing_tag="$candidate"
+    existing_tag_sha="$sha"
+    break
+  fi
+done
 
 if [ -n "$existing_tag_sha" ]; then
   marker=""
@@ -98,7 +107,7 @@ if [ -n "$existing_tag_sha" ]; then
     rc_conflict=true
   fi
   subject=$(commit_subject "$existing_tag_sha")
-  conflicts+="  - build ${BUILD_NUMBER} is already taken — tag ${EXPECTED_TAG}${marker}"$'\n'
+  conflicts+="  - build ${BUILD_NUMBER} is already taken — tag ${existing_tag}${marker}"$'\n'
   conflicts+="      ${existing_tag_sha:0:8} — ${subject}"$'\n'
 fi
 


### PR DESCRIPTION
This PR resolves [Add prefix to the nightly beta tag name (Eigen)](https://app.notion.com/p/artsy/Add-different-names-for-nightly-betas-Eigen-3c9cab0764a0805f88bfda5836366f75?v=286cab0764a08059893e000cea221ae4&source=copy_link) <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Nightly betas now get a `-nightly` suffix on their git tag (e.g. `ios-9.16.0-2026.08.14.08-nightly`)

### Why

Every beta tag looks the same (`ios-9.16.0-2026081405`) whether it came from the 5:00 UTC nightly or from someone triggering a beta by hand. But they're not interchangeable: the nightly is the build we QA and cut releases from.

Today the only way to tell which is which is to open the tag and look at the commit it points at. 

Putting the marker in the tag name makes it visible in the [tag list](https://github.com/artsy/eigen/tags) and in the build pickers, with no lookup.

### Changes

- The four `build-deploy-*` workflows pass `is_nightly:${{ github.event_name == 'schedule' }}`, so only the scheduled runs get the suffix.
- `ship_beta_ios` / `ship_beta_android` append it via `nightly_tag_suffix`.
- Everything that reads beta tags back was updated to accept both forms:
  - the build pickers in `promote_beta_ios` / `select_android_build`, which now label nightlies `[nightly]`
  - `resolve_promoted_fingerprint`, so the Expo Updates fingerprint gate keeps working on promotion
  - `check_build_status_gh`, so the duplicate-build-number guard still catches a manual beta
    triggered in the same UTC hour as the nightly
  - `rc-release-automation`, which strips the suffix when reading the build number out of the tag


<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Add prefix to the nightly beta tag name - daria

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
