### PR TITLE
fix(lens): turn off camera torch

### DIFF
--- a/src/app/Scenes/Lens/Components/LensCameraPreview.tsx
+++ b/src/app/Scenes/Lens/Components/LensCameraPreview.tsx
@@ -24,7 +24,7 @@ export type LensCameraPreviewHandle = {
 
 interface LensCameraPreviewProps {
   isActive: boolean
-  torchEnabled: boolean
+  torchMode?: "on" | "off"
   onStatusChange: (status: LensCameraStatus) => void
   onCapture: (photo: LensPhoto) => void
   onError: (error: unknown) => void
@@ -32,7 +32,7 @@ interface LensCameraPreviewProps {
 
 export const LensCameraPreview = forwardRef<LensCameraPreviewHandle, LensCameraPreviewProps>(
   (props, ref) => {
-    const { isActive, torchEnabled, onStatusChange, onCapture, onError } = props
+    const { isActive, torchMode, onStatusChange, onCapture, onError } = props
 
     const { hasPermission, canRequestPermission, requestPermission } = useCameraPermission()
     const device = useCameraDevice("back")
@@ -104,10 +104,7 @@ export const LensCameraPreview = forwardRef<LensCameraPreviewHandle, LensCameraP
         device={device}
         outputs={[photoOutput]}
         isActive={isActive}
-        // Omitted, not "off", when disabled: an explicit torchMode on the first render makes
-        // vision-camera call setTorchMode() before the CameraX session opens, which throws
-        // `Camera is not active` on Android and tears the session down.
-        torchMode={torchEnabled ? "on" : undefined}
+        torchMode={torchMode}
         onError={(error) => {
           setHasErrored(true)
           onError(error)

--- a/src/app/Scenes/Lens/Screens/LensCamera.tsx
+++ b/src/app/Scenes/Lens/Screens/LensCamera.tsx
@@ -33,7 +33,7 @@ type LensScreenState = LensCameraStatus | { kind: "loading" }
  */
 export const LensCamera: React.FC<Props> = ({ navigation }) => {
   const [state, setState] = useState<LensScreenState>({ kind: "loading" })
-  const [torchEnabled, setTorchEnabled] = useState(false)
+  const [torchMode, setTorchMode] = useState<"on" | "off">()
   const camera = useRef<LensCameraPreviewHandle>(null)
   // Measured, not read from useWindowDimensions(), which over-reports height on Android -- see
   // `LensPhoto.captureContainerWidth`. With the window's value the brackets sit below true center.
@@ -64,7 +64,7 @@ export const LensCamera: React.FC<Props> = ({ navigation }) => {
   }
 
   const handleToggleTorch = () => {
-    setTorchEnabled((current) => !current)
+    setTorchMode((current) => (current === "on" ? "off" : "on"))
   }
 
   const handleSelectFromLibrary = async () => {
@@ -125,7 +125,7 @@ export const LensCamera: React.FC<Props> = ({ navigation }) => {
         <LensCameraPreview
           ref={camera}
           isActive={!!isActive && state.kind === "ready"}
-          torchEnabled={torchEnabled}
+          torchMode={torchMode}
           onStatusChange={setState}
           onCapture={(photo) =>
             navigation.navigate("LensAnalyzing", {
@@ -169,7 +169,7 @@ export const LensCamera: React.FC<Props> = ({ navigation }) => {
             mode={state.kind === "ready" ? "camera" : "libraryOnly"}
             isCameraInitialized={state.kind === "ready"}
             deviceHasTorch={state.kind === "ready" && state.hasTorch}
-            isTorchEnabled={torchEnabled}
+            isTorchEnabled={torchMode === "on"}
             onTakePhoto={handleTakePhoto}
             onToggleTorch={handleToggleTorch}
             onSelectFromLibrary={handleSelectFromLibrary}

--- a/src/app/Scenes/Lens/__tests__/LensCamera.tests.tsx
+++ b/src/app/Scenes/Lens/__tests__/LensCamera.tests.tsx
@@ -3,7 +3,7 @@ import { LensCamera } from "app/Scenes/Lens/Screens/LensCamera"
 import { goBack } from "app/system/navigation/navigate"
 import { requestPhotos } from "app/utils/requestPhotos"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
-import { useCameraPermission } from "react-native-vision-camera"
+import { useCameraDevice, useCameraPermission } from "react-native-vision-camera"
 
 jest.mock("app/utils/requestPhotos", () => ({
   requestPhotos: jest.fn(),
@@ -20,6 +20,7 @@ const navigationProps = {
 describe("LensCamera", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.mocked(useCameraDevice).mockReturnValue(undefined)
   })
 
   it("shows the permission placeholder (with the library button still enabled) when camera access is undetermined", () => {
@@ -55,6 +56,29 @@ describe("LensCamera", () => {
       screen.getByText("Take a photo and we'll match it with a similar artwork.")
     ).toBeOnTheScreen()
     expect(screen.getByTestId("lens-library-photo-icon")).toBeOnTheScreen()
+  })
+
+  it("turns the camera torch off after it has been enabled", () => {
+    jest.mocked(useCameraPermission).mockReturnValue({
+      hasPermission: true,
+      canRequestPermission: false,
+      requestPermission: jest.fn(),
+      status: "authorized",
+    } as any)
+    jest.mocked(useCameraDevice).mockReturnValue({
+      hasTorch: true,
+      supportsFocusMetering: true,
+    } as any)
+
+    renderWithWrappers(<LensCamera {...navigationProps} />)
+
+    expect(screen.UNSAFE_getByType("Camera" as any).props.torchMode).toBeUndefined()
+
+    fireEvent.press(screen.getByTestId("lens-torch-button"))
+    expect(screen.UNSAFE_getByType("Camera" as any).props.torchMode).toBe("on")
+
+    fireEvent.press(screen.getByTestId("lens-torch-button"))
+    expect(screen.UNSAFE_getByType("Camera" as any).props.torchMode).toBe("off")
   })
 
   it("shows 'Go to Settings' (not another permission prompt) once camera access has been denied", () => {


### PR DESCRIPTION
This PR resolves [PBRW-2079]

### Description

Fixes an issue in Artsy Lens where the camera torch could be turned on but not turned off. The camera now explicitly receives `torchMode="off"` after the torch has been enabled. Checked on my real iphone.

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix: artsy lens torch issue @nickskalkin 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-2079]: https://artsyproduct.atlassian.net/browse/PBRW-2079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ