### PR TITLE
feat: unleash version/platform constraints demo

### DIFF
--- a/src/app/Components/UnleashConstraintDemo.tsx
+++ b/src/app/Components/UnleashConstraintDemo.tsx
@@ -1,0 +1,41 @@
+import { Flex, Text } from "@artsy/palette-mobile"
+import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
+import { useUnleashEnvironment } from "app/system/flags/hooks/useUnleashEnvironment"
+import { getAppVersion } from "app/utils/appVersion"
+import { Platform } from "react-native"
+
+export const UnleashConstraintDemo: React.FC = () => {
+  const versionGate = useExperimentFlag("onyx_demo-version-gate")
+  const platformGate = useExperimentFlag("onyx_demo-platform-gate")
+  const { unleashEnv } = useUnleashEnvironment()
+
+  return (
+    <Flex>
+      <GateSection
+        title="VERSION GATE"
+        detail={`appVersion ${getAppVersion()} · unleash ${unleashEnv}`}
+        enabled={versionGate}
+      />
+      <GateSection
+        title="PLATFORM GATE"
+        detail={`appPlatformOS ${Platform.OS} · unleash ${unleashEnv}`}
+        enabled={platformGate}
+      />
+    </Flex>
+  )
+}
+
+const GateSection: React.FC<{ title: string; detail: string; enabled: boolean }> = ({
+  title,
+  detail,
+  enabled,
+}) => (
+  <Flex px={2} py={1} backgroundColor={enabled ? "green100" : "red100"}>
+    <Text variant="sm" color="mono0" fontWeight="bold">
+      {title}: {enabled ? "ON" : "OFF"}
+    </Text>
+    <Text variant="xs" color="mono0">
+      {detail}
+    </Text>
+  </Flex>
+)

--- a/src/app/Scenes/HomeView/Components/HomeHeader.tsx
+++ b/src/app/Scenes/HomeView/Components/HomeHeader.tsx
@@ -1,6 +1,7 @@
 import { OwnerType } from "@artsy/cohesion"
 import { Flex } from "@artsy/palette-mobile"
 import { GlobalSearchInput } from "app/Components/GlobalSearchInput/GlobalSearchInput"
+import { UnleashConstraintDemo } from "app/Components/UnleashConstraintDemo"
 import { PaymentFailureBanner } from "app/Scenes/HomeView/Components/PaymentFailureBanner"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
@@ -17,6 +18,7 @@ export const HomeHeader: React.FC<{
 
   return (
     <Flex backgroundColor="background">
+      <UnleashConstraintDemo />
       {!!showPaymentFailureBanner && <PaymentFailureBanner />}
       <Flex pb={1} pt={2}>
         <Flex flexDirection="row" px={2} gap={1} justifyContent="space-around" alignItems="center">

--- a/src/app/system/flags/experiments.ts
+++ b/src/app/system/flags/experiments.ts
@@ -27,6 +27,12 @@ export const experiments = {
   "onyx_artsy-lens": {
     description: "Enable Artsy Lens (reverse-image-search camera) entry points",
   },
+  "onyx_demo-version-gate": {
+    description: "Demo only: proves an appVersion constraint gates a flag per app version",
+  },
+  "onyx_demo-platform-gate": {
+    description: "Demo only: proves an appPlatformOS constraint gates a flag per platform",
+  },
 } satisfies { [key: string]: ExperimentDescriptor }
 
 export type EXPERIMENT_NAME = keyof typeof experiments


### PR DESCRIPTION
### Description

Proof of concept that Unleash flag can be gated on app version and platform. The app already sends `appVersion` and `appPlatformOS` in the Unleash context, those fields just were never registered as context fields in Unleash, so they don't show up in the constraint dropdown.

I added a throwaway banner at the top of Home with two sections, each backed by its own flag so the two dimensions can be demoed independently:

- **VERSION GATE** - `onyx_demo-version-gate`, prints the `appVersion` it reports
- **PLATFORM GATE** - `onyx_demo-platform-gate`, prints the `appPlatformOS` it reports

Each section turns fully green or red with its flag. Changing a constraint in Unleash flips the matching section in almost real time.

| Screenshot | Unleash | Unleash |
|---|---|---|
| <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-09-04 at 14 23 57" src="https://github.com/user-attachments/assets/8b864449-12e4-4c0b-b279-701c5da3bf2d" /> | <img width="1148" height="671" alt="Screenshot 2026-09-04 at 14 24 20" src="https://github.com/user-attachments/assets/cd63b848-c60b-4a86-ab09-e0a025fe4120" /> | <img width="1137" height="655" alt="Screenshot 2026-09-04 at 14 24 30" src="https://github.com/user-attachments/assets/bf07fb17-59f4-4942-8bdd-09d3b8c87330" /> |
| <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-09-04 at 14 25 48" src="https://github.com/user-attachments/assets/cf91a5b6-5b2a-4630-a56a-f9dfa841819a" /> | <img width="1132" height="664" alt="Screenshot 2026-09-04 at 14 25 57" src="https://github.com/user-attachments/assets/28cbc6bb-4b7f-418c-90d5-6c6d99f1b975" /> | <img width="1137" height="673" alt="Screenshot 2026-09-04 at 14 26 15" src="https://github.com/user-attachments/assets/a51a958c-736c-4ea5-8e16-25d58529b123" /> |

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
