### PR TITLE
feat: artsy lens - design feedback

### DIFF
--- a/src/app/Components/SearchByPhotoButton/SearchByPhotoButton.tsx
+++ b/src/app/Components/SearchByPhotoButton/SearchByPhotoButton.tsx
@@ -5,11 +5,12 @@ import { PixelRatio } from "react-native"
 interface SearchByPhotoButtonProps {
   onPress: () => void
   testID?: string
+  label?: string
   /** `Button`'s own vocabulary, passed straight through -- `fillLight` for the black Lens screens. */
   variant?: ButtonProps["variant"]
 }
 
-const LABEL = "Search by Photo"
+const DEFAULT_LABEL = "Search by Photo"
 
 const ICON_SIZE = 20
 
@@ -24,6 +25,7 @@ export const SEARCH_BY_PHOTO_BUTTON_SPACE = 50 * PixelRatio.getFontScale() + 10
 export const SearchByPhotoButton: React.FC<SearchByPhotoButtonProps> = ({
   onPress,
   testID = "search-by-photo-button",
+  label = DEFAULT_LABEL,
   variant = "fillDark",
 }) => {
   return (
@@ -36,7 +38,7 @@ export const SearchByPhotoButton: React.FC<SearchByPhotoButtonProps> = ({
       onPress={onPress}
       testID={testID}
     >
-      {LABEL}
+      {label}
     </Button>
   )
 }

--- a/src/app/Scenes/Lens/Components/LensCameraButtons.tsx
+++ b/src/app/Scenes/Lens/Components/LensCameraButtons.tsx
@@ -1,4 +1,4 @@
-import { BoltFillIcon, ImageSetIcon } from "@artsy/icons/native"
+import { BoltFillIcon, PhotographIcon } from "@artsy/icons/native"
 import { DEFAULT_HIT_SLOP, Flex, FlexProps, Touchable, useSpace } from "@artsy/palette-mobile"
 import { LensCapturePhotoButton } from "app/Scenes/Lens/Components/LensCapturePhotoButton"
 
@@ -84,7 +84,7 @@ export const LensCameraButtons: React.FC<LensCameraButtonsProps> = (props) => {
           alignItems="center"
           bg="mono0"
         >
-          <ImageSetIcon fill="mono100" width={18} height={18} />
+          <PhotographIcon testID="lens-library-photo-icon" fill="mono100" width={18} height={18} />
         </Flex>
       </Touchable>
     </Flex>

--- a/src/app/Scenes/Lens/Components/LensHeader.tsx
+++ b/src/app/Scenes/Lens/Components/LensHeader.tsx
@@ -1,12 +1,11 @@
-import { BackButton, DEFAULT_HIT_SLOP, Flex, NAVBAR_HEIGHT, Text } from "@artsy/palette-mobile"
+import { BackButton, DEFAULT_HIT_SLOP, Flex, NAVBAR_HEIGHT } from "@artsy/palette-mobile"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 interface LensHeaderProps {
   onClose: () => void
-  title?: string
 }
 
-export const LensHeader: React.FC<LensHeaderProps> = ({ onClose, title }) => {
+export const LensHeader: React.FC<LensHeaderProps> = ({ onClose }) => {
   const insets = useSafeAreaInsets()
 
   return (
@@ -18,14 +17,6 @@ export const LensHeader: React.FC<LensHeaderProps> = ({ onClose, title }) => {
       px={2}
     >
       <BackButton color="mono0" showX onPress={onClose} hitSlop={DEFAULT_HIT_SLOP} />
-
-      {!!title && (
-        <Flex position="absolute" left={0} right={0} alignItems="center" pointerEvents="none">
-          <Text variant="sm-display" color="mono0">
-            {title}
-          </Text>
-        </Flex>
-      )}
     </Flex>
   )
 }

--- a/src/app/Scenes/Lens/Screens/LensAnalyzing.tsx
+++ b/src/app/Scenes/Lens/Screens/LensAnalyzing.tsx
@@ -140,7 +140,7 @@ export const LensAnalyzing: React.FC<Props> = ({ route, navigation }) => {
               height={displayCard.height}
               borderRadius={16}
               overflow="hidden"
-              bg="mono10"
+              bg="mono100"
               justifyContent="center"
               alignItems="center"
             >

--- a/src/app/Scenes/Lens/Screens/LensCamera.tsx
+++ b/src/app/Scenes/Lens/Screens/LensCamera.tsx
@@ -1,4 +1,5 @@
-import { Flex, Spinner, Theme } from "@artsy/palette-mobile"
+import { CameraStrokeIcon } from "@artsy/icons/native"
+import { Flex, Spinner, Text, Theme } from "@artsy/palette-mobile"
 import { useIsFocused } from "@react-navigation/native"
 import { StackScreenProps } from "@react-navigation/stack"
 import { captureException, withScope } from "@sentry/react-native"
@@ -146,7 +147,21 @@ export const LensCamera: React.FC<Props> = ({ navigation }) => {
         )}
 
         <Flex position="absolute" top={0} left={0} right={0}>
-          <LensHeader title="Artsy Lens" onClose={handleClose} />
+          <LensHeader onClose={handleClose} />
+
+          <Flex alignItems="center" px={4} mt={1} pointerEvents="none">
+            <Flex flexDirection="row" alignItems="center">
+              <CameraStrokeIcon fill="mono0" width={18} height={18} />
+
+              <Text variant="sm-display" color="mono0" ml={0.5}>
+                ARTSY LENS
+              </Text>
+            </Flex>
+
+            <Text variant="sm" color="mono0" textAlign="center" mt={1}>
+              Take a photo and we'll match it with a similar artwork.
+            </Text>
+          </Flex>
         </Flex>
 
         <Flex position="absolute" bottom={0} left={0} right={0} height={LENS_CAMERA_BUTTONS_HEIGHT}>

--- a/src/app/Scenes/Lens/Screens/LensResults.tsx
+++ b/src/app/Scenes/Lens/Screens/LensResults.tsx
@@ -21,7 +21,8 @@ import { ExtractNodeType } from "app/utils/relayHelpers"
 import { Suspense, useEffect } from "react"
 import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 
-const MATCHES_TITLE = "Here are some matches to your photo"
+const MATCHES_TITLE = "Great taste! Here are some matches to your photo"
+const NO_MATCHES_TITLE = "Unfortunately, we couldn't find great matches for that photo"
 const SEARCHING_TITLE = "Searching for matches..."
 
 type Props = StackScreenProps<LensNavigationStack, "LensResults">
@@ -56,7 +57,7 @@ const LensResults: React.FC<Props> = ({ route, navigation }) => {
       <LensResultsHeader
         onBack={goBack}
         photoUri={photoUri}
-        title={hasNoMatches ? undefined : MATCHES_TITLE}
+        title={hasNoMatches ? NO_MATCHES_TITLE : MATCHES_TITLE}
       />
 
       <Screen.Body fullwidth pt={1}>
@@ -68,12 +69,11 @@ const LensResults: React.FC<Props> = ({ route, navigation }) => {
         />
       </Screen.Body>
 
-      {/* Empty state only: with matches on screen, tapping one is the action, and a permanent CTA
-          over the grid would compete with it. */}
       {!!hasNoMatches && (
         <Screen.BottomView>
           <SearchByPhotoButton
             testID="lensResultsSearchByPhotoButton"
+            label="Try another photo"
             onPress={() => restartSearch(navigation)}
           />
         </Screen.BottomView>
@@ -94,9 +94,7 @@ const ArtworksGrid: React.FC<{
       contextScreenOwnerType={OwnerType.search}
       contextScreen={OwnerType.search}
       ListEmptyComponent={
-        <SimpleMessage m={2}>
-          We couldn't find any matches for that image. Try another photo.
-        </SimpleMessage>
+        <SimpleMessage m={2}>No matches found. Please try another photo.</SimpleMessage>
       }
       hasMore={hasNext}
       isLoading={isLoadingNext}

--- a/src/app/Scenes/Lens/Screens/__tests__/LensResults.tests.tsx
+++ b/src/app/Scenes/Lens/Screens/__tests__/LensResults.tests.tsx
@@ -81,6 +81,9 @@ describe("LensResults", () => {
   it("offers a way to search another photo when there are no matches", () => {
     renderWithRelay({ ArtworkConnection: () => ({ edges: [] }) })
 
+    expect(screen.getByText("No matches found. Please try another photo.")).toBeOnTheScreen()
+    expect(screen.getByText("Try another photo")).toBeOnTheScreen()
+
     fireEvent.press(screen.getByTestId("lensResultsSearchByPhotoButton"))
 
     expect(mockNavigate).toHaveBeenCalledWith("LensCamera")
@@ -105,13 +108,16 @@ describe("LensResults", () => {
   it("tells the user these are matches to their photo", () => {
     renderWithRelay({ Artwork: () => ({ title: "Cool Painting" }) })
 
-    expect(screen.getByText("Here are some matches to your photo")).toBeTruthy()
+    expect(screen.getByText("Great taste! Here are some matches to your photo")).toBeTruthy()
   })
 
   it("claims no matches when there are none", () => {
     renderWithRelay({ ArtworkConnection: () => ({ edges: [] }) })
 
-    expect(screen.queryByText("Here are some matches to your photo")).toBeNull()
+    expect(
+      screen.getByText("Unfortunately, we couldn't find great matches for that photo")
+    ).toBeOnTheScreen()
+    expect(screen.queryByText("Great taste! Here are some matches to your photo")).toBeNull()
   })
 
   it("deletes the searched photo on the way out", () => {

--- a/src/app/Scenes/Lens/__tests__/LensCamera.tests.tsx
+++ b/src/app/Scenes/Lens/__tests__/LensCamera.tests.tsx
@@ -47,6 +47,16 @@ describe("LensCamera", () => {
     expect(goBack).toHaveBeenCalledTimes(1)
   })
 
+  it("shows the Artsy Lens guidance and a photo icon for the library", () => {
+    renderWithWrappers(<LensCamera {...navigationProps} />)
+
+    expect(screen.getByText("ARTSY LENS")).toBeOnTheScreen()
+    expect(
+      screen.getByText("Take a photo and we'll match it with a similar artwork.")
+    ).toBeOnTheScreen()
+    expect(screen.getByTestId("lens-library-photo-icon")).toBeOnTheScreen()
+  })
+
   it("shows 'Go to Settings' (not another permission prompt) once camera access has been denied", () => {
     jest.mocked(useCameraPermission).mockReturnValue({
       hasPermission: false,


### PR DESCRIPTION
### Description

Updates the Artsy Lens experience based on design feedback:

- Replaces the stacked-images gallery icon with a photo icon.
- Adds the camera icon, ARTSY LENS branding, and guidance copy to the camera screen.
- Updates the successful results header
- Updates the no-results experience
- Uses a black placeholder while the selected photo is being processed

| | | |
|---|---|---|
| <img width="1080" height="2424" alt="Screenshot_1788517724" src="https://github.com/user-attachments/assets/1813adff-6800-4579-8ce3-3ca51f7245cb" /> | <img width="1080" height="2424" alt="Screenshot_1788517697" src="https://github.com/user-attachments/assets/bd8f9880-f5fd-4ab8-8ee0-abc2e2712490" /> | <img width="1080" height="2424" alt="Screenshot_1788517685" src="https://github.com/user-attachments/assets/5c5d0d92-14e5-408e-89f9-ac2457dcca06" /> |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
