### PR TITLE
fix(DI-578): explicitly add portalprovider to providers list

### DIFF
--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -46,7 +46,8 @@ export const Providers: React.FC<{ children: React.ReactNode }> = ({ children })
       PopoverMessageProvider,
       ToastProvider, // uses: GlobalStoreProvider
       GravityWebsocketContextProvider, // uses GlobalStoreProvider
-      ArtworkListsProvider,
+      PortalProvider,
+      ArtworkListsProvider, // uses BottomSheetModalProvider, which nests its own PortalProvider
       ShareSheetProvider, // uses BottomSheetProvider
       KeyboardControllerProvider,
     ],


### PR DESCRIPTION
This PR resolves [DI-578](https://www.notion.so/3cacab0764a080d8895ffb14c32ab84f)
Assisted-by: Claude:Sonnet-5

#### Problem

Our app uses a tool called [Portals](https://github.com/gorhom/react-native-portal) to allow React components in one part of the component tree to render (or “teleport”) something in another part of the component tree. 

Portals require a PortalProvider to be included near the root of the component tree in order to share context between both ends of the “portal.”

We currently don't have an explicit PortalProvider in our list of [Providers](https://github.com/artsy/eigen/blob/d17ec9eb7d9b8beec923cd62c0279f90262d0730/src/app/Providers.tsx#L26), so the Portals in HomeView, Search, and now Discover Daily *shouldn't* work.

They *do* work, however, because [ArtworkListsProvider](https://github.com/artsy/eigen/blob/d17ec9eb7d9b8beec923cd62c0279f90262d0730/src/app/Components/ArtworkLists/ArtworkListsStore.tsx#L187) (which is included in that list of Providers) happens to add a BottomSheetModalProvider that in turn adds a [PortalProvider](https://github.com/gorhom/react-native-bottom-sheet/blob/9bfbeb521b90d525791a3400a68eec523ad7e444/src/components/bottomSheetModalProvider/BottomSheetModalProvider.tsx#L208).

So the Portals in our app currently work because of how ArtworkListsProvider is implemented, and if that implementation were to change, those Portals will mysteriously stop working as expected.

#### Solution

Add PortalProvider to the list of Providers.

As long as we add it *before* ArtworkListsProvider in the list, HomeView, Search and Discover Daily's Portals will continue to use the PortalProvider nested in ArtworkListsProvider as they do today.

And if we ever change ArtworkListsProvider to no longer have a nested PortalProvider, it will become the new one that gets used, without any mysterious breaks in functionality.

#### Acceptance Criteria

1. Test that the search overlay appears when searching on the Home screen and the Search screen
2. Test that the save animation appears when onboarding with Discover Daily
3. Test the bottom sheet that appears when saving an artwork on several surfaces (ex., in rails, on artwork screens, in discover daily, etc.)

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Explicitly added PortalProvider to Providers list.

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
