### PR TITLE
fix(PHIRE-3450): Refactor Sentry crash rate alert monitors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,59 +108,125 @@ jobs:
               --generate-notes \
               --notes "$(printf "%s\n\n%s\n\n%s" "$sentry_header" "$sentry_footer" "$sentry_mobile_vitals_details")"
 
-  create-sentry-alerts:
+  sentry-alert-workflow:
     needs: generate-release
+    runs-on: ubuntu-latest
+    outputs:
+      workflow_id: ${{ steps.find_or_create.outputs.workflow_id }}
+
+    steps:
+      - name: Find or create Mobile Release Crash Rate workflow
+        id: find_or_create
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN_ALERTS }}
+        run: |
+          # Reuse the alert across releases so the Slack action isn't recreated every time -
+          # only the per-release detector (crash rate thresholds) is release-specific.
+          workflow_name="Mobile Release Crash Rate"
+
+          existing_id=$(curl --fail-with-body -s -X GET "https://sentry.io/api/0/organizations/artsynet/workflows/" \
+            -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
+            | jq -r --arg name "$workflow_name" '.[] | select(.name == $name) | .id' | head -n1)
+
+          if [ -n "$existing_id" ]; then
+            echo "Found existing alert '$workflow_name' (id: $existing_id)"
+            workflow_id="$existing_id"
+          else
+            echo "Creating alert '$workflow_name'"
+            workflow_id=$(curl --fail-with-body -X POST "https://sentry.io/api/0/organizations/artsynet/workflows/" \
+              -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
+              -H 'Content-Type: application/json' \
+              -d "{
+                \"name\": \"$workflow_name\",
+                \"enabled\": true,
+                \"owner\": \"team:${{ env.SENTRY_OWNER_TEAM }}\",
+                \"triggers\": { \"logicType\": \"any-short\", \"conditions\": [] },
+                \"action_filters\": [
+                  {
+                    \"logicType\": \"any\",
+                    \"conditions\": [
+                      { \"type\": \"issue_priority_greater_or_equal\", \"comparison\": 75, \"conditionResult\": true },
+                      { \"type\": \"issue_priority_deescalating\", \"comparison\": 75, \"conditionResult\": true }
+                    ],
+                    \"actions\": [
+                      {
+                        \"type\": \"slack\",
+                        \"integrationId\": \"${{ env.SENTRY_SLACK_INTEGRATION_ID }}\",
+                        \"config\": {
+                          \"targetType\": \"specific\",
+                          \"targetIdentifier\": \"${{ env.SENTRY_SLACK_CHANNEL_ID }}\",
+                          \"targetDisplay\": \"#mobile-alerts\"
+                        },
+                        \"data\": {},
+                        \"status\": \"active\"
+                      }
+                    ]
+                  },
+                  {
+                    \"logicType\": \"any\",
+                    \"conditions\": [
+                      { \"type\": \"issue_priority_greater_or_equal\", \"comparison\": 50, \"conditionResult\": true },
+                      { \"type\": \"issue_priority_deescalating\", \"comparison\": 50, \"conditionResult\": true }
+                    ],
+                    \"actions\": [
+                      {
+                        \"type\": \"slack\",
+                        \"integrationId\": \"${{ env.SENTRY_SLACK_INTEGRATION_ID }}\",
+                        \"config\": {
+                          \"targetType\": \"specific\",
+                          \"targetIdentifier\": \"${{ env.SENTRY_SLACK_CHANNEL_ID }}\",
+                          \"targetDisplay\": \"#mobile-alerts\"
+                        },
+                        \"data\": {},
+                        \"status\": \"active\"
+                      }
+                    ]
+                  }
+                ]
+              }" | jq -r '.id')
+            echo "Created alert '$workflow_name' (id: $workflow_id)"
+          fi
+
+          echo "workflow_id=$workflow_id" >> "$GITHUB_OUTPUT"
+
+  create-sentry-alerts:
+    needs: [generate-release, sentry-alert-workflow]
     runs-on: ubuntu-latest
     strategy:
       matrix:
         release_version: ${{ fromJson(needs.generate-release.outputs.sentry_release_versions) }}
 
     steps:
-      - name: Create Sentry crash rate alert
+      - name: Create Sentry crash rate monitor
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN_ALERTS }}
         run: |
-          curl --fail-with-body -X POST https://sentry.io/api/0/organizations/artsynet/alert-rules/ \
+          curl --fail-with-body -X POST https://sentry.io/api/0/organizations/artsynet/projects/eigen/detectors/ \
             -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
             -H 'Content-Type: application/json' \
             -d "{
               \"name\": \"Release Crashes Threshold - ${{ matrix.release_version }}\",
-              \"queryType\": 2,
-              \"dataset\": \"metrics\",
-              \"aggregate\": \"percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate\",
-              \"query\": \"release:${{ matrix.release_version }}\",
-              \"timeWindow\": 120,
-              \"thresholdType\": 1,
-              \"resolveThreshold\": ${{ env.SENTRY_ALERT_RESOLVE_THRESHOLD }},
-              \"environment\": \"production\",
-              \"projects\": [\"eigen\"],
+              \"type\": \"metric_issue\",
               \"owner\": \"team:${{ env.SENTRY_OWNER_TEAM }}\",
-              \"triggers\": [
+              \"workflowIds\": [${{ needs.sentry-alert-workflow.outputs.workflow_id }}],
+              \"dataSources\": [
                 {
-                  \"label\": \"critical\",
-                  \"alertThreshold\": ${{ env.SENTRY_ALERT_CRITICAL_THRESHOLD }},
-                  \"actions\": [
-                    {
-                      \"type\": \"slack\",
-                      \"targetType\": \"specific\",
-                      \"targetIdentifier\": \"#mobile-alerts\",
-                      \"inputChannelId\": \"${{ env.SENTRY_SLACK_CHANNEL_ID }}\",
-                      \"integrationId\": ${{ env.SENTRY_SLACK_INTEGRATION_ID }}
-                    }
-                  ]
-                },
-                {
-                  \"label\": \"warning\",
-                  \"alertThreshold\": ${{ env.SENTRY_ALERT_WARNING_THRESHOLD }},
-                  \"actions\": [
-                    {
-                      \"type\": \"slack\",
-                      \"targetType\": \"specific\",
-                      \"targetIdentifier\": \"#mobile-alerts\",
-                      \"inputChannelId\": \"${{ env.SENTRY_SLACK_CHANNEL_ID }}\",
-                      \"integrationId\": ${{ env.SENTRY_SLACK_INTEGRATION_ID }}
-                    }
-                  ]
+                  \"queryType\": 2,
+                  \"dataset\": \"metrics\",
+                  \"aggregate\": \"percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate\",
+                  \"query\": \"release:${{ matrix.release_version }}\",
+                  \"timeWindow\": 7200,
+                  \"environment\": \"production\",
+                  \"eventTypes\": []
                 }
-              ]
+              ],
+              \"config\": { \"detectionType\": \"static\" },
+              \"conditionGroup\": {
+                \"logicType\": \"any\",
+                \"conditions\": [
+                  { \"type\": \"lt\", \"comparison\": ${{ env.SENTRY_ALERT_CRITICAL_THRESHOLD }}, \"conditionResult\": 75 },
+                  { \"type\": \"lt\", \"comparison\": ${{ env.SENTRY_ALERT_WARNING_THRESHOLD }}, \"conditionResult\": 50 },
+                  { \"type\": \"gte\", \"comparison\": ${{ env.SENTRY_ALERT_RESOLVE_THRESHOLD }}, \"conditionResult\": 0 }
+                ]
+              }
             }"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,8 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN_ALERTS }}
         run: |
+          set -o pipefail
+
           # Reuse the alert across releases so the Slack action isn't recreated every time -
           # only the per-release detector (crash rate thresholds) is release-specific.
           workflow_name="Mobile Release Crash Rate"


### PR DESCRIPTION
This PR resolves [PHIRE-3450] <!-- eg [PROJECT-XXXX] -->

### Description

#### Context: 
We have our Sentry crash rate alerts setup whenever we release, and we use Sentry's API for that (`/organizations/{org}/alert-rules/`), that one failed in the recent release ([GH Action status](https://github.com/artsy/eigen/actions/runs/34340680016/job/102447698556))

However, Sentry is planning to deprecate and remove that endpoint in favor of a new one ([Sentry docs](https://docs.sentry.io/api/monitors/create-an-alert-for-an-organization/))

The new flow now needs two steps to set up an alert monitor: first we create an alert config, then use it with a new monitor thresholds


This PR updates our Actions to use the new flow for creating crash rate alerts for new releases


### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Migrate Sentry crash rate alerts off deprecated Sentry API endpoint

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3450]: https://artsyproduct.atlassian.net/browse/PHIRE-3450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ