### PR TITLE
fix: address occasional crashes from bottom sheet modals

### DIFF
--- a/src/app/Scenes/Favorites/FollowsTab.tsx
+++ b/src/app/Scenes/Favorites/FollowsTab.tsx
@@ -105,7 +105,7 @@ export const FollowsTab = () => {
         sentryName="FollowsTab"
         visible={showFollowsBottomSheet}
         snapPoints={SNAP_POINTS}
-        enableDynamicSizing
+        enableDynamicSizing={false}
         onDismiss={() => {
           setShowFollowsBottomSheet(false)
         }}

--- a/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalAdd.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalAdd.tsx
@@ -3,7 +3,6 @@ import { Flex, Text, useColor, useSpace } from "@artsy/palette-mobile"
 import { BOTTOM_TABS_HEIGHT } from "@artsy/palette-mobile/dist/elements/Screen/StickySubHeader"
 import { BottomSheetView } from "@gorhom/bottom-sheet"
 import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
-import { defaultIndicatorHandleStyle } from "app/Components/BottomSheet/defaultIndicatorHandleStyle"
 import { MenuItem } from "app/Components/MenuItem"
 import { Tab } from "app/Scenes/MyCollection/MyCollection"
 import { MyCollectionTabsStore } from "app/Scenes/MyCollection/State/MyCollectionTabsStore"
@@ -28,8 +27,6 @@ export const MyCollectionBottomSheetModalAdd: React.FC<{ isVisible: boolean }> =
       visible={isVisible}
       snapPoints={SNAP_POINTS}
       enableDynamicSizing={false}
-      enablePanDownToClose
-      handleIndicatorStyle={defaultIndicatorHandleStyle(color)}
       backgroundStyle={{
         backgroundColor: color("mono0"),
       }}

--- a/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalAdd.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalAdd.tsx
@@ -21,6 +21,9 @@ export const MyCollectionBottomSheetModalAdd: React.FC<{}> = () => {
         paddingBottom: bottom + BOTTOM_TABS_HEIGHT + space(2),
       }}
     >
+      <BottomSheetView>
+        <Text>LOL this is MyCollectionBottomSheetModalAdd </Text>
+      </BottomSheetView>
       <Flex pb={1}>
         <Text textAlign="center" variant="sm" pt={2} pb={2}>
           Add to My Collection

--- a/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalAdd.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalAdd.tsx
@@ -1,7 +1,9 @@
 import { ArtworkIcon, GroupIcon } from "@artsy/icons/native"
-import { Flex, Text, useSpace } from "@artsy/palette-mobile"
+import { Flex, Text, useColor, useSpace } from "@artsy/palette-mobile"
 import { BOTTOM_TABS_HEIGHT } from "@artsy/palette-mobile/dist/elements/Screen/StickySubHeader"
 import { BottomSheetView } from "@gorhom/bottom-sheet"
+import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
+import { defaultIndicatorHandleStyle } from "app/Components/BottomSheet/defaultIndicatorHandleStyle"
 import { MenuItem } from "app/Components/MenuItem"
 import { Tab } from "app/Scenes/MyCollection/MyCollection"
 import { MyCollectionTabsStore } from "app/Scenes/MyCollection/State/MyCollectionTabsStore"
@@ -9,57 +11,74 @@ import { MyCollectionTabsStore } from "app/Scenes/MyCollection/State/MyCollectio
 import { navigate } from "app/system/navigation/navigate"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
-export const MyCollectionBottomSheetModalAdd: React.FC<{}> = () => {
+const SNAP_POINTS = [370]
+
+export const MyCollectionBottomSheetModalAdd: React.FC<{ isVisible: boolean }> = ({
+  isVisible,
+}) => {
   const setViewKind = MyCollectionTabsStore.useStoreActions((state) => state.setViewKind)
 
   const { bottom } = useSafeAreaInsets()
   const space = useSpace()
+  const color = useColor()
 
   return (
-    <BottomSheetView
-      style={{
-        paddingBottom: bottom + BOTTOM_TABS_HEIGHT + space(2),
+    <AutomountedBottomSheetModal
+      sentryName="MyCollectionBottomSheetModalAdd"
+      visible={isVisible}
+      snapPoints={SNAP_POINTS}
+      enableDynamicSizing={false}
+      enablePanDownToClose
+      handleIndicatorStyle={defaultIndicatorHandleStyle(color)}
+      backgroundStyle={{
+        backgroundColor: color("mono0"),
+      }}
+      onDismiss={() => {
+        setViewKind({ viewKind: null })
       }}
     >
-      <BottomSheetView>
-        <Text>LOL this is MyCollectionBottomSheetModalAdd </Text>
+      <BottomSheetView
+        style={{
+          paddingBottom: bottom + BOTTOM_TABS_HEIGHT + space(2),
+        }}
+      >
+        <Flex pb={1}>
+          <Text textAlign="center" variant="sm" pt={2} pb={2}>
+            Add to My Collection
+          </Text>
+          <MenuItem
+            title="Add Artists"
+            description="List the artists in your collection."
+            onPress={() => {
+              setViewKind({ viewKind: null })
+
+              navigate("my-collection/collected-artists/new", {
+                passProps: {
+                  source: Tab.collection,
+                },
+              })
+            }}
+            icon={<GroupIcon height={24} width={24} fill="mono100" />}
+            alignItems="flex-start"
+          />
+
+          <MenuItem
+            title="Add Artworks"
+            description="Upload images and details of an artwork in your collection."
+            onPress={() => {
+              setViewKind({ viewKind: null })
+
+              navigate("my-collection/artworks/new", {
+                passProps: {
+                  source: Tab.collection,
+                },
+              })
+            }}
+            icon={<ArtworkIcon height={24} width={24} />}
+            alignItems="flex-start"
+          />
+        </Flex>
       </BottomSheetView>
-      <Flex pb={1}>
-        <Text textAlign="center" variant="sm" pt={2} pb={2}>
-          Add to My Collection
-        </Text>
-        <MenuItem
-          title="Add Artists"
-          description="List the artists in your collection."
-          onPress={() => {
-            setViewKind({ viewKind: null })
-
-            navigate("my-collection/collected-artists/new", {
-              passProps: {
-                source: Tab.collection,
-              },
-            })
-          }}
-          icon={<GroupIcon height={24} width={24} fill="mono100" />}
-          alignItems="flex-start"
-        />
-
-        <MenuItem
-          title="Add Artworks"
-          description="Upload images and details of an artwork in your collection."
-          onPress={() => {
-            setViewKind({ viewKind: null })
-
-            navigate("my-collection/artworks/new", {
-              passProps: {
-                source: Tab.collection,
-              },
-            })
-          }}
-          icon={<ArtworkIcon height={24} width={24} />}
-          alignItems="flex-start"
-        />
-      </Flex>
-    </BottomSheetView>
+    </AutomountedBottomSheetModal>
   )
 }

--- a/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalArtistPreview.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalArtistPreview.tsx
@@ -260,7 +260,7 @@ export const MyCollectionBottomSheetModal: React.FC<{
   <AutomountedBottomSheetModal
     visible={visible}
     snapPoints={SNAP_POINTS}
-    enableDynamicSizing
+    enableDynamicSizing={false}
     onDismiss={onDismiss}
   >
     <BottomSheetView>

--- a/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalArtistPreview.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalArtistPreview.tsx
@@ -262,6 +262,7 @@ export const MyCollectionBottomSheetModal: React.FC<{
     snapPoints={SNAP_POINTS}
     enableDynamicSizing={false}
     onDismiss={onDismiss}
+    sentryName="MyCollectionBottomSheetModal"
   >
     <BottomSheetView>
       <MyCollectionBottomSheetModalArtistPreviewQueryRenderer

--- a/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalProfile.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalProfile.tsx
@@ -20,7 +20,7 @@ export const MyCollectionBottomSheetModalProfile: React.FC<{
       sentryName="MyCollectionBottomSheetModalProfile"
       visible={isVisible}
       snapPoints={SNAP_POINTS}
-      enableDynamicSizing
+      enableDynamicSizing={false}
       onDismiss={() => {
         setViewKind({ viewKind: null })
       }}

--- a/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModals.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModals.tsx
@@ -45,6 +45,8 @@ export const MyCollectionBottomSheetModals: React.FC<{}> = () => {
         index={0}
         onChange={handleSheetChanges}
         snapPoints={snapPoints}
+        // This brings the issue of another modal being displayed on the back
+        // enableDynamicSizing={false}
         enablePanDownToClose
         backdropComponent={renderBackdrop}
         handleIndicatorStyle={defaultIndicatorHandleStyle(color)}
@@ -53,20 +55,18 @@ export const MyCollectionBottomSheetModals: React.FC<{}> = () => {
         }}
       >
         {view === "Add" && <MyCollectionBottomSheetModalAdd />}
-        {view === "Profile" && (
-          <MyCollectionBottomSheetModalProfile isVisible={view === "Profile"} />
-        )}
-        {view === "Artist" && !!artistId && !!interestId ? (
-          <MyCollectionBottomSheetModal
-            visible={view === "Artist" && !!artistId && !!interestId}
-            artistID={artistId}
-            interestId={interestId}
-            onDismiss={() => {
-              setViewKind({ viewKind: null })
-            }}
-          />
-        ) : null}
       </BottomSheet>
+      {view === "Profile" && <MyCollectionBottomSheetModalProfile isVisible={view === "Profile"} />}
+      {view === "Artist" && !!artistId && !!interestId ? (
+        <MyCollectionBottomSheetModal
+          visible={view === "Artist" && !!artistId && !!interestId}
+          artistID={artistId}
+          interestId={interestId}
+          onDismiss={() => {
+            setViewKind({ viewKind: null })
+          }}
+        />
+      ) : null}
     </>
   )
 }

--- a/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModals.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModals.tsx
@@ -1,61 +1,19 @@
-import { useColor } from "@artsy/palette-mobile"
-import BottomSheet, { BottomSheetProps } from "@gorhom/bottom-sheet"
-import { DefaultBottomSheetBackdrop } from "app/Components/BottomSheet/DefaultBottomSheetBackdrop"
-import { defaultIndicatorHandleStyle } from "app/Components/BottomSheet/defaultIndicatorHandleStyle"
 import { MyCollectionBottomSheetModalAdd } from "app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalAdd"
 import { MyCollectionBottomSheetModal } from "app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalArtistPreview"
 import { MyCollectionBottomSheetModalProfile } from "app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalProfile"
 import { MyCollectionTabsStore } from "app/Scenes/MyCollection/State/MyCollectionTabsStore"
-import { useCallback, useMemo, useRef } from "react"
 
 export type MyCollectionBottomSheetModalKind = "Add" | "Artist" | "Profile" | null
 
 export const MyCollectionBottomSheetModals: React.FC<{}> = () => {
-  const color = useColor()
-  const bottomSheetRef = useRef<BottomSheet>(null)
-
   const setViewKind = MyCollectionTabsStore.useStoreActions((actions) => actions.setViewKind)
   const view = MyCollectionTabsStore.useStoreState((state) => state.viewKind)
   const artistId = MyCollectionTabsStore.useStoreState((state) => state.artistId)
   const interestId = MyCollectionTabsStore.useStoreState((state) => state.interestId)
 
-  const snapPoints = useMemo(() => [view === "Artist" ? 410 : 370], [])
-
-  const handleSheetChanges = useCallback((index: number) => {
-    if (index === -1) {
-      setViewKind({ viewKind: null })
-    }
-  }, [])
-
-  const hideBottomSheet = () => {
-    if (view) {
-      bottomSheetRef.current?.close()
-      setViewKind({ viewKind: null })
-    }
-  }
-
-  const renderBackdrop: BottomSheetProps["backdropComponent"] = (props) => {
-    return <DefaultBottomSheetBackdrop pressBehavior="close" onClose={hideBottomSheet} {...props} />
-  }
-
   return (
     <>
-      <BottomSheet
-        ref={bottomSheetRef}
-        index={0}
-        onChange={handleSheetChanges}
-        snapPoints={snapPoints}
-        // This brings the issue of another modal being displayed on the back
-        // enableDynamicSizing={false}
-        enablePanDownToClose
-        backdropComponent={renderBackdrop}
-        handleIndicatorStyle={defaultIndicatorHandleStyle(color)}
-        backgroundStyle={{
-          backgroundColor: color("mono0"),
-        }}
-      >
-        {view === "Add" && <MyCollectionBottomSheetModalAdd />}
-      </BottomSheet>
+      {view === "Add" && <MyCollectionBottomSheetModalAdd isVisible={view === "Add"} />}
       {view === "Profile" && <MyCollectionBottomSheetModalProfile isVisible={view === "Profile"} />}
       {view === "Artist" && !!artistId && !!interestId ? (
         <MyCollectionBottomSheetModal

--- a/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/__tests__/MyCollectionBottomSheetModalAdd.tests.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/__tests__/MyCollectionBottomSheetModalAdd.tests.tsx
@@ -1,4 +1,3 @@
-import BottomSheet from "@gorhom/bottom-sheet"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { MyCollectionBottomSheetModalAdd } from "app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalAdd"
 import { Tab } from "app/Scenes/MyCollection/MyCollection"
@@ -10,9 +9,7 @@ describe("MyCollectionBottomSheetModalAdd", () => {
   const TestRenderer = () => {
     return (
       <MyCollectionTabsStoreProvider injections={{ view: "Add" }}>
-        <BottomSheet index={0} snapPoints={["50%"]}>
-          <MyCollectionBottomSheetModalAdd />
-        </BottomSheet>
+        <MyCollectionBottomSheetModalAdd isVisible />
       </MyCollectionTabsStoreProvider>
     )
   }


### PR DESCRIPTION
This PR resolves [PHIRE-3449] <!-- eg [PROJECT-XXXX] -->

### Description

Addresses some occasional crashes similar to https://github.com/artsy/eigen/pull/13957/changes that were happening on iOS only. 

https://artsynet.sentry.io/issues/7440783053/events/9f9e41654b8d4e3a827a4ef3c3d77870/


Also refactors the modals in my collection (there was some weirdness of containers some modals were rendering inside other modals)

| Platform | Before | After |
|---|---|---|
| follows | <video src="https://github.com/user-attachments/assets/9d3a5503-170a-482f-9c2e-16b36105d3e2" width="400" /> | <video src="https://github.com/user-attachments/assets/62013016-418c-4f16-9f88-a6342416a660" width="400" /> |
| myCollection | <video src="https://github.com/user-attachments/assets/6aa67eb6-35e5-41b8-9919-09443f72767f" width="400" /> | <video src="https://github.com/user-attachments/assets/431fe6bc-4166-4a64-b2cb-67988985e015" width="400" /> |













<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- address some occasional crashes on bottom sheets  

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3449]: https://artsyproduct.atlassian.net/browse/PHIRE-3449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ