### PR TITLE
chore(release): v9.17.0 RC

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
   },
   "dependencies": {
     "@artsy/changelog": "0.1.0",
-    "@artsy/cohesion": "4.396.0",
+    "@artsy/cohesion": "4.397.0",
     "@artsy/icons": "3.79.0",
     "@artsy/palette-mobile": "24.12.0",
     "@artsy/to-title-case": "1.2.0",

--- a/src/app/Components/GlobalSearchInput/GlobalSearchInput.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInput.tsx
@@ -1,8 +1,9 @@
-import { ActionType, OwnerType } from "@artsy/cohesion"
+import { ActionType, ContextModule, ScreenOwnerType } from "@artsy/cohesion"
 import { Flex, RoundSearchInput, Touchable } from "@artsy/palette-mobile"
 import { GlobalSearchInputOverlay } from "app/Components/GlobalSearchInput/GlobalSearchInputOverlay"
 import { useDismissSearchOverlayOnTabBarPress } from "app/Components/GlobalSearchInput/utils/useDismissSearchOverlayOnTabBarPress"
 import { SearchByPhotoIconButton } from "app/Components/SearchByPhotoButton/SearchByPhotoIconButton"
+import { tappedSearchByImage } from "app/Components/SearchByPhotoButton/tracks"
 import { ICON_HIT_SLOP } from "app/Components/constants"
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
@@ -16,7 +17,7 @@ export type GlobalSearchInput = {
 }
 
 interface GlobalSearchInputProps {
-  ownerType: OwnerType
+  ownerType: ScreenOwnerType
   onOverlayVisibilityChange?: (isVisible: boolean) => void
 }
 
@@ -72,7 +73,20 @@ export const GlobalSearchInput = forwardRef<GlobalSearchInput, GlobalSearchInput
             </Flex>
           </Touchable>
 
-          {!!enableArtsyLens && <SearchByPhotoIconButton onPress={() => navigate("/lens")} />}
+          {!!enableArtsyLens && (
+            <SearchByPhotoIconButton
+              onPress={() => {
+                tracking.trackEvent(
+                  tappedSearchByImage({
+                    contextModule: ContextModule.header,
+                    contextScreenOwnerType: ownerType,
+                    type: "search_input_icon",
+                  })
+                )
+                navigate("/lens")
+              }}
+            />
+          )}
         </Flex>
 
         <GlobalSearchInputOverlay
@@ -86,7 +100,7 @@ export const GlobalSearchInput = forwardRef<GlobalSearchInput, GlobalSearchInput
 )
 
 const tracks = {
-  tappedGlobalSearchBar: ({ ownerType }: { ownerType: OwnerType }) => ({
+  tappedGlobalSearchBar: ({ ownerType }: { ownerType: ScreenOwnerType }) => ({
     action: ActionType.tappedGlobalSearchBar,
     context_screen_owner_type: ownerType,
   }),

--- a/src/app/Components/GlobalSearchInput/GlobalSearchInput.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInput.tsx
@@ -4,10 +4,10 @@ import { GlobalSearchInputOverlay } from "app/Components/GlobalSearchInput/Globa
 import { useDismissSearchOverlayOnTabBarPress } from "app/Components/GlobalSearchInput/utils/useDismissSearchOverlayOnTabBarPress"
 import { SearchByPhotoIconButton } from "app/Components/SearchByPhotoButton/SearchByPhotoIconButton"
 import { ICON_HIT_SLOP } from "app/Components/constants"
-import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { useDebouncedValue } from "app/utils/hooks/useDebouncedValue"
+import { useEnableArtsyLens } from "app/utils/hooks/useEnableArtsyLens"
 import { forwardRef, Fragment, useEffect, useImperativeHandle, useState } from "react"
 import { useTracking } from "react-tracking"
 
@@ -27,7 +27,7 @@ export const GlobalSearchInput = forwardRef<GlobalSearchInput, GlobalSearchInput
     const debouncedIsVisible = useDebouncedValue({ value: isVisible })
 
     const tracking = useTracking()
-    const enableArtsyLens = useExperimentFlag("onyx_artsy-lens")
+    const enableArtsyLens = useEnableArtsyLens()
 
     useEffect(() => {
       onOverlayVisibilityChange?.(isVisible)

--- a/src/app/Components/GlobalSearchInput/GlobalSearchInputOverlay.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInputOverlay.tsx
@@ -1,4 +1,4 @@
-import { OwnerType } from "@artsy/cohesion"
+import { ContextModule, ScreenOwnerType } from "@artsy/cohesion"
 import { Box, Flex, RoundSearchInput, Spacer, useSpace } from "@artsy/palette-mobile"
 import { Portal } from "@gorhom/portal"
 import { useNavigation } from "@react-navigation/native"
@@ -6,6 +6,7 @@ import { GlobalSearchInputOverlayEmptyState } from "app/Components/GlobalSearchI
 import { useSearch } from "app/Components/GlobalSearchInput/useSearch"
 import { SearchByPhotoButton } from "app/Components/SearchByPhotoButton/SearchByPhotoButton"
 import { SearchByPhotoIconButton } from "app/Components/SearchByPhotoButton/SearchByPhotoIconButton"
+import { tappedSearchByImage } from "app/Components/SearchByPhotoButton/tracks"
 import { DEFAULT_SCREEN_ANIMATION_DURATION } from "app/Components/constants"
 import { BOTTOM_TABS_HEIGHT } from "app/Navigation/AuthenticatedRoutes/Tabs"
 import { RecentSearches } from "app/Scenes/Search/RecentSearches"
@@ -32,6 +33,7 @@ import Animated, {
 } from "react-native-reanimated"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { graphql } from "react-relay"
+import { useTracking } from "react-tracking"
 
 export const globalSearchInputOverlayQuery = graphql`
   query GlobalSearchInputOverlayQuery($term: String!, $skipSearchQuery: Boolean!) {
@@ -106,7 +108,7 @@ const GlobalSearchInputOverlayContent: React.FC<{ query: string }> = ({ query })
 }
 
 export const GlobalSearchInputOverlay: React.FC<{
-  ownerType: OwnerType
+  ownerType: ScreenOwnerType
   visible: boolean
   hideModal: () => void
 }> = ({ hideModal, ownerType, visible }) => {
@@ -116,6 +118,7 @@ export const GlobalSearchInputOverlay: React.FC<{
   const { goBack, canGoBack } = useNavigation()
   const opacity = useSharedValue(0)
   const enableArtsyLens = useEnableArtsyLens()
+  const tracking = useTracking()
 
   useBackHandler(() => {
     if (!!canGoBack()) {
@@ -185,6 +188,13 @@ export const GlobalSearchInputOverlay: React.FC<{
                 <SearchByPhotoIconButton
                   testID="search-overlay-camera-icon"
                   onPress={() => {
+                    tracking.trackEvent(
+                      tappedSearchByImage({
+                        contextModule: ContextModule.searchOverlay,
+                        contextScreenOwnerType: ownerType,
+                        type: "search_input_icon",
+                      })
+                    )
                     hideModal()
                     navigate("/lens")
                   }}
@@ -208,6 +218,13 @@ export const GlobalSearchInputOverlay: React.FC<{
             <Flex px={2} pb={1}>
               <SearchByPhotoButton
                 onPress={() => {
+                  tracking.trackEvent(
+                    tappedSearchByImage({
+                      contextModule: ContextModule.searchOverlay,
+                      contextScreenOwnerType: ownerType,
+                      type: "search_overlay_button",
+                    })
+                  )
                   hideModal()
                   navigate("/lens")
                 }}

--- a/src/app/Components/GlobalSearchInput/GlobalSearchInputOverlay.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInputOverlay.tsx
@@ -16,10 +16,10 @@ import { SearchPills } from "app/Scenes/Search/SearchPills"
 import { SearchResults } from "app/Scenes/Search/SearchResults"
 import { TrendingSearches } from "app/Scenes/Search/TrendingSearches/TrendingSearches"
 import { SEARCH_PILLS } from "app/Scenes/Search/constants"
-import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { useBackHandler } from "app/utils/hooks/useBackHandler"
+import { useEnableArtsyLens } from "app/utils/hooks/useEnableArtsyLens"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { Suspense, useEffect, useState } from "react"
 import { ScrollView, StyleSheet } from "react-native"
@@ -115,7 +115,7 @@ export const GlobalSearchInputOverlay: React.FC<{
   const insets = useSafeAreaInsets()
   const { goBack, canGoBack } = useNavigation()
   const opacity = useSharedValue(0)
-  const enableArtsyLens = useExperimentFlag("onyx_artsy-lens")
+  const enableArtsyLens = useEnableArtsyLens()
 
   useBackHandler(() => {
     if (!!canGoBack()) {

--- a/src/app/Components/GlobalSearchInput/__tests__/GlobalSearchInput.tests.tsx
+++ b/src/app/Components/GlobalSearchInput/__tests__/GlobalSearchInput.tests.tsx
@@ -1,6 +1,7 @@
 import { OwnerType } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { GlobalSearchInput } from "app/Components/GlobalSearchInput/GlobalSearchInput"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
 import { navigate } from "app/system/navigation/navigate"
 import { useSelectedTab } from "app/utils/hooks/useSelectedTab"
@@ -31,6 +32,7 @@ describe("GlobalSearchInput", () => {
     jest.clearAllMocks()
     mockUseledTab.mockReturnValue("home")
     mockUseExperimentFlag.mockReturnValue(false)
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableArtsyLens: true })
   })
 
   it("renders the search label properly", () => {
@@ -63,6 +65,15 @@ describe("GlobalSearchInput", () => {
 
     it("hides the camera icon when the onyx_artsy-lens experiment is off", () => {
       mockUseExperimentFlag.mockReturnValue(false)
+
+      renderWithWrappers(<GlobalSearchInput ownerType={OwnerType.home} />)
+
+      expect(screen.queryByTestId("search-input-camera-icon")).not.toBeOnTheScreen()
+    })
+
+    it("hides the camera icon when AREnableArtsyLens is off, even if the experiment is on", () => {
+      mockUseExperimentFlag.mockImplementation((key) => key === "onyx_artsy-lens")
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableArtsyLens: false })
 
       renderWithWrappers(<GlobalSearchInput ownerType={OwnerType.home} />)
 

--- a/src/app/Components/GlobalSearchInput/__tests__/GlobalSearchInput.tests.tsx
+++ b/src/app/Components/GlobalSearchInput/__tests__/GlobalSearchInput.tests.tsx
@@ -97,7 +97,22 @@ describe("GlobalSearchInput", () => {
 
       expect(navigate).toHaveBeenCalledWith("/lens")
       expect(onOverlayVisibilityChange).not.toHaveBeenCalledWith(true)
-      expect(mockTrackEvent).not.toHaveBeenCalled()
+    })
+
+    it("reports the tap as the search input icon entry point", () => {
+      mockUseExperimentFlag.mockImplementation((key) => key === "onyx_artsy-lens")
+
+      renderWithWrappers(<GlobalSearchInput ownerType={OwnerType.home} />)
+
+      fireEvent.press(screen.getByTestId("search-input-camera-icon"))
+
+      expect(mockTrackEvent).toHaveBeenCalledExactlyOnceWith({
+        action: "tappedSearchByImage",
+        context_module: "header",
+        context_screen_owner_type: "home",
+        destination_screen_owner_type: "searchByImage",
+        type: "search_input_icon",
+      })
     })
   })
 

--- a/src/app/Components/GlobalSearchInput/__tests__/GlobalSearchInputOverlay.tests.tsx
+++ b/src/app/Components/GlobalSearchInput/__tests__/GlobalSearchInputOverlay.tests.tsx
@@ -5,6 +5,7 @@ import { GlobalSearchInputOverlay } from "app/Components/GlobalSearchInput/Globa
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
 import { navigate } from "app/system/navigation/navigate"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 jest.mock("app/system/flags/hooks/useExperimentFlag", () => ({
@@ -77,6 +78,22 @@ describe("GlobalSearchInputOverlay — Search by Photo entry point", () => {
     expect(navigate).toHaveBeenCalledWith("/lens")
   })
 
+  it("reports the button tap as the overlay button entry point", () => {
+    mockUseExperimentFlag.mockImplementation((key) => key === "onyx_artsy-lens")
+
+    renderOverlay()
+
+    fireEvent.press(screen.getByTestId("search-by-photo-button"))
+
+    expect(mockTrackEvent).toHaveBeenCalledExactlyOnceWith({
+      action: "tappedSearchByImage",
+      context_module: "searchOverlay",
+      context_screen_owner_type: "home",
+      destination_screen_owner_type: "searchByImage",
+      type: "search_overlay_button",
+    })
+  })
+
   describe("the camera icon inside the input", () => {
     it("carries the icon over from the collapsed search bar", () => {
       mockUseExperimentFlag.mockImplementation((key) => key === "onyx_artsy-lens")
@@ -119,6 +136,22 @@ describe("GlobalSearchInputOverlay — Search by Photo entry point", () => {
 
       expect(hideModal).toHaveBeenCalledTimes(1)
       expect(navigate).toHaveBeenCalledWith("/lens")
+    })
+
+    it("reports the tap against the overlay, not the search bar", () => {
+      mockUseExperimentFlag.mockImplementation((key) => key === "onyx_artsy-lens")
+
+      renderOverlay()
+
+      fireEvent.press(screen.getByTestId("search-overlay-camera-icon"))
+
+      expect(mockTrackEvent).toHaveBeenCalledExactlyOnceWith({
+        action: "tappedSearchByImage",
+        context_module: "searchOverlay",
+        context_screen_owner_type: "home",
+        destination_screen_owner_type: "searchByImage",
+        type: "search_input_icon",
+      })
     })
   })
 })

--- a/src/app/Components/GlobalSearchInput/__tests__/GlobalSearchInputOverlay.tests.tsx
+++ b/src/app/Components/GlobalSearchInput/__tests__/GlobalSearchInputOverlay.tests.tsx
@@ -2,6 +2,7 @@ import { OwnerType } from "@artsy/cohesion"
 import { PortalHost } from "@gorhom/portal"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { GlobalSearchInputOverlay } from "app/Components/GlobalSearchInput/GlobalSearchInputOverlay"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
 import { navigate } from "app/system/navigation/navigate"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
@@ -36,6 +37,16 @@ describe("GlobalSearchInputOverlay — Search by Photo entry point", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableArtsyLens: true })
+  })
+
+  it("hides the Search by Photo button when AREnableArtsyLens is off", () => {
+    mockUseExperimentFlag.mockImplementation((key) => key === "onyx_artsy-lens")
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableArtsyLens: false })
+
+    renderOverlay()
+
+    expect(screen.queryByTestId("search-by-photo-button")).not.toBeOnTheScreen()
   })
 
   it("renders the Search by Photo button when onyx_artsy-lens is on", () => {

--- a/src/app/Components/SearchByPhotoButton/SearchByPhotoButton.tsx
+++ b/src/app/Components/SearchByPhotoButton/SearchByPhotoButton.tsx
@@ -5,11 +5,12 @@ import { PixelRatio } from "react-native"
 interface SearchByPhotoButtonProps {
   onPress: () => void
   testID?: string
+  label?: string
   /** `Button`'s own vocabulary, passed straight through -- `fillLight` for the black Lens screens. */
   variant?: ButtonProps["variant"]
 }
 
-const LABEL = "Search by Photo"
+const DEFAULT_LABEL = "Search by Photo"
 
 const ICON_SIZE = 20
 
@@ -24,6 +25,7 @@ export const SEARCH_BY_PHOTO_BUTTON_SPACE = 50 * PixelRatio.getFontScale() + 10
 export const SearchByPhotoButton: React.FC<SearchByPhotoButtonProps> = ({
   onPress,
   testID = "search-by-photo-button",
+  label = DEFAULT_LABEL,
   variant = "fillDark",
 }) => {
   return (
@@ -36,7 +38,7 @@ export const SearchByPhotoButton: React.FC<SearchByPhotoButtonProps> = ({
       onPress={onPress}
       testID={testID}
     >
-      {LABEL}
+      {label}
     </Button>
   )
 }

--- a/src/app/Components/SearchByPhotoButton/tracks.ts
+++ b/src/app/Components/SearchByPhotoButton/tracks.ts
@@ -1,0 +1,23 @@
+import {
+  ActionType,
+  ContextModule,
+  OwnerType,
+  ScreenOwnerType,
+  TappedSearchByImage,
+} from "@artsy/cohesion"
+
+export const tappedSearchByImage = ({
+  contextModule,
+  contextScreenOwnerType,
+  type,
+}: {
+  contextModule: ContextModule
+  contextScreenOwnerType: ScreenOwnerType
+  type: TappedSearchByImage["type"]
+}): TappedSearchByImage => ({
+  action: ActionType.tappedSearchByImage,
+  context_module: contextModule,
+  context_screen_owner_type: contextScreenOwnerType,
+  destination_screen_owner_type: OwnerType.searchByImage,
+  type,
+})

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveFlightAnimation.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveFlightAnimation.tsx
@@ -27,8 +27,6 @@ const BASE_SCALE = 1
 const POP_START_SCALE = 0.4
 const POP_OVERSHOOT_SCALE = 1.1
 
-const BADGE_APPROXIMATE_LEFT = 20
-
 interface InfiniteDiscoverySaveFlightAnimationProps {
   artwork: NewUserOnboardingSavedArtwork | null
   onComplete: () => void
@@ -45,7 +43,7 @@ export const InfiniteDiscoverySaveFlightAnimation: React.FC<
 
   const startLeft = screenWidth / 2 - CARD_WIDTH / 2
   const startTop = screenHeight / 2 - CARD_HEIGHT / 2
-  const endLeft = BADGE_APPROXIMATE_LEFT
+  const endLeft = 0
   const endTop = safeAreaInsets.top
 
   return (

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
@@ -97,7 +97,7 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
       <BottomSheetView>
         <Flex px={2} pt={2} style={{ paddingBottom: safeAreaInsets.bottom + 16 }}>
           <View style={{ height: FAN_CONTAINER_HEIGHT * scale, width: REFERENCE_WIDTH * scale }}>
-            {savedArtworks.map((artwork, index) => {
+            {savedArtworks.slice(0, CARD_COUNT).map((artwork, index) => {
               const config = FAN_CONFIGS[index]
               return (
                 // `style` sets the card's final fanned-out position; `from`/`animate` offset it

--- a/src/app/Scenes/InfiniteDiscovery/hooks/__tests__/useInfiniteDiscoveryCardSave.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/__tests__/useInfiniteDiscoveryCardSave.tests.tsx
@@ -1,4 +1,5 @@
 import { ScreenDimensionsProvider } from "@artsy/palette-mobile"
+import FastImage from "@d11/react-native-fast-image"
 import { act, renderHook } from "@testing-library/react-native"
 import { InfiniteDiscoveryArtworkCard_artwork$data } from "__generated__/InfiniteDiscoveryArtworkCard_artwork.graphql"
 import * as useSaveArtworkToArtworkListsModule from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
@@ -11,6 +12,10 @@ const mockTrack = { savedArtwork: jest.fn() }
 jest.mock("app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking", () => ({
   useInfiniteDiscoveryTracking: () => mockTrack,
 }))
+
+jest.mock("@d11/react-native-fast-image", () => ({ preload: jest.fn() }))
+
+const mockFastImagePreload = FastImage.preload as jest.Mock
 
 jest.mock("react-native-reanimated", () => ({
   ...require("react-native-reanimated/mock"),
@@ -139,6 +144,9 @@ describe("useInfiniteDiscoveryCardSave", () => {
         expect.objectContaining({ internalID: "artwork-1", blurhash: "blurhash-1" })
       )
       expect(getState().sessionState.newUserOnboardingSavedArtworks).toEqual([])
+      expect(mockFastImagePreload).toHaveBeenCalledWith([
+        { uri: result.current.pendingSaveAnimationArtwork?.url },
+      ])
     })
 
     it("commits the artwork to the onboarding list immediately when Reduce Motion is enabled, skipping the flight animation", () => {

--- a/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave.ts
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave.ts
@@ -1,5 +1,6 @@
 import { useScreenDimensions } from "@artsy/palette-mobile"
 import { createGeminiUrl } from "@artsy/palette-mobile/dist/utils/createGeminiUrl"
+import FastImage from "@d11/react-native-fast-image"
 import { InfiniteDiscoveryArtworkCard_artwork$data } from "__generated__/InfiniteDiscoveryArtworkCard_artwork.graphql"
 import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
 import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking"
@@ -28,7 +29,9 @@ export const useInfiniteDiscoveryCardSave = (
   const track = useInfiniteDiscoveryTracking()
   const isReducedMotionEnabled = useReducedMotion()
 
-  const { hasSavedArtworks } = GlobalStore.useAppState((state) => state.infiniteDiscovery)
+  const hasSavedArtworks = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.hasSavedArtworks
+  )
   const setHasSavedArtworks = GlobalStore.actions.infiniteDiscovery.setHasSavedArtworks
   const isNewUserOnboardingSession =
     GlobalStore.useAppState((state) => state.onboarding.onboardingState) === "incomplete"
@@ -47,11 +50,17 @@ export const useInfiniteDiscoveryCardSave = (
 
   const buildOnboardingSavedArtwork = (
     artwork: NonNullable<InfiniteDiscoveryArtworkCard_artwork$data>
-  ) => ({
-    internalID: artwork.internalID,
-    url: getThumbnailUrl(artwork.images[0]?.url ?? "", screenWidth),
-    blurhash: artwork.images[0]?.blurhash,
-  })
+  ) => {
+    const url = getThumbnailUrl(artwork.images[0]?.url ?? "", screenWidth)
+
+    FastImage.preload([{ uri: url }])
+
+    return {
+      internalID: artwork.internalID,
+      url,
+      blurhash: artwork.images[0]?.blurhash,
+    }
+  }
 
   const addOnboardingSavedArtwork = () => {
     if (!artwork) return

--- a/src/app/Scenes/Lens/Components/LensCameraButtons.tsx
+++ b/src/app/Scenes/Lens/Components/LensCameraButtons.tsx
@@ -1,4 +1,4 @@
-import { BoltFillIcon, ImageSetIcon } from "@artsy/icons/native"
+import { BoltFillIcon, PhotographIcon } from "@artsy/icons/native"
 import { DEFAULT_HIT_SLOP, Flex, FlexProps, Touchable, useSpace } from "@artsy/palette-mobile"
 import { LensCapturePhotoButton } from "app/Scenes/Lens/Components/LensCapturePhotoButton"
 
@@ -84,7 +84,7 @@ export const LensCameraButtons: React.FC<LensCameraButtonsProps> = (props) => {
           alignItems="center"
           bg="mono0"
         >
-          <ImageSetIcon fill="mono100" width={18} height={18} />
+          <PhotographIcon testID="lens-library-photo-icon" fill="mono100" width={18} height={18} />
         </Flex>
       </Touchable>
     </Flex>

--- a/src/app/Scenes/Lens/Components/LensCameraPreview.tsx
+++ b/src/app/Scenes/Lens/Components/LensCameraPreview.tsx
@@ -24,7 +24,7 @@ export type LensCameraPreviewHandle = {
 
 interface LensCameraPreviewProps {
   isActive: boolean
-  torchEnabled: boolean
+  torchMode?: "on" | "off"
   onStatusChange: (status: LensCameraStatus) => void
   onCapture: (photo: LensPhoto) => void
   onError: (error: unknown) => void
@@ -32,7 +32,7 @@ interface LensCameraPreviewProps {
 
 export const LensCameraPreview = forwardRef<LensCameraPreviewHandle, LensCameraPreviewProps>(
   (props, ref) => {
-    const { isActive, torchEnabled, onStatusChange, onCapture, onError } = props
+    const { isActive, torchMode, onStatusChange, onCapture, onError } = props
 
     const { hasPermission, canRequestPermission, requestPermission } = useCameraPermission()
     const device = useCameraDevice("back")
@@ -104,10 +104,7 @@ export const LensCameraPreview = forwardRef<LensCameraPreviewHandle, LensCameraP
         device={device}
         outputs={[photoOutput]}
         isActive={isActive}
-        // Omitted, not "off", when disabled: an explicit torchMode on the first render makes
-        // vision-camera call setTorchMode() before the CameraX session opens, which throws
-        // `Camera is not active` on Android and tears the session down.
-        torchMode={torchEnabled ? "on" : undefined}
+        torchMode={torchMode}
         onError={(error) => {
           setHasErrored(true)
           onError(error)

--- a/src/app/Scenes/Lens/Components/LensHeader.tsx
+++ b/src/app/Scenes/Lens/Components/LensHeader.tsx
@@ -1,12 +1,11 @@
-import { BackButton, DEFAULT_HIT_SLOP, Flex, NAVBAR_HEIGHT, Text } from "@artsy/palette-mobile"
+import { BackButton, DEFAULT_HIT_SLOP, Flex, NAVBAR_HEIGHT } from "@artsy/palette-mobile"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 interface LensHeaderProps {
   onClose: () => void
-  title?: string
 }
 
-export const LensHeader: React.FC<LensHeaderProps> = ({ onClose, title }) => {
+export const LensHeader: React.FC<LensHeaderProps> = ({ onClose }) => {
   const insets = useSafeAreaInsets()
 
   return (
@@ -18,14 +17,6 @@ export const LensHeader: React.FC<LensHeaderProps> = ({ onClose, title }) => {
       px={2}
     >
       <BackButton color="mono0" showX onPress={onClose} hitSlop={DEFAULT_HIT_SLOP} />
-
-      {!!title && (
-        <Flex position="absolute" left={0} right={0} alignItems="center" pointerEvents="none">
-          <Text variant="sm-display" color="mono0">
-            {title}
-          </Text>
-        </Flex>
-      )}
     </Flex>
   )
 }

--- a/src/app/Scenes/Lens/Lens.tsx
+++ b/src/app/Scenes/Lens/Lens.tsx
@@ -1,3 +1,4 @@
+import { OwnerType } from "@artsy/cohesion"
 import { NavigationContainer, NavigationIndependentTree } from "@react-navigation/native"
 import { createStackNavigator } from "@react-navigation/stack"
 import { useNavigationTheme } from "app/Navigation/useNavigationTheme"
@@ -5,6 +6,8 @@ import { LensAnalyzing } from "app/Scenes/Lens/Screens/LensAnalyzing"
 import { LensCamera } from "app/Scenes/Lens/Screens/LensCamera"
 import { LensResultsScreen } from "app/Scenes/Lens/Screens/LensResults"
 import { LensNavigationStack } from "app/Scenes/Lens/types"
+import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
+import { screen } from "app/utils/track/helpers"
 import { StatusBar } from "react-native"
 
 const Stack = createStackNavigator<LensNavigationStack>()
@@ -22,27 +25,31 @@ export const Lens: React.FC = () => {
   const theme = useNavigationTheme()
 
   return (
-    <NavigationIndependentTree>
-      <NavigationContainer theme={theme}>
-        <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
-        <Stack.Navigator
-          detachInactiveScreens={false}
-          initialRouteName="LensCamera"
-          screenOptions={{ headerShown: false }}
-        >
-          <Stack.Screen name="LensCamera" component={LensCamera} />
-          <Stack.Screen
-            name="LensAnalyzing"
-            component={LensAnalyzing}
-            options={{ animation: "fade" }}
-          />
-          <Stack.Screen
-            name="LensResults"
-            component={LensResultsScreen}
-            options={{ animation: "fade" }}
-          />
-        </Stack.Navigator>
-      </NavigationContainer>
-    </NavigationIndependentTree>
+    <ProvideScreenTrackingWithCohesionSchema
+      info={screen({ context_screen_owner_type: OwnerType.searchByImage })}
+    >
+      <NavigationIndependentTree>
+        <NavigationContainer theme={theme}>
+          <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
+          <Stack.Navigator
+            detachInactiveScreens={false}
+            initialRouteName="LensCamera"
+            screenOptions={{ headerShown: false }}
+          >
+            <Stack.Screen name="LensCamera" component={LensCamera} />
+            <Stack.Screen
+              name="LensAnalyzing"
+              component={LensAnalyzing}
+              options={{ animation: "fade" }}
+            />
+            <Stack.Screen
+              name="LensResults"
+              component={LensResultsScreen}
+              options={{ animation: "fade" }}
+            />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </NavigationIndependentTree>
+    </ProvideScreenTrackingWithCohesionSchema>
   )
 }

--- a/src/app/Scenes/Lens/Lens.tsx
+++ b/src/app/Scenes/Lens/Lens.tsx
@@ -8,7 +8,6 @@ import { LensResultsScreen } from "app/Scenes/Lens/Screens/LensResults"
 import { LensNavigationStack } from "app/Scenes/Lens/types"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
-import { StatusBar } from "react-native"
 
 const Stack = createStackNavigator<LensNavigationStack>()
 
@@ -30,7 +29,6 @@ export const Lens: React.FC = () => {
     >
       <NavigationIndependentTree>
         <NavigationContainer theme={theme}>
-          <StatusBar barStyle="light-content" translucent backgroundColor="transparent" />
           <Stack.Navigator
             detachInactiveScreens={false}
             initialRouteName="LensCamera"

--- a/src/app/Scenes/Lens/Screens/LensAnalyzing.tsx
+++ b/src/app/Scenes/Lens/Screens/LensAnalyzing.tsx
@@ -85,7 +85,12 @@ export const LensAnalyzing: React.FC<Props> = ({ route, navigation }) => {
 
         // LensResults owns the cropped file after navigation.
         tempPhotoUris.current = tempPhotoUris.current.filter((uri) => uri !== cropped.uri)
-        navigation.replace("LensResults", { s3Bucket: bucket, s3Key: key, photoUri: cropped.uri })
+        navigation.replace("LensResults", {
+          s3Bucket: bucket,
+          s3Key: key,
+          photoUri: cropped.uri,
+          fromLibrary: !!photo.fromLibrary,
+        })
       })
       .catch((error) => {
         if (cancelled) {

--- a/src/app/Scenes/Lens/Screens/LensAnalyzing.tsx
+++ b/src/app/Scenes/Lens/Screens/LensAnalyzing.tsx
@@ -140,7 +140,7 @@ export const LensAnalyzing: React.FC<Props> = ({ route, navigation }) => {
               height={displayCard.height}
               borderRadius={16}
               overflow="hidden"
-              bg="mono10"
+              bg="mono100"
               justifyContent="center"
               alignItems="center"
             >

--- a/src/app/Scenes/Lens/Screens/LensCamera.tsx
+++ b/src/app/Scenes/Lens/Screens/LensCamera.tsx
@@ -1,4 +1,5 @@
-import { Flex, Spinner, Theme } from "@artsy/palette-mobile"
+import { CameraStrokeIcon } from "@artsy/icons/native"
+import { Flex, Spinner, Text, Theme } from "@artsy/palette-mobile"
 import { useIsFocused } from "@react-navigation/native"
 import { StackScreenProps } from "@react-navigation/stack"
 import { captureException, withScope } from "@sentry/react-native"
@@ -146,7 +147,21 @@ export const LensCamera: React.FC<Props> = ({ navigation }) => {
         )}
 
         <Flex position="absolute" top={0} left={0} right={0}>
-          <LensHeader title="Artsy Lens" onClose={handleClose} />
+          <LensHeader onClose={handleClose} />
+
+          <Flex alignItems="center" px={4} mt={1} pointerEvents="none">
+            <Flex flexDirection="row" alignItems="center">
+              <CameraStrokeIcon fill="mono0" width={18} height={18} />
+
+              <Text variant="sm-display" color="mono0" ml={0.5}>
+                ARTSY LENS
+              </Text>
+            </Flex>
+
+            <Text variant="sm" color="mono0" textAlign="center" mt={1}>
+              Take a photo and we'll match it with a similar artwork.
+            </Text>
+          </Flex>
         </Flex>
 
         <Flex position="absolute" bottom={0} left={0} right={0} height={LENS_CAMERA_BUTTONS_HEIGHT}>

--- a/src/app/Scenes/Lens/Screens/LensCamera.tsx
+++ b/src/app/Scenes/Lens/Screens/LensCamera.tsx
@@ -1,6 +1,6 @@
 import { CameraStrokeIcon } from "@artsy/icons/native"
 import { Flex, Spinner, Text, Theme } from "@artsy/palette-mobile"
-import { useIsFocused } from "@react-navigation/native"
+import { useFocusEffect, useIsFocused } from "@react-navigation/native"
 import { StackScreenProps } from "@react-navigation/stack"
 import { captureException, withScope } from "@sentry/react-native"
 import {
@@ -17,11 +17,12 @@ import { LensCornerBrackets } from "app/Scenes/Lens/Components/LensCornerBracket
 import { LensHeader } from "app/Scenes/Lens/Components/LensHeader"
 import { LensPermissionPlaceholder } from "app/Scenes/Lens/Components/LensPermissionPlaceholder"
 import { LensNavigationStack } from "app/Scenes/Lens/types"
+import { GlobalStore } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
 import { requestPhotos } from "app/utils/requestPhotos"
 import useAppState from "app/utils/useAppState"
-import { useRef, useState } from "react"
-import { AppState, Linking } from "react-native"
+import { useCallback, useRef, useState } from "react"
+import { AppState, Linking, StatusBar } from "react-native"
 
 type Props = StackScreenProps<LensNavigationStack, "LensCamera">
 
@@ -41,6 +42,8 @@ export const LensCamera: React.FC<Props> = ({ navigation }) => {
 
   const isFocused = useIsFocused()
   const [appState, setAppState] = useState(AppState.currentState)
+  const theme = GlobalStore.useAppState((state) => state.devicePrefs.colorScheme)
+
   useAppState({ onChange: setAppState })
   const isActive = isFocused && appState === "active"
 
@@ -95,6 +98,19 @@ export const LensCamera: React.FC<Props> = ({ navigation }) => {
       reportError("selectPhotosFromLibrary", error)
     }
   }
+
+  useFocusEffect(
+    useCallback(() => {
+      requestAnimationFrame(() => {
+        // Explicitly set the status bar style to Light Content
+        StatusBar.setBarStyle("light-content", true)
+      })
+
+      return () => {
+        StatusBar.setBarStyle(theme === "dark" ? "light-content" : "dark-content", true)
+      }
+    }, [theme])
+  )
 
   return (
     <Theme theme="v3light">

--- a/src/app/Scenes/Lens/Screens/LensCamera.tsx
+++ b/src/app/Scenes/Lens/Screens/LensCamera.tsx
@@ -34,7 +34,7 @@ type LensScreenState = LensCameraStatus | { kind: "loading" }
  */
 export const LensCamera: React.FC<Props> = ({ navigation }) => {
   const [state, setState] = useState<LensScreenState>({ kind: "loading" })
-  const [torchEnabled, setTorchEnabled] = useState(false)
+  const [torchMode, setTorchMode] = useState<"on" | "off">()
   const camera = useRef<LensCameraPreviewHandle>(null)
   // Measured, not read from useWindowDimensions(), which over-reports height on Android -- see
   // `LensPhoto.captureContainerWidth`. With the window's value the brackets sit below true center.
@@ -67,7 +67,7 @@ export const LensCamera: React.FC<Props> = ({ navigation }) => {
   }
 
   const handleToggleTorch = () => {
-    setTorchEnabled((current) => !current)
+    setTorchMode((current) => (current === "on" ? "off" : "on"))
   }
 
   const handleSelectFromLibrary = async () => {
@@ -141,7 +141,7 @@ export const LensCamera: React.FC<Props> = ({ navigation }) => {
         <LensCameraPreview
           ref={camera}
           isActive={!!isActive && state.kind === "ready"}
-          torchEnabled={torchEnabled}
+          torchMode={torchMode}
           onStatusChange={setState}
           onCapture={(photo) =>
             navigation.navigate("LensAnalyzing", {
@@ -185,7 +185,7 @@ export const LensCamera: React.FC<Props> = ({ navigation }) => {
             mode={state.kind === "ready" ? "camera" : "libraryOnly"}
             isCameraInitialized={state.kind === "ready"}
             deviceHasTorch={state.kind === "ready" && state.hasTorch}
-            isTorchEnabled={torchEnabled}
+            isTorchEnabled={torchMode === "on"}
             onTakePhoto={handleTakePhoto}
             onToggleTorch={handleToggleTorch}
             onSelectFromLibrary={handleSelectFromLibrary}

--- a/src/app/Scenes/Lens/Screens/LensResults.tsx
+++ b/src/app/Scenes/Lens/Screens/LensResults.tsx
@@ -21,7 +21,8 @@ import { ExtractNodeType } from "app/utils/relayHelpers"
 import { Suspense, useEffect } from "react"
 import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 
-const MATCHES_TITLE = "Here are some matches to your photo"
+const MATCHES_TITLE = "Great taste! Here are some matches to your photo"
+const NO_MATCHES_TITLE = "Unfortunately, we couldn't find great matches for that photo"
 const SEARCHING_TITLE = "Searching for matches..."
 
 type Props = StackScreenProps<LensNavigationStack, "LensResults">
@@ -56,7 +57,7 @@ const LensResults: React.FC<Props> = ({ route, navigation }) => {
       <LensResultsHeader
         onBack={goBack}
         photoUri={photoUri}
-        title={hasNoMatches ? undefined : MATCHES_TITLE}
+        title={hasNoMatches ? NO_MATCHES_TITLE : MATCHES_TITLE}
       />
 
       <Screen.Body fullwidth pt={1}>
@@ -68,12 +69,11 @@ const LensResults: React.FC<Props> = ({ route, navigation }) => {
         />
       </Screen.Body>
 
-      {/* Empty state only: with matches on screen, tapping one is the action, and a permanent CTA
-          over the grid would compete with it. */}
       {!!hasNoMatches && (
         <Screen.BottomView>
           <SearchByPhotoButton
             testID="lensResultsSearchByPhotoButton"
+            label="Try another photo"
             onPress={() => restartSearch(navigation)}
           />
         </Screen.BottomView>
@@ -94,9 +94,7 @@ const ArtworksGrid: React.FC<{
       contextScreenOwnerType={OwnerType.search}
       contextScreen={OwnerType.search}
       ListEmptyComponent={
-        <SimpleMessage m={2}>
-          We couldn't find any matches for that image. Try another photo.
-        </SimpleMessage>
+        <SimpleMessage m={2}>No matches found. Please try another photo.</SimpleMessage>
       }
       hasMore={hasNext}
       isLoading={isLoadingNext}

--- a/src/app/Scenes/Lens/Screens/LensResults.tsx
+++ b/src/app/Scenes/Lens/Screens/LensResults.tsx
@@ -1,4 +1,10 @@
-import { OwnerType } from "@artsy/cohesion"
+import {
+  ActionType,
+  ContextModule,
+  OwnerType,
+  SearchedByImageWithNoResults,
+  SearchedByImageWithResults,
+} from "@artsy/cohesion"
 import { Screen, SimpleMessage } from "@artsy/palette-mobile"
 import { StackScreenProps } from "@react-navigation/stack"
 import { LensResultsQuery } from "__generated__/LensResultsQuery.graphql"
@@ -20,6 +26,7 @@ import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import { ExtractNodeType } from "app/utils/relayHelpers"
 import { Suspense, useEffect } from "react"
 import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
+import { useTracking } from "react-tracking"
 
 const MATCHES_TITLE = "Great taste! Here are some matches to your photo"
 const NO_MATCHES_TITLE = "Unfortunately, we couldn't find great matches for that photo"
@@ -35,7 +42,8 @@ const restartSearch = (navigation: Navigation) => {
 }
 
 const LensResults: React.FC<Props> = ({ route, navigation }) => {
-  const { s3Bucket, s3Key, photoUri } = route.params
+  const { s3Bucket, s3Key, photoUri, fromLibrary } = route.params
+  const tracking = useTracking()
 
   const queryData = useLazyLoadQuery<LensResultsQuery>(lensResultsQuery, {
     s3Bucket,
@@ -51,6 +59,17 @@ const LensResults: React.FC<Props> = ({ route, navigation }) => {
   const artworks = extractNodes(data.artworksByImageConnection)
   // Suspense holds the placeholder until the query resolves, so empty here means no matches.
   const hasNoMatches = artworks.length === 0
+
+  useEffect(() => {
+    const photoSource = fromLibrary ? "photo_library" : "camera"
+
+    tracking.trackEvent(
+      hasNoMatches
+        ? tracks.searchedByImageWithNoResults(photoSource)
+        : tracks.searchedByImageWithResults(photoSource)
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <Screen>
@@ -91,8 +110,9 @@ const ArtworksGrid: React.FC<{
   return (
     <MasonryInfiniteScrollArtworkGrid
       artworks={artworks}
-      contextScreenOwnerType={OwnerType.search}
-      contextScreen={OwnerType.search}
+      contextModule={ContextModule.artworkGrid}
+      contextScreenOwnerType={OwnerType.searchByImage}
+      contextScreen={OwnerType.searchByImage}
       ListEmptyComponent={
         <SimpleMessage m={2}>No matches found. Please try another photo.</SimpleMessage>
       }
@@ -101,6 +121,21 @@ const ArtworksGrid: React.FC<{
       loadMore={loadMore}
     />
   )
+}
+
+type PhotoSource = SearchedByImageWithResults["photo_source"]
+
+const tracks = {
+  searchedByImageWithResults: (photoSource: PhotoSource): SearchedByImageWithResults => ({
+    action: ActionType.searchedByImageWithResults,
+    context_owner_type: OwnerType.searchByImage,
+    photo_source: photoSource,
+  }),
+  searchedByImageWithNoResults: (photoSource: PhotoSource): SearchedByImageWithNoResults => ({
+    action: ActionType.searchedByImageWithNoResults,
+    context_owner_type: OwnerType.searchByImage,
+    photo_source: photoSource,
+  }),
 }
 
 const artworksFragment = graphql`

--- a/src/app/Scenes/Lens/Screens/__tests__/LensResults.tests.tsx
+++ b/src/app/Scenes/Lens/Screens/__tests__/LensResults.tests.tsx
@@ -4,6 +4,7 @@ import { LensResultsTestsQuery } from "__generated__/LensResultsTestsQuery.graph
 import { LensResultsScreen } from "app/Scenes/Lens/Screens/LensResults"
 import { discardTempPhotos } from "app/Scenes/Lens/utils/discardTempPhotos"
 import { goBack, navigate } from "app/system/navigation/navigate"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { BackHandler } from "react-native"
 import { graphql } from "react-relay"
@@ -14,6 +15,7 @@ jest.mock("app/Scenes/Lens/utils/discardTempPhotos", () => ({
 
 const mockNavigate = jest.fn()
 const photoUri = "file:///tmp/cropped.jpg"
+let fromLibrary = false
 
 describe("LensResults", () => {
   const { renderWithRelay } = setupTestWrapper<LensResultsTestsQuery>({
@@ -23,7 +25,7 @@ describe("LensResults", () => {
           {
             key: "LensResults",
             name: "LensResults",
-            params: { s3Bucket: "my-bucket", s3Key: "my-key", photoUri },
+            params: { s3Bucket: "my-bucket", s3Key: "my-key", photoUri, fromLibrary },
           } as any
         }
         navigation={{ navigate: mockNavigate } as any}
@@ -39,6 +41,7 @@ describe("LensResults", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    fromLibrary = false
   })
 
   it("uses the artwork's standard link when a result is pressed", () => {
@@ -128,5 +131,53 @@ describe("LensResults", () => {
     unmount()
 
     expect(discardTempPhotos).toHaveBeenCalledWith([photoUri])
+  })
+
+  describe("tracking", () => {
+    it("reports a search that found matches", () => {
+      renderWithRelay({ Artwork: () => ({ title: "Cool Painting" }) })
+
+      expect(mockTrackEvent).toHaveBeenCalledExactlyOnceWith({
+        action: "searchedByImageWithResults",
+        context_owner_type: "searchByImage",
+        photo_source: "camera",
+      })
+    })
+
+    it("reports a search that found nothing", () => {
+      renderWithRelay({ ArtworkConnection: () => ({ edges: [] }) })
+
+      expect(mockTrackEvent).toHaveBeenCalledExactlyOnceWith({
+        action: "searchedByImageWithNoResults",
+        context_owner_type: "searchByImage",
+        photo_source: "camera",
+      })
+    })
+
+    it("separates a photo picked from the library from a capture", () => {
+      fromLibrary = true
+
+      renderWithRelay({ Artwork: () => ({ title: "Cool Painting" }) })
+
+      expect(mockTrackEvent).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ photo_source: "photo_library" })
+      )
+    })
+
+    it("attributes a tapped result to the image search, not to text search", () => {
+      renderWithRelay({ Artwork: () => ({ title: "Cool Painting", slug: "cool-painting" }) })
+
+      fireEvent.press(screen.getByTestId("artworkGridItem-Cool Painting"))
+
+      expect(mockTrackEvent).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          action: "tappedMainArtworkGrid",
+          context_module: "artworkGrid",
+          context_screen: "searchByImage",
+          context_screen_owner_type: "searchByImage",
+          destination_screen_owner_type: "artwork",
+        })
+      )
+    })
   })
 })

--- a/src/app/Scenes/Lens/Screens/__tests__/LensResults.tests.tsx
+++ b/src/app/Scenes/Lens/Screens/__tests__/LensResults.tests.tsx
@@ -81,6 +81,9 @@ describe("LensResults", () => {
   it("offers a way to search another photo when there are no matches", () => {
     renderWithRelay({ ArtworkConnection: () => ({ edges: [] }) })
 
+    expect(screen.getByText("No matches found. Please try another photo.")).toBeOnTheScreen()
+    expect(screen.getByText("Try another photo")).toBeOnTheScreen()
+
     fireEvent.press(screen.getByTestId("lensResultsSearchByPhotoButton"))
 
     expect(mockNavigate).toHaveBeenCalledWith("LensCamera")
@@ -105,13 +108,16 @@ describe("LensResults", () => {
   it("tells the user these are matches to their photo", () => {
     renderWithRelay({ Artwork: () => ({ title: "Cool Painting" }) })
 
-    expect(screen.getByText("Here are some matches to your photo")).toBeTruthy()
+    expect(screen.getByText("Great taste! Here are some matches to your photo")).toBeTruthy()
   })
 
   it("claims no matches when there are none", () => {
     renderWithRelay({ ArtworkConnection: () => ({ edges: [] }) })
 
-    expect(screen.queryByText("Here are some matches to your photo")).toBeNull()
+    expect(
+      screen.getByText("Unfortunately, we couldn't find great matches for that photo")
+    ).toBeOnTheScreen()
+    expect(screen.queryByText("Great taste! Here are some matches to your photo")).toBeNull()
   })
 
   it("deletes the searched photo on the way out", () => {

--- a/src/app/Scenes/Lens/__tests__/LensAnalyzing.tests.tsx
+++ b/src/app/Scenes/Lens/__tests__/LensAnalyzing.tests.tsx
@@ -59,6 +59,7 @@ describe("LensAnalyzing", () => {
         s3Bucket: "my-bucket",
         s3Key: "my-key",
         photoUri: portraitCrop.uri,
+        fromLibrary: false,
       })
     )
   })

--- a/src/app/Scenes/Lens/__tests__/LensCamera.tests.tsx
+++ b/src/app/Scenes/Lens/__tests__/LensCamera.tests.tsx
@@ -47,6 +47,16 @@ describe("LensCamera", () => {
     expect(goBack).toHaveBeenCalledTimes(1)
   })
 
+  it("shows the Artsy Lens guidance and a photo icon for the library", () => {
+    renderWithWrappers(<LensCamera {...navigationProps} />)
+
+    expect(screen.getByText("ARTSY LENS")).toBeOnTheScreen()
+    expect(
+      screen.getByText("Take a photo and we'll match it with a similar artwork.")
+    ).toBeOnTheScreen()
+    expect(screen.getByTestId("lens-library-photo-icon")).toBeOnTheScreen()
+  })
+
   it("shows 'Go to Settings' (not another permission prompt) once camera access has been denied", () => {
     jest.mocked(useCameraPermission).mockReturnValue({
       hasPermission: false,

--- a/src/app/Scenes/Lens/__tests__/LensCamera.tests.tsx
+++ b/src/app/Scenes/Lens/__tests__/LensCamera.tests.tsx
@@ -3,7 +3,7 @@ import { LensCamera } from "app/Scenes/Lens/Screens/LensCamera"
 import { goBack } from "app/system/navigation/navigate"
 import { requestPhotos } from "app/utils/requestPhotos"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
-import { useCameraPermission } from "react-native-vision-camera"
+import { useCameraDevice, useCameraPermission } from "react-native-vision-camera"
 
 jest.mock("app/utils/requestPhotos", () => ({
   requestPhotos: jest.fn(),
@@ -20,6 +20,7 @@ const navigationProps = {
 describe("LensCamera", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.mocked(useCameraDevice).mockReturnValue(undefined)
   })
 
   it("shows the permission placeholder (with the library button still enabled) when camera access is undetermined", () => {
@@ -55,6 +56,29 @@ describe("LensCamera", () => {
       screen.getByText("Take a photo and we'll match it with a similar artwork.")
     ).toBeOnTheScreen()
     expect(screen.getByTestId("lens-library-photo-icon")).toBeOnTheScreen()
+  })
+
+  it("turns the camera torch off after it has been enabled", () => {
+    jest.mocked(useCameraPermission).mockReturnValue({
+      hasPermission: true,
+      canRequestPermission: false,
+      requestPermission: jest.fn(),
+      status: "authorized",
+    } as any)
+    jest.mocked(useCameraDevice).mockReturnValue({
+      hasTorch: true,
+      supportsFocusMetering: true,
+    } as any)
+
+    renderWithWrappers(<LensCamera {...navigationProps} />)
+
+    expect(screen.UNSAFE_getByType("Camera" as any).props.torchMode).toBeUndefined()
+
+    fireEvent.press(screen.getByTestId("lens-torch-button"))
+    expect(screen.UNSAFE_getByType("Camera" as any).props.torchMode).toBe("on")
+
+    fireEvent.press(screen.getByTestId("lens-torch-button"))
+    expect(screen.UNSAFE_getByType("Camera" as any).props.torchMode).toBe("off")
   })
 
   it("shows 'Go to Settings' (not another permission prompt) once camera access has been denied", () => {

--- a/src/app/Scenes/Lens/types.ts
+++ b/src/app/Scenes/Lens/types.ts
@@ -26,5 +26,6 @@ export type LensNavigationStack = {
     s3Bucket: string
     s3Key: string
     photoUri: string
+    fromLibrary: boolean
   }
 }

--- a/src/app/Scenes/Search/TrendingSearches/TrendingSearches.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/TrendingSearches.tsx
@@ -12,7 +12,7 @@ import {
   TrendingPeriod,
   useTrendingSearches,
 } from "app/Scenes/Search/TrendingSearches/useTrendingSearches"
-import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
+import { useEnableArtsyLens } from "app/utils/hooks/useEnableArtsyLens"
 import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
 import { times } from "lodash"
 import { startTransition, useEffect, useState } from "react"
@@ -21,7 +21,7 @@ import { useTracking } from "react-tracking"
 
 export const TrendingSearches: React.FC = () => {
   const tabBarHeight = useBottomTabBarHeight()
-  const enableArtsyLens = useExperimentFlag("onyx_artsy-lens")
+  const enableArtsyLens = useEnableArtsyLens()
   const [period, setPeriod] = useState<TrendingPeriod>("ONE_DAY")
 
   const handlePeriodChange = (next: TrendingPeriod) => {

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -189,6 +189,12 @@ export const features = {
     showInDevMenu: true,
     echoFlagKey: "AREnableGlobalMapList",
   },
+  AREnableArtsyLens: {
+    description: "Enable Artsy Lens (reverse-image-search camera) entry points",
+    readyForRelease: false,
+    showInDevMenu: true,
+    echoFlagKey: "AREnableArtsyLens",
+  },
 } satisfies { [key: string]: FeatureDescriptor }
 
 export interface DevToggleDescriptor {

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -191,7 +191,7 @@ export const features = {
   },
   AREnableArtsyLens: {
     description: "Enable Artsy Lens (reverse-image-search camera) entry points",
-    readyForRelease: false,
+    readyForRelease: true,
     showInDevMenu: true,
     echoFlagKey: "AREnableArtsyLens",
   },

--- a/src/app/utils/hooks/useEnableArtsyLens.ts
+++ b/src/app/utils/hooks/useEnableArtsyLens.ts
@@ -1,0 +1,9 @@
+import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+
+export function useEnableArtsyLens() {
+  const isReleased = useFeatureFlag("AREnableArtsyLens")
+  const isRolledOut = useExperimentFlag("onyx_artsy-lens")
+
+  return isReleased && isRolledOut
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,12 +22,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@artsy/cohesion@npm:4.396.0":
-  version: 4.396.0
-  resolution: "@artsy/cohesion@npm:4.396.0"
+"@artsy/cohesion@npm:4.397.0":
+  version: 4.397.0
+  resolution: "@artsy/cohesion@npm:4.397.0"
   dependencies:
     core-js: "npm:3"
-  checksum: 10c0/9ea42dd1fc855abb29f985171dd1147765a21240b3454410df21a1692dd481ca064b1d680c381acdd5f26105539f574fde5ecf694123073cb53a832d57bb4f0e
+  checksum: 10c0/3e95886db6d890eafd21be991e1d9b70270a67f0b8ebc65bc1913bf638672d3b0e7f1ea99f8790daa5f546dd6465ad781e2f24c1bb95646823fe3d619f1253cc
   languageName: node
   linkType: hard
 
@@ -13587,7 +13587,7 @@ __metadata:
   resolution: "eigen@workspace:."
   dependencies:
     "@artsy/changelog": "npm:0.1.0"
-    "@artsy/cohesion": "npm:4.396.0"
+    "@artsy/cohesion": "npm:4.397.0"
     "@artsy/icons": "npm:3.79.0"
     "@artsy/palette-mobile": "npm:24.12.0"
     "@artsy/to-title-case": "npm:1.2.0"


### PR DESCRIPTION
## Release Candidate 9.17.0

This branch was automatically created as the release candidate for version 9.17.0.

> ⚠️ Do not merge this PR. It is used for tracking the release and 🍒 cherry-picking fixes only.

## Changelog

### Cross-platform user-facing changes
- Add follow fairs and shows - mounir — MounirDhahri (#13757)
- fix city guide interactions - mounir — MounirDhahri (#13910)
- Fix sorting not refreshing on saved artwork lists — gkartalis (#13960)
- Show a scrollable rail of artworks from the show on each City guide event card, instead of a single static cover image - mounir — MounirDhahri (#13971)
- Fixed a glitch in Discover Daily that caused commercial actions to show up unexpectedly. — iskounen (#13974)
- add city picker wrapper screen [behind ff] - mounir — MounirDhahri (#13987)
- fix bottom button offset in onboarding - brian — brainbicycle (#13985)
- Added animation to onboarding bottom sheet — iskounen (#13983)
- Added animation to another onboarding bottom sheet — iskounen (#13984)
- Animate an artwork save during onboarding — iskounen (#13993)
- artsy lens - image search behind a feature flag @nickskalkin — dblandin (#13959)

### iOS user-facing changes
- make live auction error screen closable again — MrSltun (#13969)

### Dev changes
- Convert remaining City guide class components to functional components with hooks — MounirDhahri (#13961)
- Lazily mount inactive tabs in Inbox and City guide instead of mounting all tabs up front. — MounirDhahri (#13972)
- Merge the `City`, `Map` and `CityGuide` scenes into a single `Scenes/CityGuide` scene and rename its components, screens and utils to match — MounirDhahri (#13976)
- Add support for preselecting cities in CityGuide via URL parameter — MounirDhahri (#13982)
- save device token under current running app bundle id - brian — brainbicycle (#13973)
- attempt to fix some crashes of bottomsheets — gkartalis (#13957)
- Tag Sentry events with the current route and the open bottom sheet, so native crashes can be attributed to a screen — gkartalis (#13958)
- Added tests to the useInfiniteDiscoveryCardSave hook — iskounen (#13991)
- feat(lens): Add Artsy Lens camera capture spike — dblandin (#13959)
- add rollback script for expo-updates — MrSltun (#14009)

#nochangelog