### PR TITLE
fix(DI-584): set completed_onboarding_at flag when onboarding ends

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -8,6 +8,7 @@ import { InfiniteDiscoveryArtwork } from "app/Scenes/InfiniteDiscovery/InfiniteD
 import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking"
 import { useSavesSummaryToast } from "app/Scenes/InfiniteDiscovery/hooks/useSavesSummaryToast"
 import { useOnboardingTracking } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useOnboardingTracking"
+import { useUpdateUserProfile } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useUpdateUserProfile"
 import { GlobalStore } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
@@ -22,6 +23,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   const negativeSignalsEnabled = useFeatureFlag("AREnabledDiscoverDailyNegativeSignals")
   const track = useInfiniteDiscoveryTracking()
   const { trackCompletedOnboarding, trackTappedSkip } = useOnboardingTracking()
+  const { commitMutation } = useUpdateUserProfile()
   const { setMoreInfoSheetVisible } = GlobalStore.actions.infiniteDiscovery
   const hideRightButton = !topArtwork || !topArtwork.slug || !topArtwork.title
   const rightButtonLabel = negativeSignalsEnabled ? "More information" : "Share Artwork"
@@ -55,6 +57,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
     if (newUserOnboardingSavedArtworkCount >= 1) {
       GlobalStore.actions.progressiveOnboarding.setDeferHomeTooltipsThisSession(true)
     }
+    commitMutation({ completedOnboarding: true })
     GlobalStore.actions.onboarding.setOnboardingState("complete")
   }
 

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
@@ -7,6 +7,7 @@ import {
 import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
 import { ArtworkThumbnail } from "app/Scenes/InfiniteDiscovery/Components/ArtworkThumbnail"
 import { useOnboardingTracking } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useOnboardingTracking"
+import { useUpdateUserProfile } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useUpdateUserProfile"
 import { GlobalStore } from "app/store/GlobalStore"
 import { MotiView } from "moti"
 import { useCallback } from "react"
@@ -54,6 +55,7 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
   const { setOnboardingState } = GlobalStore.actions.onboarding
   const { setNewUserOnboardingCompletionBottomSheetVisible } = GlobalStore.actions.infiniteDiscovery
   const { trackCompletedOnboarding } = useOnboardingTracking()
+  const { commitMutation } = useUpdateUserProfile()
 
   const handleContinueBrowsing = () => {
     setNewUserOnboardingCompletionBottomSheetVisible(false)
@@ -64,6 +66,7 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
     if (newUserOnboardingSavedArtworkCount >= 1) {
       GlobalStore.actions.progressiveOnboarding.setDeferHomeTooltipsThisSession(true)
     }
+    commitMutation({ completedOnboarding: true })
     setOnboardingState("complete")
     setNewUserOnboardingCompletionBottomSheetVisible(false)
   }

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -3,6 +3,7 @@ import { fireEvent, screen } from "@testing-library/react-native"
 import { InfiniteDiscoveryHeader } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader"
 import { InfiniteDiscoveryArtwork } from "app/Scenes/InfiniteDiscovery/InfiniteDiscovery"
 import { GlobalStore, __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import RNShare from "react-native-share"
@@ -82,6 +83,10 @@ describe("InfiniteDiscoveryHeader", () => {
     GlobalStore.actions.onboarding.setOnboardingState("complete")
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnabledDiscoverDailyNegativeSignals: false })
     ;(RNShare.open as jest.Mock).mockResolvedValue({ success: true, message: "shared" })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
   })
 
   it("renders more button when topArtwork has required data", () => {
@@ -167,6 +172,31 @@ describe("InfiniteDiscoveryHeader", () => {
 
       expect(setOnboardingStateSpy).toHaveBeenCalledWith("complete")
       expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })
+    })
+
+    it("still exits onboarding when Skip is pressed if the profile mutation fails", () => {
+      jest.spyOn(console, "error").mockImplementation()
+      const setOnboardingStateSpy = jest.spyOn(GlobalStore.actions.onboarding, "setOnboardingState")
+
+      renderWithWrappers(<InfiniteDiscoveryHeader />)
+
+      fireEvent.press(screen.getByLabelText("Skip to home"))
+
+      const environment = getMockRelayEnvironment()
+      environment.mock.rejectMostRecentOperation(new Error("network error"))
+
+      expect(setOnboardingStateSpy).toHaveBeenCalledWith("complete")
+    })
+
+    it("sends completedOnboarding: true in the profile mutation when Skip is pressed", () => {
+      renderWithWrappers(<InfiniteDiscoveryHeader />)
+
+      fireEvent.press(screen.getByLabelText("Skip to home"))
+
+      const environment = getMockRelayEnvironment()
+      const operation = environment.mock.getMostRecentOperation()
+
+      expect(operation.request.variables.input).toEqual({ completedOnboarding: true })
     })
 
     it("does not defer Home tooltips when Skip is pressed without any saves", () => {

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/NewUserOnboardingCompletionBottomSheet.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/NewUserOnboardingCompletionBottomSheet.tests.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react-native"
 import { NewUserOnboardingCompletionBottomSheet } from "app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet"
 import { __globalStoreTestUtils__, GlobalStore } from "app/store/GlobalStore"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 const SAVED_ARTWORKS = Array.from({ length: 5 }, (_, i) => ({
@@ -14,6 +15,10 @@ describe("NewUserOnboardingCompletionBottomSheet", () => {
     GlobalStore.actions.onboarding.setOnboardingState("complete")
     GlobalStore.actions.infiniteDiscovery.resetSavedArtworksCount()
     GlobalStore.actions.infiniteDiscovery.resetNewUserOnboardingSessionState()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
   })
 
   it("renders the sheet content when completionBottomSheetVisible is true", () => {
@@ -57,6 +62,35 @@ describe("NewUserOnboardingCompletionBottomSheet", () => {
       state?.infiniteDiscovery.sessionState.newUserOnboardingCompletionBottomSheetVisible
     ).toBe(false)
     expect(state?.onboarding.onboardingState).toBe("complete")
+  })
+
+  it('"Take Me Home" still completes onboarding if the profile mutation fails', () => {
+    jest.spyOn(console, "error").mockImplementation()
+    GlobalStore.actions.onboarding.setOnboardingState("incomplete")
+    GlobalStore.actions.infiniteDiscovery.setNewUserOnboardingCompletionBottomSheetVisible(true)
+
+    renderWithWrappers(<NewUserOnboardingCompletionBottomSheet />)
+
+    fireEvent.press(screen.getByText("Take Me Home"))
+
+    const environment = getMockRelayEnvironment()
+    environment.mock.rejectMostRecentOperation(new Error("network error"))
+
+    expect(__globalStoreTestUtils__?.getCurrentState().onboarding.onboardingState).toBe("complete")
+  })
+
+  it('"Take Me Home" sends completedOnboarding: true in the profile mutation', () => {
+    GlobalStore.actions.onboarding.setOnboardingState("incomplete")
+    GlobalStore.actions.infiniteDiscovery.setNewUserOnboardingCompletionBottomSheetVisible(true)
+
+    renderWithWrappers(<NewUserOnboardingCompletionBottomSheet />)
+
+    fireEvent.press(screen.getByText("Take Me Home"))
+
+    const environment = getMockRelayEnvironment()
+    const operation = environment.mock.getMostRecentOperation()
+
+    expect(operation.request.variables.input).toEqual({ completedOnboarding: true })
   })
 
   it('"Take Me Home" defers Home tooltips to the next session when at least one artwork was saved', () => {

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
@@ -21,6 +21,7 @@ import {
   FollowedArtistsBank,
 } from "app/Scenes/Onboarding/Screens/Onboarding/Components/FollowedArtistsBank"
 import { useOnboardingTracking } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useOnboardingTracking"
+import { useUpdateUserProfile } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useUpdateUserProfile"
 import { OnboardingSearchResultsScreen } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/OnboardingSearchResults"
 import { GlobalStore } from "app/store/GlobalStore"
 import { OnboardingFollowedArtist } from "app/store/OnboardingModel"
@@ -34,6 +35,7 @@ const SET_ID = "onboarding:suggested-artists"
 
 export const FollowArtists: React.FC = () => {
   const { trackCompletedOnboarding, trackTappedSkip } = useOnboardingTracking()
+  const { commitMutation } = useUpdateUserProfile()
   const { bottom } = useSafeAreaInsets()
   const space = useSpace()
   const [query, setQuery] = useState("")
@@ -78,6 +80,7 @@ export const FollowArtists: React.FC = () => {
             onPress={() => {
               trackTappedSkip(ContextModule.onboardingFlow, OwnerType.onboarding)
               trackCompletedOnboarding()
+              commitMutation({ completedOnboarding: true })
               GlobalStore.actions.onboarding.setOnboardingState("complete")
             }}
             hitSlop={DEFAULT_HIT_SLOP}
@@ -152,6 +155,7 @@ export const FollowArtists: React.FC = () => {
                 trackCompletedOnboarding()
                 GlobalStore.actions.progressiveOnboarding.setDeferHomeTooltipsThisSession(true)
                 GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
+                commitMutation({ completedOnboarding: true })
                 GlobalStore.actions.onboarding.setOnboardingState("complete")
               }}
             >

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
@@ -3,6 +3,7 @@ import { fireEvent, screen } from "@testing-library/react-native"
 import { FollowedArtistsBank } from "app/Scenes/Onboarding/Screens/Onboarding/Components/FollowedArtistsBank"
 import { FollowArtists } from "app/Scenes/Onboarding/Screens/Onboarding/FollowArtists"
 import { __globalStoreTestUtils__, GlobalStore } from "app/store/GlobalStore"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { KeyboardController } from "react-native-keyboard-controller"
@@ -59,6 +60,10 @@ describe("FollowArtists", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     dismissSpy = jest.spyOn(KeyboardController, "dismiss").mockImplementation(jest.fn())
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
   })
 
   describe("default view", () => {
@@ -203,6 +208,39 @@ describe("FollowArtists", () => {
       expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })
     })
 
+    it("still sets onboardingState to complete if the profile mutation fails", () => {
+      jest.spyOn(console, "error").mockImplementation()
+      renderWithWrappers(<FollowArtists />)
+
+      fireEvent.press(screen.getByText("OrderedSet"))
+      fireEvent.press(screen.getByText("OrderedSet"))
+      fireEvent.press(screen.getByText("OrderedSet"))
+
+      fireEvent.press(screen.getByTestId("continue-button"))
+
+      const environment = getMockRelayEnvironment()
+      environment.mock.rejectMostRecentOperation(new Error("network error"))
+
+      expect(__globalStoreTestUtils__?.getCurrentState().onboarding.onboardingState).toBe(
+        "complete"
+      )
+    })
+
+    it("sends completedOnboarding: true in the profile mutation", () => {
+      renderWithWrappers(<FollowArtists />)
+
+      fireEvent.press(screen.getByText("OrderedSet"))
+      fireEvent.press(screen.getByText("OrderedSet"))
+      fireEvent.press(screen.getByText("OrderedSet"))
+
+      fireEvent.press(screen.getByTestId("continue-button"))
+
+      const environment = getMockRelayEnvironment()
+      const operation = environment.mock.getMostRecentOperation()
+
+      expect(operation.request.variables.input).toEqual({ completedOnboarding: true })
+    })
+
     it("defers home tooltips when pressed", () => {
       renderWithWrappers(<FollowArtists />)
 
@@ -231,6 +269,31 @@ describe("FollowArtists", () => {
         "complete"
       )
       expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })
+    })
+
+    it("still sets onboardingState to complete if the profile mutation fails", () => {
+      jest.spyOn(console, "error").mockImplementation()
+      renderWithWrappers(<FollowArtists />)
+
+      fireEvent.press(screen.getByLabelText("Skip to home"))
+
+      const environment = getMockRelayEnvironment()
+      environment.mock.rejectMostRecentOperation(new Error("network error"))
+
+      expect(__globalStoreTestUtils__?.getCurrentState().onboarding.onboardingState).toBe(
+        "complete"
+      )
+    })
+
+    it("sends completedOnboarding: true in the profile mutation", () => {
+      renderWithWrappers(<FollowArtists />)
+
+      fireEvent.press(screen.getByLabelText("Skip to home"))
+
+      const environment = getMockRelayEnvironment()
+      const operation = environment.mock.getMostRecentOperation()
+
+      expect(operation.request.variables.input).toEqual({ completedOnboarding: true })
     })
 
     it("tracks the skip tap", () => {

--- a/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/__tests__/useUpdateUserProfile.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/__tests__/useUpdateUserProfile.tests.tsx
@@ -1,0 +1,68 @@
+import { act, renderHook } from "@testing-library/react-native"
+import { useUpdateUserProfile } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useUpdateUserProfile"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { RelayEnvironmentProvider } from "react-relay"
+import { MockPayloadGenerator } from "relay-test-utils"
+
+const setup = (onMutationComplete?: () => void) => {
+  return renderHook(() => useUpdateUserProfile(onMutationComplete), {
+    wrapper: ({ children }: any) => (
+      <RelayEnvironmentProvider environment={getMockRelayEnvironment()}>
+        {children}
+      </RelayEnvironmentProvider>
+    ),
+  })
+}
+
+describe("useUpdateUserProfile", () => {
+  it("calls onMutationComplete when the mutation succeeds and a callback is provided", () => {
+    const onMutationComplete = jest.fn()
+    const { result } = setup(onMutationComplete)
+
+    act(() => {
+      result.current.commitMutation({ completedOnboarding: true })
+    })
+
+    const environment = getMockRelayEnvironment()
+    act(() => {
+      environment.mock.resolveMostRecentOperation((operation) =>
+        MockPayloadGenerator.generate(operation)
+      )
+    })
+
+    expect(onMutationComplete).toHaveBeenCalled()
+  })
+
+  it("does not throw when the mutation succeeds and no callback is provided", () => {
+    const { result } = setup()
+
+    act(() => {
+      result.current.commitMutation({ completedOnboarding: true })
+    })
+
+    const environment = getMockRelayEnvironment()
+    expect(() => {
+      act(() => {
+        environment.mock.resolveMostRecentOperation((operation) =>
+          MockPayloadGenerator.generate(operation)
+        )
+      })
+    }).not.toThrow()
+  })
+
+  it("does not throw when the mutation fails and no callback is provided", () => {
+    jest.spyOn(console, "error").mockImplementation()
+    const { result } = setup()
+
+    act(() => {
+      result.current.commitMutation({ completedOnboarding: true })
+    })
+
+    const environment = getMockRelayEnvironment()
+    expect(() => {
+      act(() => {
+        environment.mock.rejectMostRecentOperation(new Error("network error"))
+      })
+    }).not.toThrow()
+  })
+})

--- a/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useUpdateUserProfile.tsx
+++ b/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useUpdateUserProfile.tsx
@@ -4,7 +4,7 @@ import {
 } from "__generated__/useUpdateUserProfileMutation.graphql"
 import { graphql, useMutation } from "react-relay"
 
-export const useUpdateUserProfile = (onMutationComplete: () => void) => {
+export const useUpdateUserProfile = (onMutationComplete?: () => void) => {
   const [commit] = useMutation<useUpdateUserProfileMutation>(UpdateProfileMutation)
 
   const commitMutation = (input: UpdateMyProfileInput) => {
@@ -13,7 +13,7 @@ export const useUpdateUserProfile = (onMutationComplete: () => void) => {
         input,
       },
       onCompleted() {
-        onMutationComplete()
+        onMutationComplete?.()
       },
       onError(e) {
         console.error(e)


### PR DESCRIPTION
This PR resolves [DI-584](https://www.notion.so/3cdcab0764a080b5b0d0e74a968d0dc9)

### Description

This PR updates the new onboarding flow to set the `completed_onboarding_at` flag for the new user in Gravity when they exit the flow, either by skipping it or by completing the prescribed task.

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Set completed_mutation_at flag when users exit onboarding.

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
