### PR TITLE
feat: artsy lens behind echo feature flag

### DIFF
--- a/src/app/Components/GlobalSearchInput/GlobalSearchInput.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInput.tsx
@@ -4,10 +4,10 @@ import { GlobalSearchInputOverlay } from "app/Components/GlobalSearchInput/Globa
 import { useDismissSearchOverlayOnTabBarPress } from "app/Components/GlobalSearchInput/utils/useDismissSearchOverlayOnTabBarPress"
 import { SearchByPhotoIconButton } from "app/Components/SearchByPhotoButton/SearchByPhotoIconButton"
 import { ICON_HIT_SLOP } from "app/Components/constants"
-import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { useDebouncedValue } from "app/utils/hooks/useDebouncedValue"
+import { useEnableArtsyLens } from "app/utils/hooks/useEnableArtsyLens"
 import { forwardRef, Fragment, useEffect, useImperativeHandle, useState } from "react"
 import { useTracking } from "react-tracking"
 
@@ -27,7 +27,7 @@ export const GlobalSearchInput = forwardRef<GlobalSearchInput, GlobalSearchInput
     const debouncedIsVisible = useDebouncedValue({ value: isVisible })
 
     const tracking = useTracking()
-    const enableArtsyLens = useExperimentFlag("onyx_artsy-lens")
+    const enableArtsyLens = useEnableArtsyLens()
 
     useEffect(() => {
       onOverlayVisibilityChange?.(isVisible)

--- a/src/app/Components/GlobalSearchInput/GlobalSearchInputOverlay.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInputOverlay.tsx
@@ -16,10 +16,10 @@ import { SearchPills } from "app/Scenes/Search/SearchPills"
 import { SearchResults } from "app/Scenes/Search/SearchResults"
 import { TrendingSearches } from "app/Scenes/Search/TrendingSearches/TrendingSearches"
 import { SEARCH_PILLS } from "app/Scenes/Search/constants"
-import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { useBackHandler } from "app/utils/hooks/useBackHandler"
+import { useEnableArtsyLens } from "app/utils/hooks/useEnableArtsyLens"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { Suspense, useEffect, useState } from "react"
 import { ScrollView, StyleSheet } from "react-native"
@@ -115,7 +115,7 @@ export const GlobalSearchInputOverlay: React.FC<{
   const insets = useSafeAreaInsets()
   const { goBack, canGoBack } = useNavigation()
   const opacity = useSharedValue(0)
-  const enableArtsyLens = useExperimentFlag("onyx_artsy-lens")
+  const enableArtsyLens = useEnableArtsyLens()
 
   useBackHandler(() => {
     if (!!canGoBack()) {

--- a/src/app/Components/GlobalSearchInput/__tests__/GlobalSearchInput.tests.tsx
+++ b/src/app/Components/GlobalSearchInput/__tests__/GlobalSearchInput.tests.tsx
@@ -1,6 +1,7 @@
 import { OwnerType } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { GlobalSearchInput } from "app/Components/GlobalSearchInput/GlobalSearchInput"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
 import { navigate } from "app/system/navigation/navigate"
 import { useSelectedTab } from "app/utils/hooks/useSelectedTab"
@@ -31,6 +32,7 @@ describe("GlobalSearchInput", () => {
     jest.clearAllMocks()
     mockUseledTab.mockReturnValue("home")
     mockUseExperimentFlag.mockReturnValue(false)
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableArtsyLens: true })
   })
 
   it("renders the search label properly", () => {
@@ -63,6 +65,15 @@ describe("GlobalSearchInput", () => {
 
     it("hides the camera icon when the onyx_artsy-lens experiment is off", () => {
       mockUseExperimentFlag.mockReturnValue(false)
+
+      renderWithWrappers(<GlobalSearchInput ownerType={OwnerType.home} />)
+
+      expect(screen.queryByTestId("search-input-camera-icon")).not.toBeOnTheScreen()
+    })
+
+    it("hides the camera icon when AREnableArtsyLens is off, even if the experiment is on", () => {
+      mockUseExperimentFlag.mockImplementation((key) => key === "onyx_artsy-lens")
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableArtsyLens: false })
 
       renderWithWrappers(<GlobalSearchInput ownerType={OwnerType.home} />)
 

--- a/src/app/Components/GlobalSearchInput/__tests__/GlobalSearchInputOverlay.tests.tsx
+++ b/src/app/Components/GlobalSearchInput/__tests__/GlobalSearchInputOverlay.tests.tsx
@@ -2,6 +2,7 @@ import { OwnerType } from "@artsy/cohesion"
 import { PortalHost } from "@gorhom/portal"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { GlobalSearchInputOverlay } from "app/Components/GlobalSearchInput/GlobalSearchInputOverlay"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
 import { navigate } from "app/system/navigation/navigate"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
@@ -36,6 +37,16 @@ describe("GlobalSearchInputOverlay — Search by Photo entry point", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableArtsyLens: true })
+  })
+
+  it("hides the Search by Photo button when AREnableArtsyLens is off", () => {
+    mockUseExperimentFlag.mockImplementation((key) => key === "onyx_artsy-lens")
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableArtsyLens: false })
+
+    renderOverlay()
+
+    expect(screen.queryByTestId("search-by-photo-button")).not.toBeOnTheScreen()
   })
 
   it("renders the Search by Photo button when onyx_artsy-lens is on", () => {

--- a/src/app/Scenes/Search/TrendingSearches/TrendingSearches.tsx
+++ b/src/app/Scenes/Search/TrendingSearches/TrendingSearches.tsx
@@ -12,7 +12,7 @@ import {
   TrendingPeriod,
   useTrendingSearches,
 } from "app/Scenes/Search/TrendingSearches/useTrendingSearches"
-import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
+import { useEnableArtsyLens } from "app/utils/hooks/useEnableArtsyLens"
 import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
 import { times } from "lodash"
 import { startTransition, useEffect, useState } from "react"
@@ -21,7 +21,7 @@ import { useTracking } from "react-tracking"
 
 export const TrendingSearches: React.FC = () => {
   const tabBarHeight = useBottomTabBarHeight()
-  const enableArtsyLens = useExperimentFlag("onyx_artsy-lens")
+  const enableArtsyLens = useEnableArtsyLens()
   const [period, setPeriod] = useState<TrendingPeriod>("ONE_DAY")
 
   const handlePeriodChange = (next: TrendingPeriod) => {

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -189,6 +189,12 @@ export const features = {
     showInDevMenu: true,
     echoFlagKey: "AREnableGlobalMapList",
   },
+  AREnableArtsyLens: {
+    description: "Enable Artsy Lens (reverse-image-search camera) entry points",
+    readyForRelease: false,
+    showInDevMenu: true,
+    echoFlagKey: "AREnableArtsyLens",
+  },
 } satisfies { [key: string]: FeatureDescriptor }
 
 export interface DevToggleDescriptor {

--- a/src/app/utils/hooks/useEnableArtsyLens.ts
+++ b/src/app/utils/hooks/useEnableArtsyLens.ts
@@ -1,0 +1,9 @@
+import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+
+export function useEnableArtsyLens() {
+  const isReleased = useFeatureFlag("AREnableArtsyLens")
+  const isRolledOut = useExperimentFlag("onyx_artsy-lens")
+
+  return isReleased && isRolledOut
+}


### PR DESCRIPTION
### Description

Adds an Echo feature flag `AREnableArtsyLens` (`readyForRelease: false`) as a second gate in front of the Artsy Lens entry points, alongside the existing Unleash flag `onyx_artsy-lens`. Both must be on for the camera icon / Search by Photo button to render.

Thanks @MrSltun for advice

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
