### PR TITLE
fix: avoid "Session expired" sign-out on transient /me 401

### DIFF
--- a/src/app/system/relay/middlewares/__tests__/checkAuthenticationMiddleware.tests.ts
+++ b/src/app/system/relay/middlewares/__tests__/checkAuthenticationMiddleware.tests.ts
@@ -8,7 +8,12 @@ import {
 } from "react-relay-network-modern"
 
 describe(checkAuthenticationMiddleware, () => {
-  const middleware = checkAuthenticationMiddleware()
+  let middleware: ReturnType<typeof checkAuthenticationMiddleware>
+
+  beforeEach(() => {
+    fetchMock.resetMocks()
+    middleware = checkAuthenticationMiddleware()
+  })
 
   const request: GraphQLRequest = {
     // @ts-ignore
@@ -23,7 +28,27 @@ describe(checkAuthenticationMiddleware, () => {
     } as any,
   }
 
-  it("calls signOut if there are errors", async () => {
+  it("calls signOut if there are errors and /me keeps returning 401", async () => {
+    const errors: GraphQLResponseErrors = [
+      { message: "The access token is invalid or has expired." },
+    ]
+    // @ts-ignore
+    const relayResponse: RelayNetworkLayerResponse = { errors }
+
+    const next: MiddlewareNextFn = () => Promise.resolve(relayResponse)
+    fetchMock.mockResponse("", { status: 401 })
+    expect(fetchMock).toHaveBeenCalledTimes(0)
+    await middleware(next)(request)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(__globalStoreTestUtils__?.dispatchedActions.map((x) => x.type)).toContain(
+      "@thunk.auth.signOut(success)"
+    )
+    expect(__globalStoreTestUtils__?.dispatchedActions.map((x) => x.type)).toContain(
+      "@thunkOn.resetAfterSignOut(success)"
+    )
+  })
+
+  it("does not sign out if /me recovers on a retry (e.g. a freshly issued token)", async () => {
     const errors: GraphQLResponseErrors = [
       { message: "The access token is invalid or has expired." },
     ]
@@ -32,14 +57,11 @@ describe(checkAuthenticationMiddleware, () => {
 
     const next: MiddlewareNextFn = () => Promise.resolve(relayResponse)
     fetchMock.mockResponseOnce("", { status: 401 })
-    expect(fetchMock).toHaveBeenCalledTimes(0)
+    fetchMock.mockResponseOnce("", { status: 200 })
     await middleware(next)(request)
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(__globalStoreTestUtils__?.dispatchedActions.map((x) => x.type)).toContain(
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(__globalStoreTestUtils__?.dispatchedActions.map((x) => x.type)).not.toContain(
       "@thunk.auth.signOut(success)"
-    )
-    expect(__globalStoreTestUtils__?.dispatchedActions.map((x) => x.type)).toContain(
-      "@thunkOn.resetAfterSignOut(success)"
     )
   })
 

--- a/src/app/system/relay/middlewares/__tests__/checkAuthenticationMiddleware.tests.ts
+++ b/src/app/system/relay/middlewares/__tests__/checkAuthenticationMiddleware.tests.ts
@@ -1,3 +1,4 @@
+import { captureMessage } from "@sentry/react-native"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { checkAuthenticationMiddleware } from "app/system/relay/middlewares/checkAuthenticationMiddleware"
 import { GraphQLRequest } from "app/system/relay/middlewares/types"
@@ -7,11 +8,14 @@ import {
   RelayNetworkLayerResponse,
 } from "react-relay-network-modern"
 
+const captureMessageMock = captureMessage as jest.Mock
+
 describe(checkAuthenticationMiddleware, () => {
   let middleware: ReturnType<typeof checkAuthenticationMiddleware>
 
   beforeEach(() => {
     fetchMock.resetMocks()
+    captureMessageMock.mockClear()
     middleware = checkAuthenticationMiddleware()
   })
 
@@ -46,6 +50,10 @@ describe(checkAuthenticationMiddleware, () => {
     expect(__globalStoreTestUtils__?.dispatchedActions.map((x) => x.type)).toContain(
       "@thunkOn.resetAfterSignOut(success)"
     )
+    expect(captureMessageMock).toHaveBeenCalledWith(
+      expect.stringContaining("signed out on expired session"),
+      expect.objectContaining({ tags: { authOutcome: "signed_out_expired" } })
+    )
   })
 
   it("does not sign out if /me recovers on a retry (e.g. a freshly issued token)", async () => {
@@ -62,6 +70,13 @@ describe(checkAuthenticationMiddleware, () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(__globalStoreTestUtils__?.dispatchedActions.map((x) => x.type)).not.toContain(
       "@thunk.auth.signOut(success)"
+    )
+    expect(captureMessageMock).toHaveBeenCalledWith(
+      expect.stringContaining("recovered after transient 401"),
+      expect.objectContaining({
+        tags: { authOutcome: "recovered_after_transient_401" },
+        extra: { attempts: 2 },
+      })
     )
   })
 

--- a/src/app/system/relay/middlewares/__tests__/checkAuthenticationMiddleware.tests.ts
+++ b/src/app/system/relay/middlewares/__tests__/checkAuthenticationMiddleware.tests.ts
@@ -80,6 +80,31 @@ describe(checkAuthenticationMiddleware, () => {
     )
   })
 
+  it("only emits one recovered event per token across concurrent recoveries", async () => {
+    const errors: GraphQLResponseErrors = [
+      { message: "The access token is invalid or has expired." },
+    ]
+    // @ts-ignore
+    const relayResponse: RelayNetworkLayerResponse = { errors }
+
+    const next: MiddlewareNextFn = () => Promise.resolve(relayResponse)
+    // Two failing requests for the same token, each recovering (401 then 200).
+    fetchMock.mockResponses(
+      ["", { status: 401 }],
+      ["", { status: 200 }],
+      ["", { status: 401 }],
+      ["", { status: 200 }]
+    )
+
+    await middleware(next)(request)
+    await middleware(next)(request)
+
+    const recoveredCalls = captureMessageMock.mock.calls.filter(
+      ([, ctx]) => ctx?.tags?.authOutcome === "recovered_after_transient_401"
+    )
+    expect(recoveredCalls).toHaveLength(1)
+  })
+
   it("passes through if there is no errors", async () => {
     const errors: GraphQLResponseErrors = []
     // @ts-ignore

--- a/src/app/system/relay/middlewares/__tests__/checkAuthenticationMiddleware.tests.ts
+++ b/src/app/system/relay/middlewares/__tests__/checkAuthenticationMiddleware.tests.ts
@@ -80,6 +80,26 @@ describe(checkAuthenticationMiddleware, () => {
     )
   })
 
+  it("does not emit a recovered event if a transient 401 is followed by a non-401 error", async () => {
+    const errors: GraphQLResponseErrors = [
+      { message: "The access token is invalid or has expired." },
+    ]
+    // @ts-ignore
+    const relayResponse: RelayNetworkLayerResponse = { errors }
+
+    const next: MiddlewareNextFn = () => Promise.resolve(relayResponse)
+    fetchMock.mockResponseOnce("", { status: 401 })
+    fetchMock.mockResponseOnce("", { status: 500 })
+    await middleware(next)(request)
+    expect(__globalStoreTestUtils__?.dispatchedActions.map((x) => x.type)).not.toContain(
+      "@thunk.auth.signOut(success)"
+    )
+    expect(captureMessageMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("recovered after transient 401"),
+      expect.anything()
+    )
+  })
+
   it("only emits one recovered event per token across concurrent recoveries", async () => {
     const errors: GraphQLResponseErrors = [
       { message: "The access token is invalid or has expired." },

--- a/src/app/system/relay/middlewares/checkAuthenticationMiddleware.ts
+++ b/src/app/system/relay/middlewares/checkAuthenticationMiddleware.ts
@@ -43,6 +43,8 @@ const checkSession = async (gravityURL: string, token: string): Promise<SessionC
 export const checkAuthenticationMiddleware = (): Middleware => {
   // We want to avoid running the forced logout more than once.
   const expiredTokens: Set<string> = new Set()
+  // Dedup per token so the recovery signal is counted per-incident, not per-request.
+  const recoveredTokens: Set<string> = new Set()
   return (next) => async (req) => {
     const res = await next(req)
     const authenticationToken = req.fetchOpts.headers["X-ACCESS-TOKEN"]
@@ -59,7 +61,8 @@ export const checkAuthenticationMiddleware = (): Middleware => {
         if (expiredTokens.has(authenticationToken)) {
           return res
         }
-        if (recoveredAfterTransient401) {
+        if (recoveredAfterTransient401 && !recoveredTokens.has(authenticationToken)) {
+          recoveredTokens.add(authenticationToken)
           captureMessage("checkAuthentication: /me recovered after transient 401", {
             level: "info",
             tags: { authOutcome: "recovered_after_transient_401" },

--- a/src/app/system/relay/middlewares/checkAuthenticationMiddleware.ts
+++ b/src/app/system/relay/middlewares/checkAuthenticationMiddleware.ts
@@ -12,9 +12,6 @@ const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 interface SessionCheckResult {
   expired: boolean
-  // A 401 on the first attempt that a later attempt cleared — the token was briefly rejected
-  // before it propagated (read-your-writes lag). Reported so we can size how often this
-  // happens in production vs. genuine expirations.
   recoveredAfterTransient401: boolean
   attempts: number
 }

--- a/src/app/system/relay/middlewares/checkAuthenticationMiddleware.ts
+++ b/src/app/system/relay/middlewares/checkAuthenticationMiddleware.ts
@@ -2,6 +2,31 @@ import { GlobalStore, unsafe__getEnvironment } from "app/store/GlobalStore"
 import { Alert } from "react-native"
 import { Middleware } from "react-relay-network-modern"
 
+// A freshly issued token (e.g. right after sign up) can briefly 401 on /me before it
+// propagates, so we confirm the session is really gone before forcing a sign out.
+const ME_CHECK_MAX_ATTEMPTS = 3
+const ME_CHECK_RETRY_DELAY = 500
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const isSessionExpired = async (gravityURL: string, token: string): Promise<boolean> => {
+  for (let attempt = 0; attempt < ME_CHECK_MAX_ATTEMPTS; attempt++) {
+    const result = await fetch(`${gravityURL}/api/v1/me`, {
+      method: "HEAD",
+      headers: {
+        "X-ACCESS-TOKEN": token,
+      },
+    })
+    if (result.status !== 401) {
+      return false
+    }
+    if (attempt < ME_CHECK_MAX_ATTEMPTS - 1) {
+      await delay(ME_CHECK_RETRY_DELAY)
+    }
+  }
+  return true
+}
+
 // This middleware is responsible of signing the user out if their session expired
 export const checkAuthenticationMiddleware = (): Middleware => {
   // We want to avoid running the forced logout more than once.
@@ -13,18 +38,13 @@ export const checkAuthenticationMiddleware = (): Middleware => {
     if (res.errors?.length && authenticationToken && !expiredTokens.has(authenticationToken)) {
       const { gravityURL } = unsafe__getEnvironment()
       try {
-        const result = await fetch(`${gravityURL}/api/v1/me`, {
-          method: "HEAD",
-          headers: {
-            "X-ACCESS-TOKEN": authenticationToken,
-          },
-        })
+        const sessionExpired = await isSessionExpired(gravityURL, authenticationToken)
         // Requests are not necessarily executed sequentially so we need to check that another request
         // didn't make it here already while we were awaiting.
         if (expiredTokens.has(authenticationToken)) {
           return res
         }
-        if (result.status === 401) {
+        if (sessionExpired) {
           expiredTokens.add(authenticationToken)
           await GlobalStore.actions.auth.signOut()
           // There is a race condition that prevents the onboarding slideshow from starting if we call an Alert

--- a/src/app/system/relay/middlewares/checkAuthenticationMiddleware.ts
+++ b/src/app/system/relay/middlewares/checkAuthenticationMiddleware.ts
@@ -1,3 +1,4 @@
+import { captureMessage } from "@sentry/react-native"
 import { GlobalStore, unsafe__getEnvironment } from "app/store/GlobalStore"
 import { Alert } from "react-native"
 import { Middleware } from "react-relay-network-modern"
@@ -9,7 +10,17 @@ const ME_CHECK_RETRY_DELAY = 500
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
-const isSessionExpired = async (gravityURL: string, token: string): Promise<boolean> => {
+interface SessionCheckResult {
+  expired: boolean
+  // A 401 on the first attempt that a later attempt cleared — the token was briefly rejected
+  // before it propagated (read-your-writes lag). Reported so we can size how often this
+  // happens in production vs. genuine expirations.
+  recoveredAfterTransient401: boolean
+  attempts: number
+}
+
+const checkSession = async (gravityURL: string, token: string): Promise<SessionCheckResult> => {
+  let sawTransient401 = false
   for (let attempt = 0; attempt < ME_CHECK_MAX_ATTEMPTS; attempt++) {
     const result = await fetch(`${gravityURL}/api/v1/me`, {
       method: "HEAD",
@@ -18,13 +29,14 @@ const isSessionExpired = async (gravityURL: string, token: string): Promise<bool
       },
     })
     if (result.status !== 401) {
-      return false
+      return { expired: false, recoveredAfterTransient401: sawTransient401, attempts: attempt + 1 }
     }
+    sawTransient401 = true
     if (attempt < ME_CHECK_MAX_ATTEMPTS - 1) {
       await delay(ME_CHECK_RETRY_DELAY)
     }
   }
-  return true
+  return { expired: true, recoveredAfterTransient401: false, attempts: ME_CHECK_MAX_ATTEMPTS }
 }
 
 // This middleware is responsible of signing the user out if their session expired
@@ -38,14 +50,28 @@ export const checkAuthenticationMiddleware = (): Middleware => {
     if (res.errors?.length && authenticationToken && !expiredTokens.has(authenticationToken)) {
       const { gravityURL } = unsafe__getEnvironment()
       try {
-        const sessionExpired = await isSessionExpired(gravityURL, authenticationToken)
+        const { expired, recoveredAfterTransient401, attempts } = await checkSession(
+          gravityURL,
+          authenticationToken
+        )
         // Requests are not necessarily executed sequentially so we need to check that another request
         // didn't make it here already while we were awaiting.
         if (expiredTokens.has(authenticationToken)) {
           return res
         }
-        if (sessionExpired) {
+        if (recoveredAfterTransient401) {
+          captureMessage("checkAuthentication: /me recovered after transient 401", {
+            level: "info",
+            tags: { authOutcome: "recovered_after_transient_401" },
+            extra: { attempts },
+          })
+        }
+        if (expired) {
           expiredTokens.add(authenticationToken)
+          captureMessage("checkAuthentication: signed out on expired session", {
+            level: "info",
+            tags: { authOutcome: "signed_out_expired" },
+          })
           await GlobalStore.actions.auth.signOut()
           // There is a race condition that prevents the onboarding slideshow from starting if we call an Alert
           // here synchronously, so we need to wait a few ticks.

--- a/src/app/system/relay/middlewares/checkAuthenticationMiddleware.ts
+++ b/src/app/system/relay/middlewares/checkAuthenticationMiddleware.ts
@@ -26,7 +26,10 @@ const checkSession = async (gravityURL: string, token: string): Promise<SessionC
       },
     })
     if (result.status !== 401) {
-      return { expired: false, recoveredAfterTransient401: sawTransient401, attempts: attempt + 1 }
+      // Only a genuine 2xx confirms the session recovered; a non-401 error (e.g. 500)
+      // tells us nothing, so don't count it as a recovery.
+      const recovered = sawTransient401 && result.ok
+      return { expired: false, recoveredAfterTransient401: recovered, attempts: attempt + 1 }
     }
     sawTransient401 = true
     if (attempt < ME_CHECK_MAX_ATTEMPTS - 1) {


### PR DESCRIPTION
This PR resolves [] <!-- Maestro signup e2e "Session expired" flake -->

### Description

Assisted-By: Claude <noreply@anthropic.com>

Seeing intermittent failures in sign up flow in maestro, with claude were able to tie back in traces to periodic failures when a recently created accessToken will 401 due to write lag. 
https://app.datadoghq.com/apm/trace/2547012183967639366?spanID=1543485863266021430

This retries before forcing a sign out which should fix most cases and captures a message to sentry to help understand the scope of this problem in production. 

https://github.com/artsy/eigen/actions/runs/33058724596/job/98471908212

<img width="320" height="640" alt="signed_out" src="https://github.com/user-attachments/assets/f7e11e0c-9069-4bd7-abfe-d8851635eed4" />


### Follow-ups
- [ ] Check sentry to see scope of this after a couple weeks, if affecting a lot we should look to fix on backend

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Retry 401s to avoid signing out users on transient failures - brian 

#### iOS user-facing changes

-

#### Android user-facing changes

-

</details>
