### PR TITLE
feat(lens): add photo thumbnail to results header

### DIFF
--- a/src/app/Scenes/Lens/Components/LensResultsHeader.tsx
+++ b/src/app/Scenes/Lens/Components/LensResultsHeader.tsx
@@ -1,7 +1,6 @@
 import { ChevronLeftIcon } from "@artsy/icons/native"
-import { Flex, NAVBAR_HEIGHT, Separator, Text, Touchable } from "@artsy/palette-mobile"
+import { Flex, Image, NAVBAR_HEIGHT, Separator, Text, Touchable } from "@artsy/palette-mobile"
 import { ICON_HIT_SLOP } from "app/Components/constants"
-import { Image } from "react-native"
 
 const THUMBNAIL_SIZE = 44
 
@@ -33,9 +32,11 @@ export const LensResultsHeader: React.FC<LensResultsHeaderProps> = ({
         <Flex ml={1} width={THUMBNAIL_SIZE} height={THUMBNAIL_SIZE} bg="mono10" overflow="hidden">
           <Image
             testID="lensResultsPhotoThumbnail"
-            source={{ uri: photoUri }}
+            src={photoUri}
+            width={THUMBNAIL_SIZE}
+            height={THUMBNAIL_SIZE}
             resizeMode="cover"
-            style={{ width: THUMBNAIL_SIZE, height: THUMBNAIL_SIZE }}
+            performResize={false}
           />
         </Flex>
 

--- a/src/app/Scenes/Lens/Components/LensResultsHeader.tsx
+++ b/src/app/Scenes/Lens/Components/LensResultsHeader.tsx
@@ -1,0 +1,54 @@
+import { ChevronLeftIcon } from "@artsy/icons/native"
+import { Flex, NAVBAR_HEIGHT, Separator, Text, Touchable } from "@artsy/palette-mobile"
+import { ICON_HIT_SLOP } from "app/Components/constants"
+import { Image } from "react-native"
+
+const THUMBNAIL_SIZE = 44
+
+interface LensResultsHeaderProps {
+  onBack: () => void
+  photoUri: string
+  title?: string
+}
+
+export const LensResultsHeader: React.FC<LensResultsHeaderProps> = ({
+  onBack,
+  photoUri,
+  title,
+}) => {
+  return (
+    <Flex>
+      <Flex flexDirection="row" alignItems="center" px={2} py={1} minHeight={NAVBAR_HEIGHT}>
+        <Touchable
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          accessibilityHint="Navigates to the previous screen"
+          onPress={onBack}
+          underlayColor="transparent"
+          hitSlop={ICON_HIT_SLOP}
+        >
+          <ChevronLeftIcon fill="mono100" />
+        </Touchable>
+
+        <Flex ml={1} width={THUMBNAIL_SIZE} height={THUMBNAIL_SIZE} bg="mono10" overflow="hidden">
+          <Image
+            testID="lensResultsPhotoThumbnail"
+            source={{ uri: photoUri }}
+            resizeMode="cover"
+            style={{ width: THUMBNAIL_SIZE, height: THUMBNAIL_SIZE }}
+          />
+        </Flex>
+
+        {!!title && (
+          <Flex flex={1} ml={1}>
+            <Text variant="sm-display" numberOfLines={3}>
+              {title}
+            </Text>
+          </Flex>
+        )}
+      </Flex>
+
+      <Separator borderColor="mono5" />
+    </Flex>
+  )
+}

--- a/src/app/Scenes/Lens/Lens.tsx
+++ b/src/app/Scenes/Lens/Lens.tsx
@@ -24,7 +24,7 @@ export const Lens: React.FC = () => {
   return (
     <NavigationIndependentTree>
       <NavigationContainer theme={theme}>
-        <StatusBar barStyle="light-content" />
+        <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
         <Stack.Navigator
           detachInactiveScreens={false}
           initialRouteName="LensCamera"

--- a/src/app/Scenes/Lens/Screens/LensAnalyzing.tsx
+++ b/src/app/Scenes/Lens/Screens/LensAnalyzing.tsx
@@ -76,14 +76,16 @@ export const LensAnalyzing: React.FC<Props> = ({ route, navigation }) => {
         }
 
         setCropped(cropped)
-        return uploadImageToS3(cropped.uri)
+        return uploadImageToS3(cropped.uri).then(({ bucket, key }) => ({ bucket, key, cropped }))
       })
-      .then(({ bucket, key }) => {
+      .then(({ bucket, key, cropped }) => {
         if (cancelled) {
           return
         }
 
-        navigation.replace("LensResults", { s3Bucket: bucket, s3Key: key })
+        // LensResults owns the cropped file after navigation.
+        tempPhotoUris.current = tempPhotoUris.current.filter((uri) => uri !== cropped.uri)
+        navigation.replace("LensResults", { s3Bucket: bucket, s3Key: key, photoUri: cropped.uri })
       })
       .catch((error) => {
         if (cancelled) {

--- a/src/app/Scenes/Lens/Screens/LensResults.tsx
+++ b/src/app/Scenes/Lens/Screens/LensResults.tsx
@@ -1,5 +1,5 @@
 import { OwnerType } from "@artsy/cohesion"
-import { Screen, SimpleMessage, Spacer } from "@artsy/palette-mobile"
+import { Screen, SimpleMessage } from "@artsy/palette-mobile"
 import { StackScreenProps } from "@react-navigation/stack"
 import { LensResultsQuery } from "__generated__/LensResultsQuery.graphql"
 import {
@@ -10,16 +10,19 @@ import { PlaceholderGrid } from "app/Components/ArtworkGrids/GenericGrid"
 import { MasonryInfiniteScrollArtworkGrid } from "app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid"
 import { SearchByPhotoButton } from "app/Components/SearchByPhotoButton/SearchByPhotoButton"
 import { PAGE_SIZE } from "app/Components/constants"
+import { LensResultsHeader } from "app/Scenes/Lens/Components/LensResultsHeader"
 import { LensNavigationStack } from "app/Scenes/Lens/types"
+import { discardTempPhotos } from "app/Scenes/Lens/utils/discardTempPhotos"
 import { goBack } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { useBackHandler } from "app/utils/hooks/useBackHandler"
 import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import { ExtractNodeType } from "app/utils/relayHelpers"
-import { Suspense } from "react"
+import { Suspense, useEffect } from "react"
 import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 
-const SCREEN_TITLE = "Your matches"
+const MATCHES_TITLE = "Here are some matches to your photo"
+const SEARCHING_TITLE = "Searching for matches..."
 
 type Props = StackScreenProps<LensNavigationStack, "LensResults">
 
@@ -31,7 +34,7 @@ const restartSearch = (navigation: Navigation) => {
 }
 
 const LensResults: React.FC<Props> = ({ route, navigation }) => {
-  const { s3Bucket, s3Key } = route.params
+  const { s3Bucket, s3Key, photoUri } = route.params
 
   const queryData = useLazyLoadQuery<LensResultsQuery>(lensResultsQuery, {
     s3Bucket,
@@ -50,10 +53,13 @@ const LensResults: React.FC<Props> = ({ route, navigation }) => {
 
   return (
     <Screen>
-      <Screen.AnimatedHeader title={SCREEN_TITLE} onBack={goBack} />
-      <Screen.StickySubHeader title={SCREEN_TITLE} />
+      <LensResultsHeader
+        onBack={goBack}
+        photoUri={photoUri}
+        title={hasNoMatches ? undefined : MATCHES_TITLE}
+      />
 
-      <Screen.Body fullwidth>
+      <Screen.Body fullwidth pt={1}>
         <ArtworksGrid
           artworks={artworks}
           hasNext={hasNext}
@@ -82,11 +88,8 @@ const ArtworksGrid: React.FC<{
   isLoadingNext: boolean
   loadMore: (pageSize: number) => void
 }> = ({ artworks, hasNext, isLoadingNext, loadMore }) => {
-  const { scrollHandler } = Screen.useListenForScreenScroll()
-
   return (
     <MasonryInfiniteScrollArtworkGrid
-      animated
       artworks={artworks}
       contextScreenOwnerType={OwnerType.search}
       contextScreen={OwnerType.search}
@@ -98,7 +101,6 @@ const ArtworksGrid: React.FC<{
       hasMore={hasNext}
       isLoading={isLoadingNext}
       loadMore={loadMore}
-      onScroll={scrollHandler}
     />
   )
 }
@@ -137,6 +139,15 @@ const lensResultsQuery = graphql`
 `
 
 export const LensResultsScreen: React.FC<Props> = (props) => {
+  const { photoUri } = props.route.params
+
+  // Keep cleanup outside Suspense so it also runs when leaving during loading.
+  useEffect(() => {
+    return () => {
+      discardTempPhotos([photoUri])
+    }
+  }, [photoUri])
+
   /**
    * Android hardware back should match the header and leave the Lens route instead of popping the
    * inner stack back to the camera. Registered above the Suspense boundary so it covers the loading
@@ -148,20 +159,18 @@ export const LensResultsScreen: React.FC<Props> = (props) => {
   })
 
   return (
-    <Suspense fallback={<Placeholder onBack={goBack} />}>
+    <Suspense fallback={<Placeholder onBack={goBack} photoUri={photoUri} />}>
       <LensResults {...props} />
     </Suspense>
   )
 }
 
-const Placeholder: React.FC<{ onBack: () => void }> = ({ onBack }) => {
+const Placeholder: React.FC<{ onBack: () => void; photoUri: string }> = ({ onBack, photoUri }) => {
   return (
     <ProvidePlaceholderContext>
       <Screen>
-        <Screen.AnimatedHeader onBack={onBack} title={SCREEN_TITLE} />
-        <Screen.StickySubHeader title={SCREEN_TITLE} />
-        <Screen.Body fullwidth>
-          <Spacer y={2} />
+        <LensResultsHeader onBack={onBack} photoUri={photoUri} title={SEARCHING_TITLE} />
+        <Screen.Body fullwidth pt={1}>
           <PlaceholderGrid />
         </Screen.Body>
       </Screen>

--- a/src/app/Scenes/Lens/Screens/__tests__/LensResults.tests.tsx
+++ b/src/app/Scenes/Lens/Screens/__tests__/LensResults.tests.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from "@testing-library/react-native"
+import FastImage from "@d11/react-native-fast-image"
+import { fireEvent, screen, within } from "@testing-library/react-native"
 import { LensResultsTestsQuery } from "__generated__/LensResultsTestsQuery.graphql"
 import { LensResultsScreen } from "app/Scenes/Lens/Screens/LensResults"
 import { discardTempPhotos } from "app/Scenes/Lens/utils/discardTempPhotos"
@@ -94,7 +95,11 @@ describe("LensResults", () => {
   it("shows the photo the search ran on", () => {
     renderWithRelay({ Artwork: () => ({ title: "Cool Painting" }) })
 
-    expect(screen.getByTestId("lensResultsPhotoThumbnail").props.source).toEqual({ uri: photoUri })
+    const thumbnail = within(screen.getByTestId("lensResultsPhotoThumbnail")).UNSAFE_getByType(
+      FastImage
+    )
+
+    expect(thumbnail.props.source.uri).toBe(photoUri)
   })
 
   it("tells the user these are matches to their photo", () => {

--- a/src/app/Scenes/Lens/Screens/__tests__/LensResults.tests.tsx
+++ b/src/app/Scenes/Lens/Screens/__tests__/LensResults.tests.tsx
@@ -1,12 +1,18 @@
 import { fireEvent, screen } from "@testing-library/react-native"
 import { LensResultsTestsQuery } from "__generated__/LensResultsTestsQuery.graphql"
 import { LensResultsScreen } from "app/Scenes/Lens/Screens/LensResults"
+import { discardTempPhotos } from "app/Scenes/Lens/utils/discardTempPhotos"
 import { goBack, navigate } from "app/system/navigation/navigate"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { BackHandler } from "react-native"
 import { graphql } from "react-relay"
 
+jest.mock("app/Scenes/Lens/utils/discardTempPhotos", () => ({
+  discardTempPhotos: jest.fn(),
+}))
+
 const mockNavigate = jest.fn()
+const photoUri = "file:///tmp/cropped.jpg"
 
 describe("LensResults", () => {
   const { renderWithRelay } = setupTestWrapper<LensResultsTestsQuery>({
@@ -16,7 +22,7 @@ describe("LensResults", () => {
           {
             key: "LensResults",
             name: "LensResults",
-            params: { s3Bucket: "my-bucket", s3Key: "my-key" },
+            params: { s3Bucket: "my-bucket", s3Key: "my-key", photoUri },
           } as any
         }
         navigation={{ navigate: mockNavigate } as any}
@@ -30,7 +36,7 @@ describe("LensResults", () => {
     variables: { s3Bucket: "my-bucket", s3Key: "my-key" },
   })
 
-  afterEach(() => {
+  beforeEach(() => {
     jest.clearAllMocks()
   })
 
@@ -83,5 +89,33 @@ describe("LensResults", () => {
     renderWithRelay({ Artwork: () => ({ title: "Cool Painting" }) })
 
     expect(screen.queryByTestId("lensResultsSearchByPhotoButton")).toBeNull()
+  })
+
+  it("shows the photo the search ran on", () => {
+    renderWithRelay({ Artwork: () => ({ title: "Cool Painting" }) })
+
+    expect(screen.getByTestId("lensResultsPhotoThumbnail").props.source).toEqual({ uri: photoUri })
+  })
+
+  it("tells the user these are matches to their photo", () => {
+    renderWithRelay({ Artwork: () => ({ title: "Cool Painting" }) })
+
+    expect(screen.getByText("Here are some matches to your photo")).toBeTruthy()
+  })
+
+  it("claims no matches when there are none", () => {
+    renderWithRelay({ ArtworkConnection: () => ({ edges: [] }) })
+
+    expect(screen.queryByText("Here are some matches to your photo")).toBeNull()
+  })
+
+  it("deletes the searched photo on the way out", () => {
+    const { unmount } = renderWithRelay({ Artwork: () => ({ title: "Cool Painting" }) })
+
+    expect(discardTempPhotos).not.toHaveBeenCalled()
+
+    unmount()
+
+    expect(discardTempPhotos).toHaveBeenCalledWith([photoUri])
   })
 })

--- a/src/app/Scenes/Lens/__tests__/LensAnalyzing.tests.tsx
+++ b/src/app/Scenes/Lens/__tests__/LensAnalyzing.tests.tsx
@@ -58,6 +58,7 @@ describe("LensAnalyzing", () => {
       expect(mockReplace).toHaveBeenCalledWith("LensResults", {
         s3Bucket: "my-bucket",
         s3Key: "my-key",
+        photoUri: portraitCrop.uri,
       })
     )
   })
@@ -187,15 +188,28 @@ describe("LensAnalyzing", () => {
 
   // Nothing else in the app prunes these, so leaving them behind piled up full-size photos.
   describe("temp file cleanup", () => {
-    it("deletes the capture and the cropped file once it leaves the screen", async () => {
+    it("deletes the capture but hands the cropped file to LensResults", async () => {
       jest.mocked(uploadImageToS3).mockResolvedValue({ bucket: "my-bucket", key: "my-key" })
 
       const { unmount } = renderWithWrappers(<LensAnalyzing {...navigationProps} />)
 
-      await waitFor(() => expect(uploadImageToS3).toHaveBeenCalled())
+      await waitFor(() => expect(mockReplace).toHaveBeenCalled())
       // Not while the cropped image is still on screen, and not before the upload has read it.
       expect(discardTempPhotos).not.toHaveBeenCalled()
 
+      unmount()
+
+      expect(discardTempPhotos).toHaveBeenCalledWith([photo.uri])
+    })
+
+    it("still deletes the cropped file when the upload fails", async () => {
+      jest.mocked(uploadImageToS3).mockRejectedValue(new Error("upload failed"))
+
+      const { unmount } = renderWithWrappers(<LensAnalyzing {...navigationProps} />)
+
+      await screen.findByText(
+        "Something went wrong finding matches for that photo. Please try again."
+      )
       unmount()
 
       expect(discardTempPhotos).toHaveBeenCalledWith([photo.uri, portraitCrop.uri])
@@ -213,10 +227,10 @@ describe("LensAnalyzing", () => {
         />
       )
 
-      await waitFor(() => expect(uploadImageToS3).toHaveBeenCalled())
+      await waitFor(() => expect(mockReplace).toHaveBeenCalled())
       unmount()
 
-      expect(discardTempPhotos).toHaveBeenCalledWith([portraitCrop.uri])
+      expect(discardTempPhotos).toHaveBeenCalledWith([])
     })
 
     it("still deletes the capture when the crop never lands", async () => {

--- a/src/app/Scenes/Lens/types.ts
+++ b/src/app/Scenes/Lens/types.ts
@@ -22,13 +22,9 @@ export type LensNavigationStack = {
   LensAnalyzing: {
     photo: LensPhoto
   }
-  /**
-   * No local photo: the files are already deleted by the time this mounts (see `LensAnalyzing`'s
-   * sweep). A results thumbnail would need the *cropped* file kept alive past the upload -- the
-   * original isn't what the search saw.
-   */
   LensResults: {
     s3Bucket: string
     s3Key: string
+    photoUri: string
   }
 }


### PR DESCRIPTION
### Description

Adds a custom header to the Artsy Lens results screen:

- Shows a thumbnail of the photo used for the search.
- Shows “Searching for matches...” while results are loading.
- Updates the title when matches are found.
- Keeps the cropped photo available until the results screen is closed, then deletes the temporary file.

<video src="https://github.com/user-attachments/assets/8fa15e3d-875e-4749-8df2-650b870a7a3b" width="300px" ></video>

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
