### PR TITLE
fix(PHIRE-3406): Fix Android expo update fetching issue

### DIFF
--- a/docs/debugging_expo_updates.md
+++ b/docs/debugging_expo_updates.md
@@ -91,8 +91,8 @@ only happens on Android.
 
 If you land in this state, either the dev menu shows "Emergency Launch: Yes" or "Fetch and Run
 Deployment" throws `ERR_UPDATES_RELOAD`. Force-quit and reopen the app. The update already downloaded,
-so a cold start will pick it up. The dev menu's "Reset Channel Override" button clears the saved
-override and prompts the same restart, for switching back to the embedded channel specifically.
+so a cold start will pick it up. To get back to the embedded channel specifically, reinstall the app;
+the override is saved in SharedPreferences and survives a normal restart.
 
 If a future expo-updates upgrade fixes either of these upstream, this flag is safe to flip back. We
 only ever call the headers-only override API from the dev menu, never the URL one.

--- a/docs/debugging_expo_updates.md
+++ b/docs/debugging_expo_updates.md
@@ -65,14 +65,34 @@ Expo updates has a bunch of native code checks to see if the local code is newer
 In dev mode there are assertions for valid state transitions that fail after switching channels, this may be a bug worth investigating and possibly PR back to expo?
 To get arround it you can comment out the assertions in the transition function in UpdatesStateMachine.swift when debugging in dev.
 
-#### Android NPE from `setUpdateRequestHeadersOverride` (`beta` build type)
+#### Android: `expoUpdatesDisableAntibrickingMeasures` must stay `"false"` on beta builds
 
 `android/app/build.gradle`'s `beta` build type must keep `expoUpdatesDisableAntibrickingMeasures: "false"`.
-`getUpdateUrl()` in expo-updates 55.0.22's Android `UpdatesConfiguration.kt` has a bug: when that flag
-is `true`, `configOverride?.let { return it.updateUrl }` returns unconditionally as soon as an override
-object exists — even if `it.updateUrl` is itself `null`, which it always is for a headers-only override
-like `setUpdateRequestHeadersOverride` (the only API the dev-menu channel switcher uses). That `null`
-gets force-unwrapped one line later and throws a `NullPointerException`. iOS's equivalent doesn't have
-this bug — it uses `if let updateUrl = configOverride?.updateUrl` there, which correctly falls back to
-the embedded URL when the override didn't set one. If a future expo-updates upgrade fixes this
-upstream, this flag is safe to flip back — we don't call the URL-override API that needs it anyway.
+Flipping it to `"true"` opens two separate bugs in expo-updates 55.0.22's Android code, depending on
+which override API you call. Neither has a safe workaround, so leave the flag alone.
+
+**NPE from `setUpdateURLAndRequestHeadersOverride`.** `getUpdateUrl()` in `UpdatesConfiguration.kt` has a
+bug. When the flag is `true`, `configOverride?.let { return it.updateUrl }` returns as soon as an
+override object exists, even if `it.updateUrl` is itself `null`, which it is for a headers-only
+override. That `null` gets force-unwrapped one line later and throws a `NullPointerException`. iOS's
+equivalent doesn't have this bug. It uses `if let updateUrl = configOverride?.updateUrl` there, which
+falls back to the embedded URL when the override didn't set one.
+
+**`ERR_UPDATES_RELOAD` from `setUpdateRequestHeadersOverride`.** With the flag `true`, saving any
+override, headers-only included, makes `getHasEmbeddedUpdate()` return `false` on the next launch, so
+`DatabaseLauncher` drops the embedded update from the launchable set. On a beta that hasn't downloaded
+an update yet, that leaves zero launchable updates, and the app falls back to an emergency launch with
+no launched update. The dev menu shows this as `isEmergencyLaunch: true` under "Active Release". The
+beta build type also sets `checkOnLaunch: "NEVER"`, so there's no remote check to recover from this.
+`Updates.fetchUpdateAsync()` still downloads fine, but Android's `relaunchReactApplicationForModule`
+hard-guards on having a launched update and rejects `reloadAsync()` with `Cannot relaunch without a
+launched update` (`ERR_UPDATES_RELOAD`). iOS's `requestRelaunch` has no such guard, which is why this
+only happens on Android.
+
+If you land in this state, either the dev menu shows "Emergency Launch: Yes" or "Fetch and Run
+Deployment" throws `ERR_UPDATES_RELOAD`. Force-quit and reopen the app. The update already downloaded,
+so a cold start will pick it up. The dev menu's "Reset Channel Override" button clears the saved
+override and prompts the same restart, for switching back to the embedded channel specifically.
+
+If a future expo-updates upgrade fixes either of these upstream, this flag is safe to flip back. We
+only ever call the headers-only override API from the dev menu, never the URL one.

--- a/src/app/system/devTools/DevMenu/Components/ExpoUpdatesOptions.tsx
+++ b/src/app/system/devTools/DevMenu/Components/ExpoUpdatesOptions.tsx
@@ -12,7 +12,7 @@ import { Expandable } from "app/Components/Expandable"
 import { ArtsyNativeModule } from "app/NativeModules/ArtsyNativeModule"
 import * as Updates from "expo-updates"
 import { useEffect, useState } from "react"
-import { Alert } from "react-native"
+import { Alert, Platform } from "react-native"
 
 type ExpoDeployment = "Canary" | "Staging" | "Production"
 
@@ -201,7 +201,7 @@ export const ExpoUpdatesOptions = () => {
             </>
           )}
 
-          {!!updateMetadata?.isEmergencyLaunch && (
+          {!!updateMetadata?.isEmergencyLaunch && Platform.OS === "android" && (
             <>
               <Message
                 title="Emergency launch"

--- a/src/app/system/devTools/DevMenu/Components/ExpoUpdatesOptions.tsx
+++ b/src/app/system/devTools/DevMenu/Components/ExpoUpdatesOptions.tsx
@@ -38,6 +38,10 @@ const isErrorWithMessage = (error: unknown): error is { message: string } => {
   )
 }
 
+const isCodedError = (error: unknown): error is { code: string } => {
+  return typeof error === "object" && error !== null && "code" in error
+}
+
 export const ExpoUpdatesOptions = () => {
   const [selectedDeployment, setSelectedDeployment] = useState<ExpoDeployment>("Staging")
   const [updateMetadata, setUpdateMetadata] = useState<any>(null)
@@ -143,6 +147,16 @@ export const ExpoUpdatesOptions = () => {
         }
       }
     } catch (error) {
+      // Android refuses to reload when the app is on an emergency launch, since there's no
+      // launched update to replace. The update is downloaded already, so force-quitting and
+      // reopening the app will run it.
+      if (isCodedError(error) && error.code === "ERR_UPDATES_RELOAD") {
+        setErrorMessage(
+          "Update downloaded, but the app can't reload itself. Force-quit and reopen the app to run it."
+        )
+        return
+      }
+
       if (
         isErrorWithMessage(error) &&
         error?.message?.includes("Code signature validation failed") &&
@@ -183,6 +197,19 @@ export const ExpoUpdatesOptions = () => {
           {!!updateMetadata && (
             <>
               <Message title="Active Release" text={activeReleaseText} variant="info" />
+              <Spacer y={2} />
+            </>
+          )}
+
+          {!!updateMetadata?.isEmergencyLaunch && (
+            <>
+              <Message
+                title="Emergency launch"
+                text={`Nothing was launchable last boot, so the app is running the embedded bundle.\nReason: ${
+                  Updates.emergencyLaunchReason || "unknown"
+                }\n\nFetching an update will still download it, but reloading it here will fail. Force-quit and reopen the app afterward to run it.`}
+                variant="warning"
+              />
               <Spacer y={2} />
             </>
           )}


### PR DESCRIPTION
This PR resolves [PHIRE-3406] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes an issue with Expo Updates on Android
The issue happens when switching channels on a beta build, then trying to fetch and deploy the new bundle from expo-updates, that causes an error on Android (iOS works fine)

What happens is that, since switching channels runs the embedded bundle as an emergency one (since the embedded was from a different channel), that causes the newly downloaded bundle to be unlaunchable automatically, requiring a manual restart of the app

#### The Fix:
Update the error message, and that should make it easier to understand why this is happening, since this scenario can only be done by an engineer



### Screenshots
#### Android
These are screenshots after switching from `Canary` to `Staging`


| | Before | After |
|---|---|---|
| Opening Dev Menu | <img width="543" height="1197" alt="image" src="https://github.com/user-attachments/assets/7d8ffe67-fd77-4406-9cc7-6117890bff2d" /> | <img width="543" height="1197" alt="image" src="https://github.com/user-attachments/assets/55a783ef-1b30-4cf8-a4b2-cd02b8b75b01" /> |
| Error message after fetching | <img width="543" height="1197" alt="image" src="https://github.com/user-attachments/assets/f1802a28-d206-4de0-bd84-abafcf9472b2" /> | <img width="543" height="1197" alt="image" src="https://github.com/user-attachments/assets/8b11f577-63eb-4c01-9203-b311ee41bf0b" /> |


#### iOS

| Before | After |
|---|---|
| <img width="1125" height="2436" alt="IMG_A57142BA988E-1" src="https://github.com/user-attachments/assets/e02d6ad1-20d0-4ffe-a60c-cb12ef3e5f4e" /> | <img width="1125" height="2436" alt="IMG_0114" src="https://github.com/user-attachments/assets/c3d9952a-4aa3-4889-a2d0-5e3a223253d9" /> |



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- update expo-update error message when running emergency bundle on Android

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3406]: https://artsyproduct.atlassian.net/browse/PHIRE-3406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ